### PR TITLE
Adds h5py.__version__, fixes #254

### DIFF
--- a/h5py/__init__.py
+++ b/h5py/__init__.py
@@ -22,6 +22,8 @@ from h5py.h5t import py_get_enum as get_enum
 
 from h5py import version
 
+__version__ = version.version
+
 __doc__ = \
 """
     This is the h5py package, a Python interface to the HDF5


### PR DESCRIPTION
Adds a **version** string to the base package. Should be merged up to master as well.
