### PR TITLE
Addressing #251 by switching to absolute imports in .pyx files.

### DIFF
--- a/h5py/h5a.pyx
+++ b/h5py/h5a.pyx
@@ -23,7 +23,7 @@ from numpy cimport import_array, ndarray, PyArray_DATA
 from utils cimport check_numpy_read, check_numpy_write, emalloc, efree
 from _proxy cimport attr_rw
 
-import _objects
+from h5py import _objects
 
 # Initialization
 import_array()

--- a/h5py/h5d.pyx
+++ b/h5py/h5d.pyx
@@ -24,7 +24,7 @@ from h5s cimport SpaceID
 from h5p cimport PropID, propwrap
 from _proxy cimport dset_rw
 
-import _objects
+from h5py import _objects
 
 # Initialization
 import_array()

--- a/h5py/h5f.pyx
+++ b/h5py/h5f.pyx
@@ -21,7 +21,7 @@ from h5t cimport typewrap
 from h5i cimport wrap_identifier
 from utils cimport emalloc, efree
 
-import _objects
+from h5py import _objects
 
 # Initialization
 

--- a/h5py/h5g.pyx
+++ b/h5py/h5g.pyx
@@ -21,7 +21,7 @@ from h5p cimport PropID
 cimport _hdf5 # to implement container testing for 1.6
 from _errors cimport set_error_handler, err_cookie
 
-import _objects
+from h5py import _objects
 
 # === Public constants and data structures ====================================
 

--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -21,7 +21,7 @@ from utils cimport  require_tuple, convert_dims, convert_tuple, \
 from numpy cimport ndarray, import_array
 from h5t cimport TypeID, py_create
 
-import _objects
+from h5py import _objects
 
 # Initialization
 import_array()

--- a/h5py/h5s.pyx
+++ b/h5py/h5s.pyx
@@ -19,7 +19,7 @@ from utils cimport  require_tuple, convert_dims, convert_tuple, \
                     emalloc, efree, create_numpy_hsize, create_hsize_array
 from numpy cimport ndarray
 
-import _objects
+from h5py import _objects
 
 
 cdef object lockid(hid_t id_):

--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -26,7 +26,7 @@ from h5r cimport Reference, RegionReference
 
 from utils cimport  emalloc, efree, \
                     require_tuple, convert_dims, convert_tuple
-import _conv
+from h5py import _conv
 
 # Runtime imports
 import sys


### PR DESCRIPTION
This should fix a few implicitly relative imports that were causing problems (#251) in Python 3.3.  The changes are confined to a handful of Cython files.

Mailing list thread is here: https://groups.google.com/d/msg/h5py/-S1wYiqLQzg/YBbUQFVnezUJ
