### PR TITLE
Fix sys.maxint/maxsize confusion causing test failure on 64bit

### DIFF
--- a/h5py/_hl/tests/test_dataset.py
+++ b/h5py/_hl/tests/test_dataset.py
@@ -432,7 +432,7 @@ class TestLen(BaseDataset):
         """ Python len() vs Dataset.len() """
         dset = self.f.create_dataset('foo', (2**33,15))
         self.assertEqual(dset.shape, (2**33, 15))
-        if sys.maxint == 2**31-1:
+        if sys.maxsize == 2**31-1:
             with self.assertRaises(OverflowError):
                 len(dset)
         else:


### PR DESCRIPTION
Incorrectly checked for 64 bit platform with sys.maxint; should be sys.maxsize to check underlying Py_ssize_t type.
