### PR TITLE
Fix for issue 304 (H5DS names mangled with HDF5 1.8.11)

### DIFF
--- a/h5py/h5ds.pyx
+++ b/h5py/h5ds.pyx
@@ -109,7 +109,7 @@ def get_scale_name(DatasetID dscale not None):
         return ''
     name = <char*>emalloc(sizeof(char)*(namelen+1))
     try:
-        H5DSget_scale_name(dscale.id, name, namelen)
+        H5DSget_scale_name(dscale.id, name, namelen+1)
         pname = name
         return pname
     finally:


### PR DESCRIPTION
Fixes #304 and improves documentation in h5ds module.
