### PR TITLE
Mac OS X setup adaptation

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -156,6 +156,8 @@ def autodetect(libdirs):
 
     if sys.platform.startswith('win'):
         regexp = re.compile('^hdf5.dll$')
+    elif sys.platform.startswith('darwin'):
+        regexp = re.compile(r'^libhdf5.dylib')
     else:
         regexp = re.compile(r'^libhdf5.so')
 

--- a/setup.py
+++ b/setup.py
@@ -120,8 +120,12 @@ else:
         COMPILER_SETTINGS['include_dirs'] += [op.join(HDF5, 'include')]
         COMPILER_SETTINGS['library_dirs'] += [op.join(HDF5, 'lib')]
     elif sys.platform == 'darwin':
-        COMPILER_SETTINGS['include_dirs'] += ['/opt/local/include']
-        COMPILER_SETTINGS['library_dirs'] += ['/opt/local/lib']
+        # putting here both macports and homebrew paths will generate
+        # "ld: warning: dir not found" at the linking phase 
+        COMPILER_SETTINGS['include_dirs'] += ['/opt/local/include'] # macports
+        COMPILER_SETTINGS['library_dirs'] += ['/opt/local/lib']     # macports
+        COMPILER_SETTINGS['include_dirs'] += ['/usr/local/include'] # homebrew
+        COMPILER_SETTINGS['library_dirs'] += ['/usr/local/lib']     # homebrew
     if MPI:
         COMPILER_SETTINGS['include_dirs'] += [mpi4py.get_include()]
     COMPILER_SETTINGS['runtime_library_dirs'] = [op.abspath(x) for x in COMPILER_SETTINGS['library_dirs']]


### PR DESCRIPTION
Tested on OS X 10.8.3, Python 2.7.5, hdf5 1.8.11 (homebrew). I didn't test with llvm-gcc, it could work.

I think the lightweight commit is self-explanatory. For the record here are my bash commands:

```
# using homebrew http://mxcl.github.io/homebrew/
brew install --enable-cxx hdf5 
# enable-cxx: I want the C++ bindings for myself, not tested without
git clone git@github.com:SnippyHolloW/h5py.git
cd h5py/
virtualenv --system-site-packages .
source bin/activate
cd h5py/
python api_gen.py
cd ..
export CC=gcc-4.8
python setup.py build
python setup.py install
```

`import h5py` works. And finally:

```
(h5py)~/labs/h5py $ python setup.py test
Autodetected HDF5 version 1.8.11
running test
running build_py
running build_ext
skipping 'h5py/defs.c' Cython extension (up-to-date)
skipping 'h5py/_errors.c' Cython extension (up-to-date)
skipping 'h5py/_objects.c' Cython extension (up-to-date)
skipping 'h5py/_proxy.c' Cython extension (up-to-date)
skipping 'h5py/h5fd.c' Cython extension (up-to-date)
skipping 'h5py/h5z.c' Cython extension (up-to-date)
skipping 'h5py/h5.c' Cython extension (up-to-date)
skipping 'h5py/h5i.c' Cython extension (up-to-date)
skipping 'h5py/h5r.c' Cython extension (up-to-date)
skipping 'h5py/utils.c' Cython extension (up-to-date)
skipping 'h5py/_conv.c' Cython extension (up-to-date)
skipping 'h5py/h5t.c' Cython extension (up-to-date)
skipping 'h5py/h5s.c' Cython extension (up-to-date)
skipping 'h5py/h5p.c' Cython extension (up-to-date)
skipping 'h5py/h5d.c' Cython extension (up-to-date)
skipping 'h5py/h5a.c' Cython extension (up-to-date)
skipping 'h5py/h5f.c' Cython extension (up-to-date)
skipping 'h5py/h5g.c' Cython extension (up-to-date)
skipping 'h5py/h5l.c' Cython extension (up-to-date)
skipping 'h5py/h5o.c' Cython extension (up-to-date)
skipping 'h5py/h5ds.c' Cython extension (up-to-date)
....................................................................................................x..........................s........ss................................................................................sss.................................................
----------------------------------------------------------------------
Ran 270 tests in 0.274s

OK (skipped=6, expected failures=1)
```
