### PR TITLE
add set_/get_link_creation_order to h5p

### DIFF
--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -50,11 +50,10 @@ def make_fapl(driver, libver, **kwds):
     return plist
 
 
-def make_fid(name, mode, userblock_size, fapl):
+def make_fid(name, mode, userblock_size, fapl, fcpl=None):
     """ Get a new FileID by opening or creating a file.
     Also validates mode argument."""
 
-    fcpl = None
     if userblock_size is not None:
         if mode in ('r', 'r+'):
             raise ValueError("User block may only be specified "
@@ -63,7 +62,8 @@ def make_fid(name, mode, userblock_size, fapl):
             userblock_size = int(userblock_size)
         except (TypeError, ValueError):
             raise ValueError("User block size must be an integer")
-        fcpl = h5p.create(h5p.FILE_CREATE)
+        if fcpl is None:
+            fcpl = h5p.create(h5p.FILE_CREATE)
         fcpl.set_userblock(userblock_size)
 
     if mode == 'r':

--- a/h5py/api_types_hdf5.pxd
+++ b/h5py/api_types_hdf5.pxd
@@ -387,6 +387,8 @@ cdef extern from "hdf5.h":
   hid_t H5P_LINK_CREATE
   hid_t H5P_LINK_ACCESS
   hid_t H5P_GROUP_CREATE
+  hid_t H5P_CRT_ORDER_TRACKED
+  hid_t H5P_CRT_ORDER_INDEXED
 
 # === H5R - Reference API =====================================================
 

--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -95,6 +95,9 @@ LINK_ACCESS = lockcls(H5P_LINK_ACCESS)
 GROUP_CREATE = lockcls(H5P_GROUP_CREATE)
 OBJECT_CREATE = lockcls(H5P_OBJECT_CREATE)
 
+CRT_ORDER_TRACKED = H5P_CRT_ORDER_TRACKED
+CRT_ORDER_INDEXED = H5P_CRT_ORDER_INDEXED
+
 DEFAULT = None   # In the HDF5 header files this is actually 0, which is an
                  # invalid identifier.  The new strategy for default options
                  # is to make them all None, to better match the Python style
@@ -332,6 +335,24 @@ cdef class PropFCID(PropCreateID):
         cdef size_t size
         H5Pget_sizes(self.id, &addr, &size)
         return (addr, size)
+
+    def set_link_creation_order(self, unsigned int flags):
+        """ (UINT flags)
+
+        Set tracking and indexing of creation order for links added to this group
+
+        flags -- h5p.CRT_ORDER_TRACKED, h5p.CRT_ORDER_INDEXED
+        """
+        H5Pset_link_creation_order(self.id, flags)
+
+    def get_link_creation_order(self):
+        """ () -> UINT flags
+
+        Get tracking and indexing of creation order for links added to this group
+        """
+        cdef unsigned int flags
+        H5Pget_link_creation_order(self.id, &flags)
+        return flags
 
 
 # Dataset creation
@@ -1097,9 +1118,25 @@ cdef class PropLAID(PropInstanceID):
 
 # Group creation
 cdef class PropGCID(PropOCID):
-
     """ Group creation property list """
-    pass
+
+    def set_link_creation_order(self, unsigned int flags):
+        """ (UINT flags)
+
+        Set tracking and indexing of creation order for links added to this group
+
+        flags -- h5p.CRT_ORDER_TRACKED, h5p.CRT_ORDER_INDEXED
+        """
+        H5Pset_link_creation_order(self.id, flags)
+
+    def get_link_creation_order(self):
+        """ () -> UINT flags
+
+        Get tracking and indexing of creation order for links added to this group
+        """
+        cdef unsigned int flags
+        H5Pget_link_creation_order(self.id, &flags)
+        return flags
 
 
 # Object creation property list

--- a/h5py/lowtest/test_h5p.py
+++ b/h5py/lowtest/test_h5p.py
@@ -61,3 +61,22 @@ class TestPL(ut.TestCase):
 
         ocid.set_obj_track_times(True)
         self.assertEqual(True,ocid.get_obj_track_times())
+
+    def test_link_creation_tracking(self):
+        """
+        tests the link creation order set/get
+        """
+
+        gcid = h5p.create(h5p.GROUP_CREATE)
+        gcid.set_link_creation_order(0)
+        self.assertEqual(0, gcid.get_link_creation_order())
+
+        flags = h5p.CRT_ORDER_TRACKED|h5p.CRT_ORDER_INDEXED
+        gcid.set_link_creation_order(flags)
+        self.assertEqual(flags, gcid.get_link_creation_order())
+
+        # test for file creation
+        fcpl = h5p.create(h5p.FILE_CREATE)
+        fcpl.set_link_creation_order(flags)
+        self.assertEqual(flags, fcpl.get_link_creation_order())
+


### PR DESCRIPTION
Implements most of the patch posted by benoit rodriguez in h5py/h5py#176, along with some unit tests. Doesn't change anything in the main highlevel interface, but does allow users to set this property in the low-level interface. Closes h5py/h5py#176 
