### PR TITLE
Add tox.ini for automated testing with different Python versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py26,py27,py32,py33
+[testenv]
+deps =
+    numpy>=1.0.1
+    Cython>=0.13
+commands =
+    python setup.py test
+[testenv:py26]
+deps =
+    unittest2
+    {[testenv]deps}


### PR DESCRIPTION
To use:

```
pip install tox
tox
```
