### PR TITLE
Allow Unicode field names for slicing on Py2

### DIFF
--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -320,8 +320,10 @@ class Dataset(HLObject):
         args = args if isinstance(args, tuple) else (args,)
 
         # Sort field indices from the rest of the args.
-        names = tuple(x for x in args if isinstance(x, str))
-        args = tuple(x for x in args if not isinstance(x, str))
+        names = tuple(x for x in args if isinstance(x, basestring))
+        args = tuple(x for x in args if not isinstance(x, basestring))
+        if not py3:
+            names = tuple(x.encode('utf-8') if isinstance(x, unicode) else x for x in names)
 
         def strip_fields(basetype):
             """ Strip extra dtype information from special types """
@@ -453,8 +455,10 @@ class Dataset(HLObject):
         args = args if isinstance(args, tuple) else (args,)
 
         # Sort field indices from the slicing
-        names = tuple(x for x in args if isinstance(x, str))
-        args = tuple(x for x in args if not isinstance(x, str))
+        names = tuple(x for x in args if isinstance(x, basestring))
+        args = tuple(x for x in args if not isinstance(x, basestring))
+        if not py3:
+            names = tuple(x.encode('utf-8') if isinstance(x, unicode) else x for x in names)
 
         # Generally we try to avoid converting the arrays on the Python
         # side.  However, for compound literals this is unavoidable.

--- a/h5py/tests/test_slicing.py
+++ b/h5py/tests/test_slicing.py
@@ -18,7 +18,7 @@
 
 import numpy as np
 
-from .common import ut, TestCase
+from .common import ut, TestCase, py3
 
 import h5py
 from h5py import h5s, h5t, h5d
@@ -297,8 +297,19 @@ class TestFieldNames(BaseSlicing):
         self.dset[...] = self.data
 
     def test_read(self):
-        """ Test read with field selections """
-        self.assertArrayEqual(self.dset['a'], self.data['a'])
+        """ Test read with field selections (bytes and unicode) """
+        if not py3:
+            # Byte strings are only allowed for field names on Py2
+            self.assertArrayEqual(self.dset[b'a'], self.data['a'])
+        self.assertArrayEqual(self.dset[u'a'], self.data['a'])
+
+    def test_unicode_names(self):
+        """ Unicode field names for for read and write """
+        self.assertArrayEqual(self.dset[u'a'], self.data['a'])
+        self.dset[u'a'] = 42
+        data = self.data.copy()
+        data['a'] = 42
+        self.assertArrayEqual(self.dset[u'a'], data['a'])
 
     def test_write(self):
         """ Test write with field selections """


### PR DESCRIPTION
Addresses issue #374.  The behavior for field names in slicing arguments is as follows:
1. On Py2, byte or Unicode strings are permitted  (change: added Unicode support)
2. On Py3, only Unicode strings are permitted (unchanged)

(2) is historically the case because of the substantial complexity required to support byte strings when dealing with NumPy compound types on Py3.
