### PR TITLE
Added additional information to errors originating in the HDF5 stack, and cleaned whitespace

### DIFF
--- a/h5py/_errors.pyx
+++ b/h5py/_errors.pyx
@@ -10,45 +10,45 @@
 # Python-style minor error classes.  If the minor error code matches an entry
 # in this dict, the generated exception will be used.
 _minor_table = {
-    H5E_SEEKERROR:      IOError,    # Seek failed 
-    H5E_READERROR:      IOError,    # Read failed  
-    H5E_WRITEERROR:     IOError,    # Write failed  
-    H5E_CLOSEERROR:     IOError,    # Close failed 
-    H5E_OVERFLOW:       IOError,    # Address overflowed 
+    H5E_SEEKERROR:      IOError,    # Seek failed
+    H5E_READERROR:      IOError,    # Read failed
+    H5E_WRITEERROR:     IOError,    # Write failed
+    H5E_CLOSEERROR:     IOError,    # Close failed
+    H5E_OVERFLOW:       IOError,    # Address overflowed
     H5E_FCNTL:          IOError,    # File control (fcntl) failed
 
-    H5E_FILEEXISTS:     IOError,    # File already exists 
-    H5E_FILEOPEN:       IOError,    # File already open 
+    H5E_FILEEXISTS:     IOError,    # File already exists
+    H5E_FILEOPEN:       IOError,    # File already open
     H5E_CANTCREATE:     IOError,    # Unable to create file
-    H5E_CANTOPENFILE:   IOError,    # Unable to open file 
-    H5E_CANTCLOSEFILE:  IOError,    # Unable to close file 
-    H5E_NOTHDF5:        IOError,    # Not an HDF5 file 
-    H5E_BADFILE:        ValueError, # Bad file ID accessed 
+    H5E_CANTOPENFILE:   IOError,    # Unable to open file
+    H5E_CANTCLOSEFILE:  IOError,    # Unable to close file
+    H5E_NOTHDF5:        IOError,    # Not an HDF5 file
+    H5E_BADFILE:        ValueError, # Bad file ID accessed
     H5E_TRUNCATED:      IOError,    # File has been truncated
-    H5E_MOUNT:          IOError,    # File mount error 
+    H5E_MOUNT:          IOError,    # File mount error
 
-    H5E_NOFILTER:       IOError,    # Requested filter is not available 
-    H5E_CALLBACK:       IOError,    # Callback failed 
-    H5E_CANAPPLY:       IOError,    # Error from filter 'can apply' callback 
-    H5E_SETLOCAL:       IOError,    # Error from filter 'set local' callback 
-    H5E_NOENCODER:      IOError,    # Filter present but encoding disabled 
+    H5E_NOFILTER:       IOError,    # Requested filter is not available
+    H5E_CALLBACK:       IOError,    # Callback failed
+    H5E_CANAPPLY:       IOError,    # Error from filter 'can apply' callback
+    H5E_SETLOCAL:       IOError,    # Error from filter 'set local' callback
+    H5E_NOENCODER:      IOError,    # Filter present but encoding disabled
 
-    H5E_BADATOM:        ValueError,  # Unable to find atom information (already closed?) 
-    H5E_BADGROUP:       ValueError,  # Unable to find ID group information 
+    H5E_BADATOM:        ValueError,  # Unable to find atom information (already closed?)
+    H5E_BADGROUP:       ValueError,  # Unable to find ID group information
     H5E_BADSELECT:      ValueError,  # Invalid selection (hyperslabs)
-    H5E_UNINITIALIZED:  ValueError,  # Information is uinitialized 
-    H5E_UNSUPPORTED:    NotImplementedError,    # Feature is unsupported 
+    H5E_UNINITIALIZED:  ValueError,  # Information is uinitialized
+    H5E_UNSUPPORTED:    NotImplementedError,    # Feature is unsupported
 
-    H5E_NOTFOUND:       KeyError,    # Object not found 
-    H5E_CANTINSERT:     ValueError,   # Unable to insert object 
+    H5E_NOTFOUND:       KeyError,    # Object not found
+    H5E_CANTINSERT:     ValueError,   # Unable to insert object
 
-    H5E_BADTYPE:        TypeError,   # Inappropriate type 
-    H5E_BADRANGE:       ValueError,  # Out of range 
+    H5E_BADTYPE:        TypeError,   # Inappropriate type
+    H5E_BADRANGE:       ValueError,  # Out of range
     H5E_BADVALUE:       ValueError,  # Bad value
 
-    H5E_EXISTS:         ValueError,  # Object already exists 
+    H5E_EXISTS:         ValueError,  # Object already exists
     H5E_ALREADYEXISTS:  ValueError,  # Object already exists, part II
-    H5E_CANTCONVERT:    TypeError,   # Can't convert datatypes 
+    H5E_CANTCONVERT:    TypeError,   # Can't convert datatypes
 
     H5E_CANTDELETE:     KeyError,    # Can't delete message
 
@@ -57,7 +57,7 @@ _minor_table = {
     H5E_CANTMOVE:       ValueError,  # Can't move a link
   }
 
-# "Fudge" table to accomodate annoying inconsistencies in HDF5's use 
+# "Fudge" table to accomodate annoying inconsistencies in HDF5's use
 # of the minor error codes.  If a (major, minor) entry appears here,
 # it will override any entry in the minor error table.
 _exact_table = {
@@ -97,7 +97,7 @@ cdef int set_exception() except -1:
     err.n = -1
 
     if H5Ewalk(H5E_WALK_UPWARD, walk_cb, &err) < 0:
-        raise RuntimeError("Failed to walk error stack")
+        raise RuntimeError("Failed to walk HDF5 error stack")
 
     if err.n < 0:   # No HDF5 exception information found
         return 0
@@ -107,7 +107,7 @@ cdef int set_exception() except -1:
 
     desc = err.err.desc
     if desc is NULL:
-        raise RuntimeError("Failed to extract top-level error description")
+        raise RuntimeError("Failed to extract top-level HDF5 error description")
 
     # Second, retrieve the bottom-most error description for additional info
 
@@ -118,9 +118,9 @@ cdef int set_exception() except -1:
 
     desc_bottom = err.err.desc
     if desc_bottom is NULL:
-        raise RuntimeError("Failed to extract bottom-level error description")
+        raise RuntimeError("Failed to extract HDF5 bottom-level error description")
 
-    msg = ("%s (%s)" % (desc.decode('utf-8').capitalize(), desc_bottom.decode('utf-8').capitalize())).encode('utf-8')
+    msg = ("HDF5 - %s (%s)" % (desc.decode('utf-8').capitalize(), desc_bottom.decode('utf-8').capitalize())).encode('utf-8')
 
     # Finally, set the exception.  We do this with the Python C function
     # so that the traceback doesn't point here.
@@ -154,26 +154,3 @@ cdef err_cookie set_error_handler(err_cookie handler):
         raise RuntimeError("Failed to install new handler")
 
     return old_handler
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
In reference to issue #345, and in addition to #400, I suggest marking errors that stem from the hdf5 stack.

In this PR I added such marks, and accidentally also removed some trailing whitespace (automatically by the editor). If you like the marks but want the witespace, let me know and I'll redo it.
