### PR TITLE
Add conditional definition of PyMPI_MPI_Message and MPI_Message PyMPI_MP...

### DIFF
--- a/h5py/api_compat.h
+++ b/h5py/api_compat.h
@@ -16,6 +16,11 @@
 #ifndef H5PY_COMPAT
 #define H5PY_COMPAT
 
+#if (MPI_VERSION < 3) && !defined(PyMPI_HAVE_MPI_Message)
+typedef void *PyMPI_MPI_Message;
+#define MPI_Message PyMPI_MPI_Message
+#endif
+
 #include <stddef.h>
 #include "Python.h"
 #include "numpy/arrayobject.h"


### PR DESCRIPTION
...I_Message. This is needed for MPI_VERSION<3 and a recent version of mpi4py.

Follows gh-401 https://groups.google.com/d/topic/h5py/Uw5x3BKwJGU/discussion and https://groups.google.com/d/topic/mpi4py/xnDyYvawB-Q/discussion.
