### PR TITLE
Add defined(MPI_VERSION) check in h5py/api_compat.h.

### DIFF
--- a/h5py/api_compat.h
+++ b/h5py/api_compat.h
@@ -16,7 +16,7 @@
 #ifndef H5PY_COMPAT
 #define H5PY_COMPAT
 
-#if (MPI_VERSION < 3) && !defined(PyMPI_HAVE_MPI_Message)
+#if defined(MPI_VERSION) && (MPI_VERSION < 3) && !defined(PyMPI_HAVE_MPI_Message)
 typedef void *PyMPI_MPI_Message;
 #define MPI_Message PyMPI_MPI_Message
 #endif


### PR DESCRIPTION
Patch from @Arfrever for issue #439

Tested on both serial (hdf5 1.8.12, gcc 4.8, debian, python 2.7.5, without `--mpi`) and parallel (hdf5 1.8.13, openmpi 1.8.1, gcc 4.8, debian, python 2.7.5, with `--mpi`) hdf5 with `python setup.py test`.
