### PR TITLE
Test & fix for dimension scales issue (#483)

### DIFF
--- a/h5py/_hl/dims.py
+++ b/h5py/_hl/dims.py
@@ -85,7 +85,12 @@ class DimensionProxy(base.CommonStateObject):
             scales = []
             def f(dsid):
                 scales.append(dsid)
-            h5ds.iterate(self._id, self._dimension, f, 0)
+            
+            # H5DSiterate raises an error if there are no dimension scales,
+            # rather than iterating 0 times.  See #483.
+            if len(self) > 0:
+                h5ds.iterate(self._id, self._dimension, f, 0)
+                
             return [
                 (self._d(h5ds.get_scale_name(id)), Dataset(id))
                 for id in scales

--- a/h5py/tests/hl/__init__.py
+++ b/h5py/tests/hl/__init__.py
@@ -1,3 +1,3 @@
-from . import test_dataset_getitem
+from . import test_dataset_getitem, test_dims_dimensionproxy
 
-MODULES = (test_dataset_getitem,)
+MODULES = (test_dataset_getitem, test_dims_dimensionproxy)

--- a/h5py/tests/hl/test_dims_dimensionproxy.py
+++ b/h5py/tests/hl/test_dims_dimensionproxy.py
@@ -1,0 +1,24 @@
+# This file is part of h5py, a Python interface to the HDF5 library.
+#
+# http://www.h5py.org
+#
+# Copyright 2008-2013 Andrew Collette and contributors
+#
+# License:  Standard 3-clause BSD; see "license.txt" for full license terms
+#           and contributor agreement.
+
+"""
+    Tests the h5py.Dataset.dims.DimensionProxy class.
+"""
+
+import numpy as np
+import h5py
+
+from ..common import ut, TestCase
+
+class TestItems(TestCase):
+
+    def test_empty(self):
+        """ no dimension scales -> empty list """
+        dset = self.f.create_dataset('x', (10,))
+        self.assertEqual(dset.dims[0].items(), [])


### PR DESCRIPTION
DimensionProxy.items() iterates over dimension scales using H5DSiterate, which is ill-behaved if the number of scales is 0.  Addresses #483.
