### PR TITLE
Bump minimum NumPy and Cython versions (#462)

### DIFF
--- a/docs/build.rst
+++ b/docs/build.rst
@@ -21,8 +21,8 @@ Installing on Windows
 
 You will need:
 
-  * Python 2.6 - 3.3
-  * NumPy 1.6 or newer
+  * Python 2.6, 2.7, 3.2, 3.3 or 3.4
+  * NumPy 1.6.1 or newer
 
 Download the installer from http://www.h5py.org and run it.  HDF5 is
 included.
@@ -36,7 +36,7 @@ System dependencies
 
 You will need:
 
-* Python 2.6 - 3.3 with development headers (``python-dev`` or similar)
+* Python 2.6, 2.7, 3.2, 3.3, or 3.4 with development headers (``python-dev`` or similar)
 * HDF5 1.8.4 or newer, shared library version with development headers (``libhdf5-dev`` or similar)
 
 On Mac OS X, `homebrew <http://brew.sh>`_ is a reliable way of getting
@@ -58,8 +58,8 @@ Via setup.py
 You will need:
 
 * The h5py tarball from http://www.h5py.org.
-* NumPy 1.5 or newer
-* `Cython <http://cython.org>`_ 0.16 or newer
+* NumPy 1.6.1 or newer
+* `Cython <http://cython.org>`_ 0.17 or newer
 
 ::
 

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ A strong emphasis on automatic conversion between Python (Numpy) datatypes and
 data structures and their HDF5 equivalents vastly simplifies the process of
 reading and writing data from Python.
 
-Supports HDF5 versions 1.8.3 and higher.  On Windows, HDF5 is included with
+Supports HDF5 versions 1.8.4 and higher.  On Windows, HDF5 is included with
 the installer.
 """
 
@@ -142,7 +142,7 @@ setup(
   packages = ['h5py', 'h5py._hl', 'h5py.tests', 'h5py.tests.old', 'h5py.tests.hl'],
   package_data = package_data,
   ext_modules = [Extension('h5py.x',['x.c'])],  # To trick build into running build_ext
-  requires = ['numpy (>=1.5.0)', 'Cython (>=0.16)'],
-  install_requires = ['numpy>=1.5.0', 'Cython>=0.16'],
+  requires = ['numpy (>=1.6.1)', 'Cython (>=0.17)'],
+  install_requires = ['numpy>=1.6.1', 'Cython>=0.17'],
   cmdclass = CMDCLASS,
 )


### PR DESCRIPTION
NumPy 1.6.1 or later appears required to build correctly.  Also Cython 0.16 produces worrisome error messages in the console output; bump to 0.17 or later.
