### PR TITLE
Add test for File auto-close (#246)

### DIFF
--- a/h5py/tests/hl/__init__.py
+++ b/h5py/tests/hl/__init__.py
@@ -1,3 +1,7 @@
-from . import test_dataset_getitem, test_dims_dimensionproxy
-
-MODULES = (test_dataset_getitem, test_dims_dimensionproxy)
+from . import  (test_dataset_getitem, 
+                test_dims_dimensionproxy,
+                test_file, )
+                
+MODULES = ( test_dataset_getitem, 
+            test_dims_dimensionproxy,
+            test_file, )

--- a/h5py/tests/hl/test_file.py
+++ b/h5py/tests/hl/test_file.py
@@ -1,0 +1,67 @@
+# This file is part of h5py, a Python interface to the HDF5 library.
+#
+# http://www.h5py.org
+#
+# Copyright 2008-2013 Andrew Collette and contributors
+#
+# License:  Standard 3-clause BSD; see "license.txt" for full license terms
+#           and contributor agreement.
+
+"""
+    Tests the h5py.File object.
+"""
+
+import h5py
+
+from ..common import ut, TestCase
+
+
+def nfiles():
+    return h5py.h5f.get_obj_count(h5py.h5f.OBJ_ALL, h5py.h5f.OBJ_FILE)
+
+def ngroups():
+    return h5py.h5f.get_obj_count(h5py.h5f.OBJ_ALL, h5py.h5f.OBJ_GROUP)
+
+        
+class TestDealloc(TestCase):
+
+    """ 
+        Behavior on object dellocation.  Note most of this behavior is
+        delegated to FileID.
+    """
+    
+    def test_autoclose(self):
+        """ File objects close automatically when out of scope, but
+        other objects remain open. """
+        
+        start_nfiles = nfiles()
+        start_ngroups = ngroups()
+        
+        fname = self.mktemp()
+        f = h5py.File(fname, 'w')
+        g = f['/']
+        
+        self.assertEqual(nfiles(), start_nfiles+1)
+        self.assertEqual(ngroups(), start_ngroups+1)
+        
+        del f
+        
+        self.assertTrue(g)
+        self.assertEqual(nfiles(), start_nfiles)
+        self.assertEqual(ngroups(), start_ngroups+1)
+        
+        f = g.file
+        
+        self.assertTrue(f)
+        self.assertEqual(nfiles(), start_nfiles+1)
+        self.assertEqual(ngroups(), start_ngroups+1)
+        
+        del g
+        
+        self.assertEqual(nfiles(), start_nfiles+1)
+        self.assertEqual(ngroups(), start_ngroups)
+        
+        del f
+        
+        self.assertEqual(nfiles(), start_nfiles)
+        self.assertEqual(ngroups(), start_ngroups)


### PR DESCRIPTION
Under the new identifier-management system, File objects don't "leak" when they go out of scope.  The underlying HDF5 file is closed when no open objects remain.

Adds a test case to verify this.  Issue #246.
