### PR TITLE
Support dynamical loading of LZF filter plugin

### DIFF
--- a/lzf/README.txt
+++ b/lzf/README.txt
@@ -15,8 +15,14 @@ is released under the BSD license (see LICENSE.txt for details).
 Using the filter from HDF5
 --------------------------
 
-There is exactly one new public function declared in lzf_filter.h, with
-the following signature:
+With HDF5 version 1.8.11 or later the filter can be loaded dynamically by the
+HDF5 library.  The filter needs to be compiled as a plugin as described below
+that is placed in the default plugin path /usr/local/hdf5/lib/plugin/.  The
+plugin path can be overridden with the environment variable HDF5_PLUGIN_PATH.
+
+With older HDF5 versions, or when statically linking the filter to your program,
+the filter must be registered manually. There is exactly one new public function
+declared in lzf_filter.h, with the following signature:
 
     int register_lzf(void)
 
@@ -38,16 +44,22 @@ version of the LZF compression library.  Since the filter is stateless, it's
 recommended to statically link the entire thing into your program; for
 example:
 
-    $ gcc -O2 -lhdf5 lzf/*.c lzf_filter.c myprog.c -o myprog
+    $ gcc -O2 lzf/*.c lzf_filter.c myprog.c -lhdf5 -o myprog
 
 It can also be built as a shared library, although you will have to install
 the resulting library somewhere the runtime linker can find it:
 
-    $ gcc -O2 -lhdf5 -fPIC -shared lzf/*.c lzf_filter.c -o liblzf_filter.so
+    $ gcc -O2 -fPIC -shared lzf/*.c lzf_filter.c -lhdf5 -o liblzf_filter.so
 
 A similar procedure should be used for building C++ code.  As in these
 examples, using option -O1 or higher is strongly recommended for increased
 performance.
+
+With HDF5 version 1.8.11 or later the filter can be dynamically loaded as a
+plugin.  The filter is built as a shared library that is *not* linked against
+the HDF5 library:
+
+    $ gcc -O2 -fPIC -shared lzf/*.c lzf_filter.c -o liblzf_filter.so
 
 
 Contact


### PR DESCRIPTION
This allows using the filter with any program linked against HDF5, e.g., `h5dump`, as discussed in this  [thread](https://groups.google.com/forum/#!topic/h5py/HjKydDPVU38).

``` python
import h5py
import numpy as np
f = h5py.File("test_lzf.h5", "w")
d = np.arange(0, 10, 0.1)
f.create_dataset("test", data=d, compression="lzf", shuffle=True)
```

``` shell
# export HDF5_PLUGIN_PATH=$PWD
# h5dump test_lzf.h5
HDF5 "test_lzf.h5" {
GROUP "/" {
   DATASET "test" {
      DATATYPE  H5T_IEEE_F64LE
      DATASPACE  SIMPLE { ( 100 ) / ( 100 ) }
      DATA {
      (0): 0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.1, 1.2, 1.3,
      (14): 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6,
      (27): 2.7, 2.8, 2.9, 3, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4,
      (41): 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 5, 5.1, 5.2, 5.3,
      (54): 5.4, 5.5, 5.6, 5.7, 5.8, 5.9, 6, 6.1, 6.2, 6.3, 6.4, 6.5, 6.6,
      (67): 6.7, 6.8, 6.9, 7, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7, 7.8, 7.9, 8,
      (81): 8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7, 8.8, 8.9, 9, 9.1, 9.2, 9.3,
      (94): 9.4, 9.5, 9.6, 9.7, 9.8, 9.9
      }
   }
}
}
```
