### PR TITLE
Disable building Cython on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ before_install:
     - sudo apt-get update -qq
     - sudo apt-get install -qq libhdf5-serial-dev
     - if [[ $TRAVIS_PYTHON_VERSION == "2.6" ]]; then pip install unittest2; fi
-    - pip install cython numpy
+    - pip install numpy
+    - pip install --install-option="--no-cython-compile" cython
 
 install: 
     - python setup.py build -f


### PR DESCRIPTION
May fix intermittent Cython install failure.
