### PR TITLE
Fixing incompatible pointer types.

### DIFF
--- a/api_gen.py
+++ b/api_gen.py
@@ -64,11 +64,11 @@ class Line(object):
                             """, re.VERBOSE)
 
     SIG_PATTERN = re.compile("""
-                            (unsigned[ ]+)?
-                            (?:[a-zA-Z_]+[a-zA-Z0-9_]*\**)
-                            [ ]+[ *]*
-                            (?P<param>[a-zA-Z_]+[a-zA-Z0-9_]*)
-                            """, re.VERBOSE)
+                             (?:unsigned[ ]+)?
+                             (?:[a-zA-Z_]+[a-zA-Z0-9_]*\**)
+                             [ ]+[ *]*
+                             (?P<param>[a-zA-Z_]+[a-zA-Z0-9_]*)
+                             """, re.VERBOSE)
                             
     def __init__(self, text):
         """ Break the line into pieces and populate object attributes.
@@ -91,10 +91,11 @@ class Line(object):
         self.fname = parts['fname']
         self.sig = parts['sig']
 
-        self.args = self.SIG_PATTERN.findall(self.sig)
+        sig_const_stripped = self.sig.replace('const', '')
+        self.args = self.SIG_PATTERN.findall(sig_const_stripped)
         if self.args is None:
             raise ValueError("Invalid function signature: {0}".format(self.sig))
-        self.args = ", ".join(x[1] for x in self.args)
+        self.args = ", ".join(self.args)
 
 
 raw_preamble = """\

--- a/h5py/_errors.pyx
+++ b/h5py/_errors.pyx
@@ -88,8 +88,8 @@ cdef herr_t walk_cb(int n, H5E_error_t *desc, void *e):
 cdef int set_exception() except -1:
 
     cdef err_data_t err
-    cdef char *desc = NULL          # Note: HDF5 forbids freeing these
-    cdef char *desc_bottom = NULL
+    cdef const char *desc = NULL          # Note: HDF5 forbids freeing these
+    cdef const char *desc_bottom = NULL
 
     # First, extract the major & minor error codes from the top of the
     # stack, along with the top-level error description

--- a/h5py/_proxy.pyx
+++ b/h5py/_proxy.pyx
@@ -256,7 +256,7 @@ ctypedef struct h5py_scatter_t:
     void* buf
 
 cdef herr_t h5py_scatter_cb(void* elem, hid_t type_id, unsigned ndim,
-                hsize_t *point, void *operator_data) except -1:
+                const hsize_t *point, void *operator_data) except -1:
 
     cdef h5py_scatter_t* info = <h5py_scatter_t*>operator_data
    
@@ -268,7 +268,7 @@ cdef herr_t h5py_scatter_cb(void* elem, hid_t type_id, unsigned ndim,
     return 0
 
 cdef herr_t h5py_gather_cb(void* elem, hid_t type_id, unsigned ndim,
-                hsize_t *point, void *operator_data) except -1:
+                const hsize_t *point, void *operator_data) except -1:
 
     cdef h5py_scatter_t* info = <h5py_scatter_t*>operator_data
    

--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -197,7 +197,7 @@ hdf5:
   herr_t    H5Literate_by_name(hid_t loc_id, char *group_name, H5_index_t idx_type, H5_iter_order_t order, hsize_t *idx, H5L_iterate_t op, void *op_data, hid_t lapl_id)
   herr_t    H5Lvisit(hid_t grp_id, H5_index_t idx_type, H5_iter_order_t order, H5L_iterate_t op, void *op_data)
   herr_t    H5Lvisit_by_name(hid_t loc_id, char *group_name, H5_index_t idx_type, H5_iter_order_t order, H5L_iterate_t op, void *op_data, hid_t lapl_id)
-  herr_t    H5Lunpack_elink_val(void *ext_linkval, size_t link_size, unsigned *flags, char **filename, char **obj_path)
+  herr_t    H5Lunpack_elink_val(void *ext_linkval, size_t link_size, unsigned *flags, const char **filename, const char **obj_path)
   herr_t    H5Lcreate_external(char *file_name, char *obj_name, hid_t link_loc_id, char *link_name, hid_t lcpl_id, hid_t lapl_id)
 
 
@@ -262,9 +262,9 @@ hdf5:
   herr_t    H5Pset_family_offset ( hid_t fapl_id, hsize_t offset)
   herr_t    H5Pget_family_offset ( hid_t fapl_id, hsize_t *offset)
   herr_t    H5Pset_fapl_log(hid_t fapl_id, char *logfile, unsigned int flags, size_t buf_size)
-  herr_t    H5Pset_fapl_multi(hid_t fapl_id, H5FD_mem_t *memb_map, hid_t *memb_fapl, char **memb_name, haddr_t *memb_addr, hbool_t relax)
+  herr_t    H5Pset_fapl_multi(hid_t fapl_id, H5FD_mem_t *memb_map, hid_t *memb_fapl, const char * const *memb_name, haddr_t *memb_addr, hbool_t relax)
   herr_t    H5Pset_cache(hid_t plist_id, int mdc_nelmts, int rdcc_nelmts,  size_t rdcc_nbytes, double rdcc_w0)
-  herr_t    H5Pget_cache(hid_t plist_id, int *mdc_nelmts, int *rdcc_nelmts, size_t *rdcc_nbytes, double *rdcc_w0)
+  herr_t    H5Pget_cache(hid_t plist_id, int *mdc_nelmts, size_t *rdcc_nelmts, size_t *rdcc_nbytes, double *rdcc_w0)
   herr_t    H5Pset_fapl_sec2(hid_t fapl_id)
   herr_t    H5Pset_fapl_stdio(hid_t fapl_id)
   hid_t     H5Pget_driver(hid_t fapl_id)
@@ -386,7 +386,7 @@ hdf5:
 
   hssize_t  H5Sget_select_elem_npoints(hid_t space_id)
   herr_t    H5Sget_select_elem_pointlist(hid_t space_id, hsize_t startpoint,  hsize_t numpoints, hsize_t *buf)
-  herr_t    H5Sselect_elements(hid_t space_id, H5S_seloper_t op,  size_t num_elements, hsize_t **coord)
+  herr_t    H5Sselect_elements(hid_t space_id, H5S_seloper_t op,  size_t num_elements, const hsize_t *coord)
 
   hssize_t  H5Sget_select_hyper_nblocks(hid_t space_id )
   herr_t    H5Sget_select_hyper_blocklist(hid_t space_id,  hsize_t startblock, hsize_t numblocks, hsize_t *buf )

--- a/h5py/h5a.pyx
+++ b/h5py/h5a.pyx
@@ -227,7 +227,7 @@ cdef class _AttrVisitor:
         self.func = func
         self.retval = None
 
-cdef herr_t cb_attr_iter(hid_t loc_id, char* attr_name, H5A_info_t *ainfo, void* vis_in) except 2:
+cdef herr_t cb_attr_iter(hid_t loc_id, const char* attr_name, const H5A_info_t *ainfo, void* vis_in) except 2:
     cdef _AttrVisitor vis = <_AttrVisitor>vis_in
     cdef AttrInfo info = AttrInfo()
     info.info = ainfo[0]
@@ -236,7 +236,7 @@ cdef herr_t cb_attr_iter(hid_t loc_id, char* attr_name, H5A_info_t *ainfo, void*
         return 1
     return 0
 
-cdef herr_t cb_attr_simple(hid_t loc_id, char* attr_name, H5A_info_t *ainfo, void* vis_in) except 2:
+cdef herr_t cb_attr_simple(hid_t loc_id, const char* attr_name, const H5A_info_t *ainfo, void* vis_in) except 2:
     cdef _AttrVisitor vis = <_AttrVisitor>vis_in
     vis.retval = vis.func(attr_name)
     if vis.retval is not None:

--- a/h5py/h5l.pyx
+++ b/h5py/h5l.pyx
@@ -67,7 +67,7 @@ cdef class _LinkVisitor:
         self.retval = None
         self.info = LinkInfo()
 
-cdef herr_t cb_link_iterate(hid_t grp, char* name, H5L_info_t *istruct, void* data) except 2:
+cdef herr_t cb_link_iterate(hid_t grp, const char* name, const H5L_info_t *istruct, void* data) except 2:
     # Standard iteration callback for iterate/visit routines
 
     cdef _LinkVisitor it = <_LinkVisitor?>data
@@ -77,7 +77,7 @@ cdef herr_t cb_link_iterate(hid_t grp, char* name, H5L_info_t *istruct, void* da
         return 0
     return 1
 
-cdef herr_t cb_link_simple(hid_t grp, char* name, H5L_info_t *istruct, void* data) except 2:
+cdef herr_t cb_link_simple(hid_t grp, const char* name, const H5L_info_t *istruct, void* data) except 2:
     # Simplified iteration callback which only provides the name
 
     cdef _LinkVisitor it = <_LinkVisitor?>data

--- a/h5py/h5o.pyx
+++ b/h5py/h5o.pyx
@@ -274,7 +274,7 @@ cdef class _ObjectVisitor:
         self.retval = None
         self.objinfo = ObjInfo()
 
-cdef herr_t cb_obj_iterate(hid_t obj, char* name, H5O_info_t *info, void* data) except 2:
+cdef herr_t cb_obj_iterate(hid_t obj, const char* name, const H5O_info_t *info, void* data) except 2:
 
     cdef _ObjectVisitor visit
 
@@ -290,7 +290,7 @@ cdef herr_t cb_obj_iterate(hid_t obj, char* name, H5O_info_t *info, void* data) 
         return 1
     return 0
 
-cdef herr_t cb_obj_simple(hid_t obj, char* name, H5O_info_t *info, void* data) except 2:
+cdef herr_t cb_obj_simple(hid_t obj, const char* name, const H5O_info_t *info, void* data) except 2:
 
     cdef _ObjectVisitor visit
 

--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -934,8 +934,8 @@ cdef class PropFAID(PropInstanceID):
         3. UINT rdcc_nbytes:     Size of raw data cache
         4. DOUBLE rdcc_w0:       Preemption policy for data cache.
         """
-        cdef int mdc, rdcc
-        cdef size_t rdcc_nbytes
+        cdef int mdc
+        cdef size_t rdcc, rdcc_nbytes
         cdef double w0
 
         H5Pget_cache(self.id, &mdc, &rdcc, &rdcc_nbytes, &w0)

--- a/h5py/h5s.pyx
+++ b/h5py/h5s.pyx
@@ -485,7 +485,7 @@ cdef class SpaceID(ObjectID):
 
         nelements = hcoords.dimensions[0]
 
-        H5Sselect_elements(self.id, <H5S_seloper_t>op, nelements, <hsize_t**>hcoords.data)
+        H5Sselect_elements(self.id, <H5S_seloper_t>op, nelements, <hsize_t*>hcoords.data)
 
 
     # === Hyperslab selection functions =======================================


### PR DESCRIPTION
This is mostly const correctness, but there are a few more subtle ones
(int*->size_t*, hsize_t**->hsize_t*).

The longer story is that GCC4.9 now warns for these, but doesn't have a -Wno,
so these mostly cosmetic bugs were preventing h5py from building in GCC with
-Werror.