### PR TITLE
Subclass from abcs

### DIFF
--- a/h5py/_hl/attrs.py
+++ b/h5py/_hl/attrs.py
@@ -19,7 +19,7 @@ from .dataset import readtime_dtype
 from .datatype import Datatype
 
 
-class AttributeManager(base.DictCompat, base.CommonStateObject):
+class AttributeManager(base.MutableMappingWithLock, base.CommonStateObject):
 
     """
         Allows dictionary-style access to an HDF5 object's attributes.
@@ -249,5 +249,3 @@ class AttributeManager(base.DictCompat, base.CommonStateObject):
         if not self._id:
             return "<Attributes of closed HDF5 object>"
         return "<Attributes of HDF5 object at %s>" % id(self._id)
-
-collections.MutableMapping.register(AttributeManager)

--- a/h5py/_hl/dims.py
+++ b/h5py/_hl/dims.py
@@ -114,7 +114,7 @@ class DimensionProxy(base.CommonStateObject):
                % (self.label, self._dimension, id(self._id)))
 
 
-class DimensionManager(base.DictCompat, base.CommonStateObject):
+class DimensionManager(base.MappingWithLock, base.CommonStateObject):
 
     """
     """

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -18,12 +18,12 @@ import collections
 
 from .. import h5g, h5i, h5o, h5r, h5t, h5l, h5p
 from . import base
-from .base import HLObject, DictCompat, phil, with_phil
+from .base import HLObject, MutableMappingWithLock, phil, with_phil
 from . import dataset
 from . import datatype
 
 
-class Group(HLObject, DictCompat):
+class Group(HLObject, MutableMappingWithLock):
 
     """ Represents an HDF5 group.
     """
@@ -465,8 +465,6 @@ class Group(HLObject, DictCompat):
         if six.PY3:
             return r
         return r.encode('utf8')
-
-collections.MutableMapping.register(Group)
 
 
 class HardLink(object):

--- a/h5py/tests/old/test_group.py
+++ b/h5py/tests/old/test_group.py
@@ -434,8 +434,8 @@ class TestPy3Dict(BaseMapping):
         vv = getattr(self.f, 'values')()
         self.assertSameElements(list(vv), [self.f.get(x) for x in self.groups])
         self.assertEqual(len(vv), len(self.groups))
-        with self.assertRaises(TypeError):
-            b'x' in vv
+        for x in self.groups:
+            self.assertIn(self.f.get(x), vv)
 
     def test_items(self):
         """ .items provides an item view """

--- a/h5py/tests/old/test_group.py
+++ b/h5py/tests/old/test_group.py
@@ -445,6 +445,91 @@ class TestPy3Dict(BaseMapping):
         for x in self.groups:
             self.assertIn((x, self.f.get(x)), iv)
 
+class TestAdditionalMappingFuncs(BaseMapping):
+    """
+    Feature: Other dict methods (pop, pop_item, clear, update, setdefault) are
+    available.
+    """
+    def setUp(self):
+        self.f = File(self.mktemp(), 'w')
+        for x in ('/test/a','/test/b','/test/c','/test/d'):
+            self.f.create_group(x)
+        self.group = self.f['test']
+
+    def tearDown(self):
+        if self.f:
+            self.f.close()
+
+    def test_pop_item(self):
+        """.pop_item exists and removes item"""
+        key, val = self.group.popitem()
+        self.assertNotIn(key, self.group)
+
+    def test_pop(self):
+        """.pop exists and removes specified item"""
+        self.group.pop('a')
+        self.assertNotIn('a', self.group)
+
+    def test_pop_default(self):
+        """.pop falls back to default"""
+        # e shouldn't exist as a group
+        value = self.group.pop('e', None)
+        self.assertEqual(value, None)
+
+    def test_pop_raises(self):
+        """.pop raises KeyError for non-existence"""
+        # e shouldn't exist as a group
+        with self.assertRaises(KeyError):
+            key = self.group.pop('e')
+
+    def test_clear(self):
+        """.clear removes groups"""
+        self.group.clear()
+        self.assertEqual(len(self.group), 0)
+
+    def test_update_dict(self):
+        """.update works with dict"""
+        new_items = {'e': np.array([42])}
+        self.group.update(new_items)
+        self.assertIn('e', self.group)
+
+    def test_update_iter(self):
+        """.update works with list"""
+        new_items = [
+            ('e', np.array([42])),
+            ('f', np.array([42]))
+        ]
+        self.group.update(new_items)
+        self.assertIn('e', self.group)
+
+    def test_update_kwargs(self):
+        """.update works with kwargs"""
+        new_items = {'e': np.array([42])}
+        self.group.update(**new_items)
+        self.assertIn('e', self.group)
+
+    def test_setdefault(self):
+        """.setdefault gets group if it exists"""
+        value = self.group.setdefault('a')
+        self.assertEqual(value, self.group.get('a'))
+
+    def test_setdefault_with_default(self):
+        """.setdefault gets default if group doesn't exist"""
+        # e shouldn't exist as a group
+        # 42 used as groups should be strings
+        value = self.group.setdefault('e', np.array([42]))
+        self.assertEqual(value, 42)
+
+    def test_setdefault_no_default(self):
+        """
+        .setdefault gets None if group doesn't exist, but as None isn't defined
+        as data for a dataset, this should raise a TypeError.
+        """
+        # e shouldn't exist as a group
+        with self.assertRaises(TypeError):
+            self.group.setdefault('e')
+
+
 class TestGet(BaseGroup):
 
     """


### PR DESCRIPTION
This changes the `DictCompat` class to be two classes `MappingWithLock` and `MutableMappingWithLock`, which inherit from `abc.Mapping` and `abc.MutableMapping`. This means that some functions which `DictCompat`, and hence Group etc., did not have (e.g. update), are now added.