### PR TITLE
Cythonize system fallback

### DIFF
--- a/setup_build.py
+++ b/setup_build.py
@@ -109,14 +109,13 @@ class h5py_build_ext(build_ext):
     def run_system_cython(pyx_files):
         try:
             retcode = subprocess.call(['cython', '--fast-fail', '--verbose'] + pyx_files)
-            print "Retcode: ", str(retcode)
             if not retcode == 0:
                 raise Exception('ERROR: Cython failed')
         except OSError as e:
-            print "ERROR: cython exec failed. Is cython not in the path? ", str(e)
+            print("ERROR: cython exec failed. Is cython not in the path? ", str(e))
             raise
         except Exception as e:
-            print "ERROR: cython exec failed", str(e)
+            print("ERROR: cython exec failed", str(e))
             raise
 
     def check_rerun_cythonize(self):
@@ -129,9 +128,9 @@ class h5py_build_ext(build_ext):
             if not op.isfile(c_src_file):
                 missing_c_src_files.append( c_src_file )
         if missing_c_src_files:
-            print "WARNING: cythonize() failed to create all .c files (setuptools too old?)"
+            print("WARNING: cythonize() failed to create all .c files (setuptools too old?)")
             pyx_files = [os.path.splitext(fname)[0] + ".pyx" for fname in missing_c_src_files]
-            print "         Executing system cython on pyx files: ", str(pyx_files)
+            print("         Executing system cython on pyx files: ", str(pyx_files))
             self.run_system_cython(pyx_files)
 
 
@@ -168,7 +167,7 @@ DEF HDF5_VERSION = %(version)s
                 f.write(s)
         
         # Run Cython
-        print "Executing cythonize()"
+        print("Executing cythonize()")
         self.extensions = cythonize(self._make_extensions(config),
                             force=config.rebuild_required or self.force)
         self.check_rerun_cythonize()

--- a/setup_build.py
+++ b/setup_build.py
@@ -13,6 +13,7 @@ from distutils.command.build_ext import build_ext
 import sys
 import os
 import os.path as op
+import subprocess
 from functools import reduce
 import api_gen
 
@@ -104,6 +105,36 @@ class h5py_build_ext(build_ext):
         return [make_extension(m) for m in MODULES]
         
         
+    @staticmethod
+    def run_system_cython(pyx_files):
+        try:
+            retcode = subprocess.call(['cython', '--fast-fail', '--verbose'] + pyx_files)
+            print "Retcode: ", str(retcode)
+            if not retcode == 0:
+                raise Exception('ERROR: Cython failed')
+        except OSError as e:
+            print "ERROR: cython exec failed. Is cython not in the path? ", str(e)
+            raise
+        except Exception as e:
+            print "ERROR: cython exec failed", str(e)
+            raise
+
+    def check_rerun_cythonize(self):
+        """ Check whether the cythonize() call produced the expected .c files.
+        If the expected .c files are not found then cython from the system path will
+        be executed in order to produce the missing files. """
+
+        missing_c_src_files = []
+        for c_src_file in [ext.sources[0] for ext in self.extensions]:
+            if not op.isfile(c_src_file):
+                missing_c_src_files.append( c_src_file )
+        if missing_c_src_files:
+            print "WARNING: cythonize() failed to create all .c files (setuptools too old?)"
+            pyx_files = [os.path.splitext(fname)[0] + ".pyx" for fname in missing_c_src_files]
+            print "         Executing system cython on pyx files: ", str(pyx_files)
+            self.run_system_cython(pyx_files)
+
+
     def run(self):
         """ Distutils calls this method to run the command """
         
@@ -137,8 +168,10 @@ DEF HDF5_VERSION = %(version)s
                 f.write(s)
         
         # Run Cython
+        print "Executing cythonize()"
         self.extensions = cythonize(self._make_extensions(config),
                             force=config.rebuild_required or self.force)
+        self.check_rerun_cythonize()
         
         # Perform the build
         build_ext.run(self)


### PR DESCRIPTION
This patch relates to #537 "h5py/defs.c: No such file or directory".

For old versions of setuptools (probably <0.7), the Cython.Build.cythonize() function can fail silently to process .pyx files into .c files. Updating setuptools fixes this problem, but this update can have more complex implications on a python site installation - and this may not be desired in a production environment.

This patch adds a fallback solution which first checks whether the expected .c files has been produced by cythonize(). If the expected .c files are not found, the system cython is executed on the appropriate set of .pyx files (only for the missing .c files).

The use of the cython from the system environment is similar to the approach of the [numpy build system](https://github.com/numpy/numpy/blob/master/tools/cythonize.py)
