### PR TITLE
Update build.rst

### DIFF
--- a/docs/build.rst
+++ b/docs/build.rst
@@ -27,6 +27,8 @@ You will need:
 Download the installer from http://www.h5py.org and run it.  HDF5 is
 included.
 
+If Anaconda Python is installed, plese use:
+  conda install h5py
 
 Installing on Linux and Mac OS X
 --------------------------------


### PR DESCRIPTION
Following the existing instructions if using Anaconda results in an installation failure in Windows. Installation instructions for Anaconda python have been added to the "Installing on Windows" section.