### PR TITLE
add user and api docs to release tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,3 +12,5 @@ include setup_build.py
 include setup_configure.py
 include ANN.rst
 include README.rst
+recursive-include docs *
+recursive-include docs_api *


### PR DESCRIPTION
Dear Andrew,

It would be nice if both the user and developer documentation were provided as part of the release tarball in PyPI so distributions can provide them as part of the packaging process. This PR addresses this by appending the relevant documentation folders in the MANIFEST.in.

Thanks for considering this,

Ghis