### PR TITLE
remove extra DS_Store files from release tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,3 +14,4 @@ include ANN.rst
 include README.rst
 recursive-include docs *
 recursive-include docs_api *
+recursive-exclude * .DS_Store


### PR DESCRIPTION
Dear Andrew,

I have noticed that, since version v2.4, an extra DS_Store file gets into the release tarball in the lzf/ folder. This PR makes sure it will be excluded from future releases.

Cheers,
Ghis