### PR TITLE
do not ship doc build in release tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,5 +13,7 @@ include setup_configure.py
 include ANN.rst
 include README.rst
 recursive-include docs *
+prune docs/_build
 recursive-include docs_api *
+prune docs_api/_build
 recursive-exclude * .DS_Store


### PR DESCRIPTION
Hi Andrew,

I noticed that the latest v2.5.0 release tarball have a few issues with regards to the documentation. I will make 2 different PRs for these, since both issues relate to different things.

This PR prevents any future temporary sphinx build directory being shipped in the release tarball. Release v2.5.0 has one of these temporary build directory in docs/ but not in docs_api/ which tells me this was not intended.

Cheers,