### PR TITLE
Requirements for setup (numpy, Cython) added

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -136,6 +136,6 @@ setup(
   ext_modules = [Extension('h5py.x',['x.c'])],  # To trick build into running build_ext
   requires = ['numpy (>=1.6.1)', 'Cython (>=0.17)'],
   install_requires = ['numpy>=1.6.1', 'Cython>=0.17', 'six'],
-  setup_requires = ['pkgconfig', 'six'],
+  setup_requires = ['numpy>=1.6.1', 'Cython>=0.17', 'pkgconfig', 'six'],
   cmdclass = CMDCLASS,
 )

--- a/setup_build.py
+++ b/setup_build.py
@@ -83,7 +83,14 @@ class h5py_build_ext(build_ext):
         except EnvironmentError:
             pass
 
-        settings['include_dirs'] += [numpy.get_include()]
+        try:
+            numpy_includes = numpy.get_include()
+        except AttributeError:
+            # if numpy is not installed get the headers from the .egg directory
+            import numpy.core
+            numpy_includes = os.path.join(os.path.dirname(numpy.core.__file__), 'include')
+
+        settings['include_dirs'] += [numpy_includes]
         if config.mpi:
             import mpi4py
             settings['include_dirs'] += [mpi4py.get_include()]


### PR DESCRIPTION
This is needed if no numpy, Cython is installed, e.g. in Virtualenvs