### PR TITLE
Large number of fixes and cleanups triggered by pylint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ install:
     - if [[ $TRAVIS_PYTHON_VERSION != "2.6" && $TRAVIS_PYTHON_VERSION != "3.2" ]]; then pip install pylint; fi
 
 script:
-    - if [[ $TRAVIS_PYTHON_VERSION != "2.6" && $TRAVIS_PYTHON_VERSION != "3.2" ]]; then pylint h5py || true; fi
+    - if [[ $TRAVIS_PYTHON_VERSION != "2.6" && $TRAVIS_PYTHON_VERSION != "3.2" ]]; then pylint h5py; fi
     - python setup.py build -f
     - python setup.py test

--- a/h5py/__init__.py
+++ b/h5py/__init__.py
@@ -7,8 +7,19 @@
 # License:  Standard 3-clause BSD; see "license.txt" for full license terms
 #           and contributor agreement.
 
+"""
+    This is the h5py package, a Python interface to the HDF5
+    scientific data format.
+"""
+
 from __future__ import absolute_import
 
+
+# --- Library setup -----------------------------------------------------------
+
+# When importing from the root of the unpacked tarball or git checkout,
+# Python sees the "h5py" source directory and tries to load it, which fails.
+# We tried working around this by using "package_dir" but that breaks Cython.
 try:
     from . import _errors
 except ImportError:
@@ -20,44 +31,38 @@ except ImportError:
     
 _errors.silence_errors()
 
-from . import _conv
-_conv.register_converters()
+from ._conv import register_converters as _register_converters
+_register_converters()
+
+from .h5z import _register_lzf
+_register_lzf()
+
+
+# --- Public API --------------------------------------------------------------
 
 from . import h5a, h5d, h5ds, h5f, h5fd, h5g, h5r, h5s, h5t, h5p, h5z
 
-h5s.NULL = h5s._NULL  # NULL is a reserved name at the Cython layer
-h5z._register_lzf()
-
-from .highlevel import *
+from ._hl import filters
+from ._hl.base import is_hdf5, HLObject
+from ._hl.files import File
+from ._hl.group import Group, SoftLink, ExternalLink, HardLink
+from ._hl.dataset import Dataset
+from ._hl.datatype import Datatype
+from ._hl.attrs import AttributeManager
 
 from .h5 import get_config
 from .h5r import Reference, RegionReference
 from .h5t import special_dtype, check_dtype
 
-# Deprecated functions
-from .h5t import py_new_vlen as new_vlen
-from .h5t import py_get_vlen as get_vlen
-from .h5t import py_new_enum as new_enum
-from .h5t import py_get_enum as get_enum
-
 from . import version
+from .version import version as __version__
 
 from .tests import run_tests
 
-__version__ = version.version
-
-__doc__ = \
-"""
-    This is the h5py package, a Python interface to the HDF5
-    scientific data format.
-
-    Version %s
-
-    HDF5 %s
-""" % (version.version, version.hdf5_version)
-
-
 def enable_ipython_completer():
+    """ Call this from an interactive IPython session to enable tab-completion
+    of group and attribute names.
+    """
     import sys
     if 'IPython' in sys.modules:
         ip_running = False
@@ -74,5 +79,16 @@ def enable_ipython_completer():
             from . import ipy_completer
             return ipy_completer.load_ipython_extension()
 
-    raise RuntimeError('completer must be enabled in active ipython session')
+    raise RuntimeError('Completer must be enabled in active ipython session')
+
+
+# --- Legacy API --------------------------------------------------------------
+
+from .h5t import py_new_vlen as new_vlen
+from .h5t import py_get_vlen as get_vlen
+from .h5t import py_new_enum as new_enum
+from .h5t import py_get_enum as get_enum
+
+
+
 

--- a/h5py/_hl/__init__.py
+++ b/h5py/_hl/__init__.py
@@ -7,5 +7,12 @@
 # License:  Standard 3-clause BSD; see "license.txt" for full license terms
 #           and contributor agreement.
 
+"""
+    This subpackage implements the high-level interface for h5py.
+    
+    Don't manually import things from here; the public API lives directly
+    in the top-level package namespace.
+"""
+
 from __future__ import absolute_import
 

--- a/h5py/_hl/attrs.py
+++ b/h5py/_hl/attrs.py
@@ -25,7 +25,7 @@ from .dataset import readtime_dtype
 from .datatype import Datatype
 
 
-class AttributeManager(base.MutableMappingWithLock, base.CommonStateObject):
+class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
 
     """
         Allows dictionary-style access to an HDF5 object's attributes.

--- a/h5py/_hl/attrs.py
+++ b/h5py/_hl/attrs.py
@@ -7,10 +7,16 @@
 # License:  Standard 3-clause BSD; see "license.txt" for full license terms
 #           and contributor agreement.
 
+"""
+    Implements high-level operations for attributes.
+    
+    Provides the AttributeManager class, available on high-level objects
+    as <obj>.attrs.
+"""
+
 from __future__ import absolute_import
 
 import numpy
-import collections
 
 from .. import h5s, h5t, h5a
 from . import base
@@ -181,7 +187,7 @@ class AttributeManager(base.MutableMappingWithLock, base.CommonStateObject):
                 try:
                     attr.write(data, mtype=htype2)
                 except:
-                    attr._close()
+                    attr.close()
                     h5a.delete(self._id, self._e(tempname))
                     raise
                 else:
@@ -191,7 +197,7 @@ class AttributeManager(base.MutableMappingWithLock, base.CommonStateObject):
                             h5a.delete(self._id, self._e(name))
                         h5a.rename(self._id, self._e(tempname), self._e(name))
                     except:
-                        attr._close()
+                        attr.close()
                         h5a.delete(self._id, self._e(tempname))
                         raise
                         
@@ -230,10 +236,12 @@ class AttributeManager(base.MutableMappingWithLock, base.CommonStateObject):
     def __iter__(self):
         """ Iterate over the names of attributes. """
         with phil:
+        
             attrlist = []
-
             def iter_cb(name, *args):
+                """ Callback to gather attribute names """
                 attrlist.append(self._d(name))
+
             h5a.iterate(self._id, iter_cb)
 
         for name in attrlist:

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -17,7 +17,7 @@ import posixpath as pp
 import sys
 
 import six
-from six.moves import xrange
+from six.moves import xrange    # pylint: disable=redefined-builtin
 
 import numpy
 

--- a/h5py/_hl/datatype.py
+++ b/h5py/_hl/datatype.py
@@ -7,12 +7,16 @@
 # License:  Standard 3-clause BSD; see "license.txt" for full license terms
 #           and contributor agreement.
 
+"""
+    Implements high-level access to committed datatypes in the file.
+"""
+
 from __future__ import absolute_import
 
 import posixpath as pp
 
 from ..h5t import TypeID
-from .base import HLObject, phil, with_phil
+from .base import HLObject, with_phil
 
 class Datatype(HLObject):
 

--- a/h5py/_hl/dims.py
+++ b/h5py/_hl/dims.py
@@ -7,21 +7,28 @@
 # License:  Standard 3-clause BSD; see "license.txt" for full license terms
 #           and contributor agreement.
 
-from __future__ import absolute_import
+"""
+    Implements support for HDF5 dimension scales.
+"""
 
-import numpy
+from __future__ import absolute_import
 
 from .. import h5ds
 from . import base
 from .base import phil, with_phil
-from .dataset import Dataset, readtime_dtype
+from .dataset import Dataset
 
 
 class DimensionProxy(base.CommonStateObject):
 
+    """
+        Represents an HDF5 "dimension".
+    """
+    
     @property
     @with_phil
     def label(self):
+        """ Get or set the dimension scale label """
         #return h5ds.get_label(self._id, self._dimension)
         # Produces a segfault for a non-existent label (Fixed in hdf5-1.8.8).
         # Here is a workaround:
@@ -33,11 +40,12 @@ class DimensionProxy(base.CommonStateObject):
     @label.setter
     @with_phil
     def label(self, val):
+        # pylint: disable=missing-docstring
         h5ds.set_label(self._id, self._dimension, self._e(val))
 
     @with_phil
-    def __init__(self, id, dimension):
-        self._id = id
+    def __init__(self, id_, dimension):
+        self._id = id_
         self._dimension = dimension
 
     @with_phil
@@ -59,39 +67,50 @@ class DimensionProxy(base.CommonStateObject):
 
     @with_phil
     def __getitem__(self, item):
+    
         if isinstance(item, int):
             scales = []
-            def f(dsid):
-                scales.append(Dataset(dsid))
-            h5ds.iterate(self._id, self._dimension, f, 0)
-            return scales[item]
+            h5ds.iterate(self._id, self._dimension, scales.append, 0)
+            return Dataset(scales[item])
+            
         else:
             def f(dsid):
+                """ Iterate over scales to find a matching name """
                 if h5ds.get_scale_name(dsid) == self._e(item):
-                    return Dataset(dsid)
+                    return dsid
+                    
             res = h5ds.iterate(self._id, self._dimension, f, 0)
             if res is None:
                 raise KeyError('%s not found' % item)
-            return res
+            return Dataset(res)
 
     def attach_scale(self, dset):
+        """ Attach a scale to this dimension.
+        
+        Provide the Dataset of the scale you would like to attach.
+        """
         with phil:
             h5ds.attach_scale(self._id, dset.id, self._dimension)
 
     def detach_scale(self, dset):
+        """ Remove a scale from this dimension.
+        
+        Provide the Dataset of the scale you would like to remove.
+        """
         with phil:
             h5ds.detach_scale(self._id, dset.id, self._dimension)
 
     def items(self):
+        """ Get a list of (name, Dataset) pairs with all scales on this
+        dimension.
+        """
         with phil:
             scales = []
-            def f(dsid):
-                scales.append(dsid)
-            
+
             # H5DSiterate raises an error if there are no dimension scales,
             # rather than iterating 0 times.  See #483.
             if len(self) > 0:
-                h5ds.iterate(self._id, self._dimension, f, 0)
+                h5ds.iterate(self._id, self._dimension, scales.append, 0)
                 
             return [
                 (self._d(h5ds.get_scale_name(id)), Dataset(id))
@@ -99,10 +118,12 @@ class DimensionProxy(base.CommonStateObject):
                 ]
 
     def keys(self):
+        """ Get a list of names for the scales on this dimension. """
         with phil:
             return [key for (key, val) in self.items()]
 
     def values(self):
+        """ Get a list of Dataset for scales on this dimension. """
         with phil:
             return [val for (key, val) in self.items()]
 
@@ -117,6 +138,10 @@ class DimensionProxy(base.CommonStateObject):
 class DimensionManager(base.MappingHDF5, base.CommonStateObject):
 
     """
+        Represents a collection of dimension associated with a dataset.
+        
+        Like AttributeManager, an instance of this class is returned when
+        accessing the ".dims" property on a Dataset.
     """
 
     @with_phil
@@ -151,5 +176,9 @@ class DimensionManager(base.MappingHDF5, base.CommonStateObject):
         return "<Dimensions of HDF5 object at %s>" % id(self._id)
 
     def create_scale(self, dset, name=''):
+        """ Create a new dimension, from an initial scale.
+        
+        Provide the dataset and a name for the scale.
+        """
         with phil:
             h5ds.set_scale(dset.id, self._e(name))

--- a/h5py/_hl/dims.py
+++ b/h5py/_hl/dims.py
@@ -114,7 +114,7 @@ class DimensionProxy(base.CommonStateObject):
                % (self.label, self._dimension, id(self._id)))
 
 
-class DimensionManager(base.MappingWithLock, base.CommonStateObject):
+class DimensionManager(base.MappingHDF5, base.CommonStateObject):
 
     """
     """

--- a/h5py/_hl/dims.py
+++ b/h5py/_hl/dims.py
@@ -113,19 +113,19 @@ class DimensionProxy(base.CommonStateObject):
                 h5ds.iterate(self._id, self._dimension, scales.append, 0)
                 
             return [
-                (self._d(h5ds.get_scale_name(id)), Dataset(id))
-                for id in scales
+                (self._d(h5ds.get_scale_name(x)), Dataset(x))
+                for x in scales
                 ]
 
     def keys(self):
         """ Get a list of names for the scales on this dimension. """
         with phil:
-            return [key for (key, val) in self.items()]
+            return [key for (key, _) in self.items()]
 
     def values(self):
         """ Get a list of Dataset for scales on this dimension. """
         with phil:
-            return [val for (key, val) in self.items()]
+            return [val for (_, val) in self.items()]
 
     @with_phil
     def __repr__(self):

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -7,17 +7,20 @@
 # License:  Standard 3-clause BSD; see "license.txt" for full license terms
 #           and contributor agreement.
 
+"""
+    Implements high-level support for HDF5 file objects.
+"""
+
 from __future__ import absolute_import
 
-import weakref
 import sys
 import os
 
 import six
 
-from .base import HLObject, phil, with_phil
+from .base import phil, with_phil
 from .group import Group
-from .. import h5, h5f, h5p, h5i, h5fd, h5t, _objects
+from .. import h5, h5f, h5p, h5i, h5fd, _objects
 from .. import version
 
 mpi = h5.get_config().mpi
@@ -49,15 +52,15 @@ def make_fapl(driver, libver, **kwds):
     if driver is None or (driver == 'windows' and sys.platform == 'win32'):
         return plist
 
-    if(driver == 'sec2'):
+    if driver == 'sec2':
         plist.set_fapl_sec2(**kwds)
-    elif(driver == 'stdio'):
+    elif driver == 'stdio':
         plist.set_fapl_stdio(**kwds)
-    elif(driver == 'core'):
+    elif driver == 'core':
         plist.set_fapl_core(**kwds)
-    elif(driver == 'family'):
+    elif driver == 'family':
         plist.set_fapl_family(memb_fapl=plist.copy(), **kwds)
-    elif(driver == 'mpio'):
+    elif driver == 'mpio':
         kwds.setdefault('info', mpi4py.MPI.Info())
         plist.set_fapl_mpio(**kwds)
     else:
@@ -202,21 +205,24 @@ class File(Group):
         @atomic.setter
         @with_phil
         def atomic(self, value):
+            # pylint: disable=missing-docstring
             self.id.set_mpi_atomicity(value)
             
     if swmr_support:
         @property
         def swmr_mode(self):
+            """ Controls single-writer multiple-reader mode """
             return self._swmr_mode
             
         @swmr_mode.setter
         @with_phil
         def swmr_mode(self, value):
+            # pylint: disable=missing-docstring
             if value:
                 self.id.start_swmr_write()
                 self._swmr_mode = True
             else:
-                raise ValueError("It is not possible to forcibly swith SWMR mode off.")
+                raise ValueError("It is not possible to forcibly switch SWMR mode off.")
 
     def __init__(self, name, mode=None, driver=None,
                  libver=None, userblock_size=None, swmr=False, **kwds):

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -18,12 +18,12 @@ import collections
 
 from .. import h5g, h5i, h5o, h5r, h5t, h5l, h5p
 from . import base
-from .base import HLObject, MutableMappingWithLock, phil, with_phil
+from .base import HLObject, MutableMappingHDF5, phil, with_phil
 from . import dataset
 from . import datatype
 
 
-class Group(HLObject, MutableMappingWithLock):
+class Group(HLObject, MutableMappingHDF5):
 
     """ Represents an HDF5 group.
     """

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -7,14 +7,16 @@
 # License:  Standard 3-clause BSD; see "license.txt" for full license terms
 #           and contributor agreement.
 
+"""
+    Implements support for high-level access to HDF5 groups.
+"""
+
 from __future__ import absolute_import
 
 import posixpath as pp
-
 import six
-
 import numpy
-import collections
+import sys
 
 from .. import h5g, h5i, h5o, h5r, h5t, h5l, h5p
 from . import base
@@ -197,6 +199,8 @@ class Group(HLObject, MutableMappingHDF5):
         >>> if cls == SoftLink:
         ...     print '"foo" is a soft link!'
         """
+        # pylint: disable=arguments-differ
+
         with phil:
             if not (getclass or getlink):
                 try:
@@ -225,15 +229,20 @@ class Group(HLObject, MutableMappingHDF5):
                         return SoftLink
                     linkbytes = self.id.links.get_val(self._e(name))
                     return SoftLink(self._d(linkbytes))
+                    
                 elif typecode == h5l.TYPE_EXTERNAL:
                     if getclass:
                         return ExternalLink
                     filebytes, linkbytes = self.id.links.get_val(self._e(name))
-                    # TODO: I think this is wrong,
-                    # we should use filesystem decoding on the filename
-                    return ExternalLink(self._d(filebytes), self._d(linkbytes))
+                    try:
+                        filetext = filebytes.decode(sys.getfilesystemencoding())
+                    except (UnicodeError, LookupError):
+                        filetext = filebytes
+                    return ExternalLink(filetext, self._d(linkbytes))
+                    
                 elif typecode == h5l.TYPE_HARD:
                     return HardLink if getclass else HardLink()
+                    
                 else:
                     raise TypeError("Unknown link type")
 
@@ -419,6 +428,7 @@ class Group(HLObject, MutableMappingHDF5):
         """
         with phil:
             def proxy(name):
+                """ Call the function with the text name, not bytes """
                 return func(self._d(name))
             return h5o.visit(self.id, proxy)
 
@@ -448,6 +458,7 @@ class Group(HLObject, MutableMappingHDF5):
         """
         with phil:
             def proxy(name):
+                """ Use the text name of the object, not bytes """
                 name = self._d(name)
                 return func(name, self[name])
             return h5o.visit(self.id, proxy)
@@ -477,7 +488,6 @@ class HardLink(object):
     pass
 
 
-#TODO: implement equality testing for these
 class SoftLink(object):
 
     """
@@ -488,6 +498,7 @@ class SoftLink(object):
 
     @property
     def path(self):
+        """ Soft link value.  Not guaranteed to be a valid path. """
         return self._path
 
     def __init__(self, path):
@@ -506,10 +517,12 @@ class ExternalLink(object):
 
     @property
     def path(self):
+        """ Soft link path, i.e. the part inside the HDF5 file. """
         return self._path
 
     @property
     def filename(self):
+        """ Path to the external HDF5 file in the filesystem. """
         return self._filename
 
     def __init__(self, filename, path):

--- a/h5py/_hl/selections.py
+++ b/h5py/_hl/selections.py
@@ -7,6 +7,9 @@
 # License:  Standard 3-clause BSD; see "license.txt" for full license terms
 #           and contributor agreement.
 
+# We use __getitem__ side effects, which pylint doesn't like.
+# pylint: disable=pointless-statement
+
 """
     High-level access to HDF5 dataspace selections
 """
@@ -20,16 +23,6 @@ import numpy as np
 
 from .. import h5s, h5r
 
-# Selection types for hyperslabs
-from ..h5s import SELECT_SET  as SET
-from ..h5s import SELECT_OR   as OR
-from ..h5s import SELECT_AND  as AND
-from ..h5s import SELECT_XOR  as XOR
-from ..h5s import SELECT_NOTB as NOTB
-from ..h5s import SELECT_NOTA as NOTA
-
-if six.PY3:
-    long = int
 
 def select(shape, args, dsid):
     """ High-level routine to generate a selection from arbitrary arguments
@@ -119,7 +112,7 @@ class _RegionProxy(object):
         """ Takes arbitrary selection terms and produces a RegionReference
         object.  Selection must be compatible with the dataset.
         """
-        selection = select(self.id.shape, args)
+        selection = select(self.id.shape, args, self.id)
         return h5r.create(self.id, '.', h5r.DATASET_REGION, selection.id)
 
 class Selection(object):
@@ -198,7 +191,7 @@ class PointSelection(Selection):
     """
 
     def _perform_selection(self, points, op):
-
+        """ Internal method which actually performs the selection """
         points = np.asarray(points, order='C', dtype='u8')
         if len(points.shape) == 1:
             points.shape = (1,points.shape[0])
@@ -306,7 +299,7 @@ class SimpleSelection(Selection):
         tshape = tuple(tshape)
 
         chunks = tuple(x//y for x, y in zip(count, tshape))
-        nchunks = long(np.product(chunks))
+        nchunks = int(np.product(chunks))
 
         if nchunks == 1:
             yield self._id
@@ -318,71 +311,6 @@ class SimpleSelection(Selection):
                 sid.offset_simple(offset)
                 yield sid
 
-
-class HyperSelection(Selection):
-
-    """
-        Represents multiple overlapping rectangular selections, combined
-        with set-like operators.  Result is a 1D shape, as with boolean array
-        selection.  Broadcasting is not supported for these selections.
-
-        When created, the entire dataspace is selected.  To make
-        adjustments to the selection, use the standard NumPy slicing
-        syntax, either via __getitem__ (as with simple selections) or via
-        __setitem__ and one of the supported operators:
-
-            >>> sel = HyperSelection((10,20))  # Initially 200 points
-            >>> sel[:,5:15] = False            # Now 100 points
-            >>> sel[:,10]   = True             # Now 110 points
-            >>> sel[...]    = XOR              # Now 90 points
-
-        Legal operators (in the h5py.selections module) are:
-           
-        SET
-            New selection, wiping out any old one
-       
-        AND, XOR, OR (or True)
-            Logical AND/XOR/OR between new and old selection
-
-        NOTA
-            Select only regions in new selection which don't intersect the old
-
-        NOTB (or False)
-            Select only regions in old selection which don't intersect the new
- 
-    """
-
-    def __getitem__(self, args):
-        self[args] = SET
-        return self
-
-    def __setitem__(self, args, op):
-
-        if not isinstance(args, tuple):
-            args = (args,)
- 
-        start, count, step, scalar = _handle_simple(self.shape, args)
-
-        if not op in (SET, OR, AND, XOR, NOTB, NOTA, True, False):
-            raise ValueError("Illegal selection operator")
-
-        if op is True:
-            op = OR
-        elif op is False:
-            op = NOTB
-
-        seltype = self._id.get_select_type()
-
-        if seltype == h5s.SEL_ALL:
-            self._id.select_hyperslab((0,)*len(self.shape), self.shape, op=h5s.SELECT_SET)
-       
-        elif seltype == h5s.SEL_NONE:
-            if op in (SET, OR, XOR, NOTA):
-                op = SET
-            else:
-                return
-
-        self._id.select_hyperslab(start, count, step, op=op)
 
 class FancySelection(Selection):
 
@@ -429,10 +357,8 @@ class FancySelection(Selection):
                         raise TypeError("Indexing elements must be in increasing order")
 
         if len(sequenceargs) > 1:
-            # TODO: fix this with broadcasting
             raise TypeError("Only one indexing vector or array is currently allowed for advanced selection")
         if len(sequenceargs) == 0:
-            # TODO: fallback to standard selection
             raise TypeError("Advanced selection inappropriate")
 
         vectorlength = len(list(sequenceargs.values())[0])
@@ -484,7 +410,7 @@ def _expand_ellipsis(args, rank):
 
     final_args = []
     n_args = len(args)
-    for idx, arg in enumerate(args):
+    for arg in args:
 
         if arg is Ellipsis:
             final_args.extend( (slice(None,None,None),)*(rank-n_args+1) )

--- a/h5py/_hl/selections.py
+++ b/h5py/_hl/selections.py
@@ -17,7 +17,7 @@
 from __future__ import absolute_import
 
 import six
-from six.moves import xrange
+from six.moves import xrange    # pylint: disable=redefined-builtin
 
 import numpy as np
 

--- a/h5py/_hl/selections2.py
+++ b/h5py/_hl/selections2.py
@@ -76,7 +76,7 @@ def read_selections_scalar(dsid, args):
 class ScalarReadSelection(object):
 
     """
-        Undocumented.
+        Implements slicing for scalar datasets.
     """
     
     def __init__(self, fspace, args):
@@ -95,7 +95,10 @@ class ScalarReadSelection(object):
         yield self.fspace, self.mspace        
 
 def select_read(fspace, args):
-    """ Undocumented. """
+    """ Top-level dispatch function for reading.
+    
+    At the moment, only supports reading from scalar datasets.
+    """
     if fspace.shape == ():
         return ScalarReadSelection(fspace, args)
 

--- a/h5py/_hl/selections2.py
+++ b/h5py/_hl/selections2.py
@@ -7,6 +7,10 @@
 # License:  Standard 3-clause BSD; see "license.txt" for full license terms
 #           and contributor agreement.
 
+"""
+    Implements a portion of the selection operations.
+"""
+
 from __future__ import absolute_import
 
 import numpy as np
@@ -26,7 +30,7 @@ def read_dtypes(dataset_dtype, names):
         raise ValueError("Field names only allowed for compound types")
 
     elif any(x not in dataset_dtype.names for x in names):
-        raise ValueError("Field %s does not appear in this type." % name)
+        raise ValueError("Field does not appear in this type.")
 
     else:
         format_dtype = np.dtype([(name, dataset_dtype.fields[name][0]) for name in names])
@@ -71,6 +75,10 @@ def read_selections_scalar(dsid, args):
 
 class ScalarReadSelection(object):
 
+    """
+        Undocumented.
+    """
+    
     def __init__(self, fspace, args):
         if args == ():
             self.mshape = None
@@ -87,7 +95,7 @@ class ScalarReadSelection(object):
         yield self.fspace, self.mspace        
 
 def select_read(fspace, args):
-    
+    """ Undocumented. """
     if fspace.shape == ():
         return ScalarReadSelection(fspace, args)
 

--- a/h5py/_objects.pyx
+++ b/h5py/_objects.pyx
@@ -212,6 +212,13 @@ cdef class ObjectID:
                 self.id = 0
 
 
+    def close(self):
+        """ Close this identifier. """
+        # Note this is the default close method.  Subclasses, e.g. FileID,
+        # which have nonlocal effects should override this.
+        self._close()
+
+
     def __nonzero__(self):
         return self.valid
 

--- a/h5py/h5s.pyx
+++ b/h5py/h5s.pyx
@@ -47,7 +47,7 @@ UNLIMITED = H5S_UNLIMITED
 NO_CLASS = H5S_NO_CLASS
 SCALAR   = H5S_SCALAR
 SIMPLE   = H5S_SIMPLE
-_NULL = H5S_NULL
+globals()["NULL"] = H5S_NULL  # "NULL" is reserved in Cython
 
 #enum H5S_sel_type
 SEL_ERROR       = H5S_SEL_ERROR

--- a/h5py/highlevel.py
+++ b/h5py/highlevel.py
@@ -7,6 +7,15 @@
 # License:  Standard 3-clause BSD; see "license.txt" for full license terms
 #           and contributor agreement.
 
+# pylint: disable=unused-import
+
+"""
+    This is the deprecated legacy high-level interface.
+    
+    Everything here is canonically located at the root of the package.
+    New code should import directly from there, e.g. "from h5py import File".
+"""
+
 from __future__ import absolute_import
 
 from ._hl import filters

--- a/h5py/ipy_completer.py
+++ b/h5py/ipy_completer.py
@@ -11,34 +11,42 @@
 #
 #-
 
+# pylint: disable=eval-used,protected-access
+
 """
-h5py completer extension for ipython. This completer is automatically loaded
-when h5py is imported within ipython. It will let you do things like::
+    This is the h5py completer extension for ipython.  It is loaded by
+    calling the function h5py.enable_ipython_completer() from within an
+    interactive IPython session.
+    
+    It will let you do things like::
 
-  f=File('foo.h5')
-  f['<tab>
-  # or:
-  f['ite<tab>
+      f=File('foo.h5')
+      f['<tab>
+      # or:
+      f['ite<tab>
 
-which will do tab completion based on the subgroups of `f`. Also::
+    which will do tab completion based on the subgroups of `f`. Also::
 
-  f['item1'].at<tab>
+      f['item1'].at<tab>
 
-will perform tab completion for the attributes in the usual way. This should
-also work::
+    will perform tab completion for the attributes in the usual way. This should
+    also work::
 
-  a = b = f['item1'].attrs.<tab>
+      a = b = f['item1'].attrs.<tab>
 
-as should::
+    as should::
 
-  f['item1/item2/it<tab>
-
+      f['item1/item2/it<tab>
 """
 
 from __future__ import absolute_import
 
 import posixpath
 import re
+import readline
+from ._hl.attrs import AttributeManager
+from ._hl.base import HLObject
+
 
 try:
     # >=ipython-1.0
@@ -59,9 +67,6 @@ except ImportError:
     from IPython import generics
     from IPython.ipapi import TryNext
 
-import readline
-
-from h5py.highlevel import AttributeManager, HLObject
 
 re_attr_match = re.compile(r"(?:.*\=)?(.+\[.*\].*)\.(\w*)$")
 re_item_match = re.compile(r"""(?:.*\=)?(.*)\[(?P<s>['|"])(?!.*(?P=s))(.*)$""")
@@ -69,12 +74,13 @@ re_object_match = re.compile(r"(?:.*\=)?(.+?)(?:\[)")
 
 
 def _retrieve_obj(name, context):
+    """ Filter function for completion. """
+
     # we don't want to call any functions, but I couldn't find a robust regex
     # that filtered them without unintended side effects. So keys containing
     # "(" will not complete.
-    try:
-        assert '(' not in name
-    except AssertionError:
+    
+    if '(' in name:
         raise ValueError()
 
     try:
@@ -93,10 +99,10 @@ def h5py_item_completer(context, command):
 
     try:
         obj = _retrieve_obj(base, context)
-    except:
+    except Exception:
         return []
 
-    path, target = posixpath.split(item)
+    path, _ = posixpath.split(item)
     if path:
         items = (posixpath.join(path, name) for name in obj[path].iterkeys())
     else:
@@ -116,7 +122,7 @@ def h5py_attr_completer(context, command):
 
     try:
         obj = _retrieve_obj(base, context)
-    except:
+    except Exception:
         return []
 
     attrs = dir(obj)
@@ -154,6 +160,7 @@ def h5py_attr_completer(context, command):
 
 
 def h5py_completer(self, event):
+    """ Completer function to be loaded into IPython """
     base = re_object_match.split(event.line)[1]
 
     if not isinstance(self._ofind(base)['obj'], (AttributeManager, HLObject)):
@@ -173,6 +180,7 @@ def h5py_completer(self, event):
 
 
 def load_ipython_extension(ip=None):
+    """ Load completer function into IPython """
     if ip is None:
         ip = get_ipython()
     ip.set_hook('complete_command', h5py_completer, re_key=r"(?:.*\=)?(.+?)\[")

--- a/h5py/version.py
+++ b/h5py/version.py
@@ -7,6 +7,10 @@
 # License:  Standard 3-clause BSD; see "license.txt" for full license terms
 #           and contributor agreement.
 
+"""
+    Versioning module for h5py.
+"""
+
 from __future__ import absolute_import
 
 from . import h5 as _h5
@@ -25,12 +29,6 @@ hdf5_version = "%d.%d.%d" % hdf5_version_tuple
 
 api_version_tuple = (1,8)
 api_version = "1.8"
-
-__doc__ = """\
-This is h5py **%s**
-
-* HDF5 version: **%s**
-""" % (version, hdf5_version)
 
 info = """\
 Summary of the h5py configuration


### PR DESCRIPTION
Fixes an enormous number of issues identified through static analysis, including:

- Rarely-used code paths broken by mistyped variable names
- Duplicated code which had been moved from function to module level and not cleaned up
- Whole classes which were unused
- Undefined format-string arguments to rarely-triggered exceptions
- Bad exception handlers which eat SystemExit, etc., by mistake
- Missing public close() methods on nearly all low-level identifiers
- Unneeded Mapping classes in h5py._hl.base
- Pointless one-line functions used as iteration callbacks when list.append would suffice
- Piles of undocumented modules, functions, and methods

Also switches on pylint as part of the Travis build for pull requests.