### PR TITLE
Attempt to turn off error printing in new threads

### DIFF
--- a/api_gen.py
+++ b/api_gen.py
@@ -217,6 +217,7 @@ class LineProcessor(object):
         imp = """\
 cdef {0.code} {0.fname}({0.sig}) except *:
     cdef {0.code} r
+    _hdf5.H5Eset_auto(NULL, NULL)
     r = _hdf5.{0.fname}({0.args})
     if r{condition}:
         if set_exception():

--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -112,6 +112,12 @@ hdf5:
   1.9.178   herr_t H5Drefresh(hid_t dataset_id)
   
   
+  # === H5E - Minimal error-handling interface ================================
+  
+  # This is used only for defs.py, to disable printing in new threads
+  herr_t H5Eset_auto(void* a, void* b)
+    
+
   # === H5F - File API ========================================================
 
   hid_t     H5Fcreate(char *filename, unsigned int flags, hid_t create_plist, hid_t access_plist)

--- a/h5py/tests/hl/__init__.py
+++ b/h5py/tests/hl/__init__.py
@@ -5,10 +5,12 @@ from . import  (test_dataset_getitem,
                 test_dataset_swmr,
                 test_dims_dimensionproxy,
                 test_file, 
-                test_attribute_create, )
+                test_attribute_create,
+                test_threads, )
                 
 MODULES = ( test_dataset_getitem, 
             test_dataset_swmr, 
             test_dims_dimensionproxy,
             test_file,
-            test_attribute_create, )
+            test_attribute_create, 
+            test_threads, )

--- a/h5py/tests/hl/test_threads.py
+++ b/h5py/tests/hl/test_threads.py
@@ -1,0 +1,61 @@
+# This file is part of h5py, a Python interface to the HDF5 library.
+#
+# http://www.h5py.org
+#
+# Copyright 2008-2013 Andrew Collette and contributors
+#
+# License:  Standard 3-clause BSD; see "license.txt" for full license terms
+#           and contributor agreement.
+
+"""
+    Tests the h5py.File object.
+"""
+
+from __future__ import absolute_import
+
+import threading
+import h5py
+
+from ..common import ut, TestCase
+
+
+class TestErrorPrinting(TestCase):
+
+    """
+        Verify the error printing is squashed in all threads.
+    """
+    
+    def test_printing(self):
+        """ No console messages should be shown from containership tests """
+        # Unfortunately we can't have this test assert anything, as
+        # HDF5 writes directly to stderr.  But it will show up in the
+        # console output.
+    
+        import threading
+
+        def test():
+            with h5py.File(self.mktemp(), 'w') as newfile:
+                try:
+                    doesnt_exist = newfile['doesnt_exist'].value
+                except KeyError:
+                    pass
+
+        th = threading.Thread(target=test)
+        th.start()
+        th.join()
+
+    def test_attr_printing(self):
+        """ No console messages should be shown for non-existing attributes """
+        
+        def test():
+        
+            with h5py.File(self.mktemp(), 'w') as newfile:
+                newfile['newdata'] = [1,2,3]
+                try:
+                    nonexistent_attr = newfile['newdata'].attrs['nonexistent_attr']
+                except KeyError:
+                    pass
+
+        th = threading.Thread(target=test)
+        th.start()
+        th.join()


### PR DESCRIPTION
Address #580 by explicitly disabling error printing before each function call.

Unfortunately, while I added some tests, I was not able to reproduce the original behavior on my Mac, so I can't say for sure if this fixes the problem.  @stuarteberg, can you test on your system?