### PR TITLE
Update mpi.rst

### DIFF
--- a/docs/mpi.rst
+++ b/docs/mpi.rst
@@ -60,7 +60,8 @@ Once you've got a Parallel-enabled build of HDF5, h5py has to be compiled in
 and build h5py with the ``--mpi`` option::
 
     $ export CC=mpicc
-    $ python setup.py build --mpi [--hdf5=/path/to/parallel/hdf5]
+    $ python setup.py configure --mpi [--hdf5=/path/to/parallel/hdf5]
+    $ python setup.py build
 
 
 Using Parallel HDF5 from h5py


### PR DESCRIPTION
python setup.py build --mpi results in 'error: option --mpi not recognized' but using this option for configure does seem to work.

The old option seems to work in 2.2, but I need the new version in 2.5