### PR TITLE
Vector assigment

### DIFF
--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -509,9 +509,10 @@ class Dataset(HLObject):
                 dtype = self.dtype
                 cast_compound = False
 
-            val = numpy.asarray(val, dtype=dtype, order='C')
+            val = numpy.asarray(val, dtype=dtype.base, order='C')
             if cast_compound:
-                val = val.astype(numpy.dtype([(names[0], dtype)]))
+                val = val.view(numpy.dtype([(names[0], dtype)]))
+                val = val.reshape(val.shape[:len(val.shape) - len(dtype.shape)])
         else:
             val = numpy.asarray(val, order='C')
 

--- a/h5py/tests/old/test_dataset.py
+++ b/h5py/tests/old/test_dataset.py
@@ -772,6 +772,22 @@ class TestCompound(BaseDataset):
         self.assertTrue(np.all(outdata == testdata))
         self.assertEqual(outdata.dtype, testdata.dtype)
 
+    def test_assign(self):
+        dt = np.dtype( [ ('weight', (np.float64, 3)),
+                         ('endpoint_type', np.uint8), ] )
+
+        testdata = np.ndarray((16,), dtype=dt)
+        for key in dt.fields:
+            testdata[key] = np.random.random(size=testdata[key].shape)*100
+
+        ds = self.f.create_dataset('test', (16,), dtype=dt)
+        for key in dt.fields:
+            ds[key] = testdata[key]
+
+        outdata = self.f['test'][...]
+
+        self.assertTrue(np.all(outdata == testdata))
+        self.assertEqual(outdata.dtype, testdata.dtype)
 
 class TestEnum(BaseDataset):
 


### PR DESCRIPTION
To my surprise, it wasn't possible to assign a vector to a component of a compound dataset. I am not aware of any other alternatives to write to a vector component. Hence this patch. 
