### PR TITLE
Update list of supported types in FAQ

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -26,6 +26,7 @@ Boolean                             NumPy 1-byte bool                           
 Array                               Any supported type
 Enumeration                         Any NumPy integer type                          Read/write as integers
 References                          Region and object
+Variable length array               Any supported type                              See :ref:`Special Types <vlen>`
 =========================           ============================================    ======================
 
 Unsupported types:
@@ -33,7 +34,6 @@ Unsupported types:
 =========================           ============================================
 Type                                Status                                 
 =========================           ============================================
-HDF5 VLEN (non-string)              Pull requests welcome
 HDF5 "time" type
 NumPy "U" strings                   No HDF5 equivalent
 NumPy generic "O"                   Not planned


### PR DESCRIPTION
Variable length arrays of arbitrary datatypes have been supported since h5py 2.3