### PR TITLE
Use correct destination type when committing

### DIFF
--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -285,7 +285,7 @@ class Group(HLObject, MutableMappingHDF5):
                           self._e(obj.path), lcpl=lcpl, lapl=self._lapl)
 
         elif isinstance(obj, numpy.dtype):
-            htype = h5t.py_create(obj)
+            htype = h5t.py_create(obj, logical=True)
             htype.commit(self.id, name, lcpl=lcpl)
 
         else:

--- a/h5py/tests/hl/__init__.py
+++ b/h5py/tests/hl/__init__.py
@@ -6,11 +6,13 @@ from . import  (test_dataset_getitem,
                 test_dims_dimensionproxy,
                 test_file, 
                 test_attribute_create,
-                test_threads, )
+                test_threads,
+                test_datatype, )
                 
 MODULES = ( test_dataset_getitem, 
             test_dataset_swmr, 
             test_dims_dimensionproxy,
             test_file,
             test_attribute_create, 
-            test_threads, )
+            test_threads,
+            test_datatype, )

--- a/h5py/tests/hl/test_datatype.py
+++ b/h5py/tests/hl/test_datatype.py
@@ -1,0 +1,27 @@
+"""
+    Tests for the h5py.Datatype class.
+"""
+
+from __future__ import absolute_import
+
+import numpy as np
+import h5py
+
+from ..common import ut, TestCase
+
+class TestVlen(TestCase):
+
+    """
+        Check that storage of vlen strings is carried out correctly.
+    """
+    
+    def test_compound(self):
+
+        fields = []
+        fields.append(('field_1', h5py.special_dtype(vlen=str)))
+        fields.append(('field_2', np.int32))
+        dt = np.dtype(fields)
+        self.f['mytype'] = np.dtype(dt)
+        dt_out = self.f['mytype'].dtype.fields['field_1'][0]
+        self.assertEqual(h5py.check_dtype(vlen=dt_out), str)
+        


### PR DESCRIPTION
Possible fix for #613... group.py was incorrectly using memory representation when storing committed types.