### PR TITLE
Longint fixes

### DIFF
--- a/h5py/api_types_hdf5.pxd
+++ b/h5py/api_types_hdf5.pxd
@@ -13,10 +13,7 @@ include "config.pxi"
 
 cdef extern from "hdf5.h":
   # Basic types
-  IF HDF5_VERSION >= (1, 9, 222):
-    ctypedef long int hid_t
-  ELSE:
-    ctypedef int hid_t
+  ctypedef long int hid_t
   ctypedef int hbool_t
   ctypedef int herr_t
   ctypedef int htri_t

--- a/h5py/api_types_hdf5.pxd
+++ b/h5py/api_types_hdf5.pxd
@@ -213,6 +213,7 @@ cdef extern from "hdf5.h":
 # === H5I - Identifier and reflection interface ===============================
 
   ctypedef enum H5I_type_t:
+    H5I_UNINIT       = -2,  # uninitialized Group
     H5I_BADID        = -1,  # invalid Group
     H5I_FILE        = 1,    # group ID for File objects
     H5I_GROUP,              # group ID for Group objects
@@ -224,7 +225,10 @@ cdef extern from "hdf5.h":
     H5I_VFL,                # group ID for virtual file layer
     H5I_GENPROP_CLS,        # group ID for generic property list classes
     H5I_GENPROP_LST,        # group ID for generic property lists
-    H5I_NGROUPS             # number of valid groups, MUST BE LAST!
+    H5I_ERROR_CLASS,        # group ID for error classes
+    H5I_ERROR_MSG,          # group ID for error messages
+    H5I_ERROR_STACK,        # group ID for error stacks
+    H5I_NTYPES              # number of valid groups, MUST BE LAST!
 
 # === H5L/H5O - Links interface (1.8.X only) ======================================
 

--- a/h5py/api_types_hdf5.pxd
+++ b/h5py/api_types_hdf5.pxd
@@ -9,9 +9,14 @@
 
 from api_types_ext cimport *
 
+include "config.pxi"
+
 cdef extern from "hdf5.h":
   # Basic types
-  ctypedef int hid_t
+  IF HDF5_VERSION >= (1, 9, 222):
+    ctypedef long int hid_t
+  ELSE:
+    ctypedef int hid_t
   ctypedef int hbool_t
   ctypedef int herr_t
   ctypedef int htri_t

--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -1247,17 +1247,17 @@ cdef class TypeEnumID(TypeCompositeID):
 # of NumPy dtype into an HDF5 type object.  The result is guaranteed to be
 # transient and unlocked.
 
-cdef dict _float_le = {2: IEEE_F16LE.id, 4: H5T_IEEE_F32LE, 8: H5T_IEEE_F64LE}
-cdef dict _float_be = {2: IEEE_F16BE.id, 4: H5T_IEEE_F32BE, 8: H5T_IEEE_F64BE}
+cdef dict _float_le = {2: H5Tcopy(IEEE_F16LE.id), 4: H5Tcopy(H5T_IEEE_F32LE), 8: H5Tcopy(H5T_IEEE_F64LE)}
+cdef dict _float_be = {2: H5Tcopy(IEEE_F16BE.id), 4: H5Tcopy(H5T_IEEE_F32BE), 8: H5Tcopy(H5T_IEEE_F64BE)}
 cdef dict _float_nt = _float_le if ORDER_NATIVE == H5T_ORDER_LE else _float_be
 
-cdef dict _int_le = {1: H5T_STD_I8LE, 2: H5T_STD_I16LE, 4: H5T_STD_I32LE, 8: H5T_STD_I64LE}
-cdef dict _int_be = {1: H5T_STD_I8BE, 2: H5T_STD_I16BE, 4: H5T_STD_I32BE, 8: H5T_STD_I64BE}
-cdef dict _int_nt = {1: H5T_NATIVE_INT8, 2: H5T_NATIVE_INT16, 4: H5T_NATIVE_INT32, 8: H5T_NATIVE_INT64}
+cdef dict _int_le = {1: H5Tcopy(H5T_STD_I8LE), 2: H5Tcopy(H5T_STD_I16LE), 4: H5Tcopy(H5T_STD_I32LE), 8: H5Tcopy(H5T_STD_I64LE)}
+cdef dict _int_be = {1: H5Tcopy(H5T_STD_I8BE), 2: H5Tcopy(H5T_STD_I16BE), 4: H5Tcopy(H5T_STD_I32BE), 8: H5Tcopy(H5T_STD_I64BE)}
+cdef dict _int_nt = {1: H5Tcopy(H5T_NATIVE_INT8), 2: H5Tcopy(H5T_NATIVE_INT16), 4: H5Tcopy(H5T_NATIVE_INT32), 8: H5Tcopy(H5T_NATIVE_INT64)}
 
-cdef dict _uint_le = {1: H5T_STD_U8LE, 2: H5T_STD_U16LE, 4: H5T_STD_U32LE, 8: H5T_STD_U64LE}
-cdef dict _uint_be = {1: H5T_STD_U8BE, 2: H5T_STD_U16BE, 4: H5T_STD_U32BE, 8: H5T_STD_U64BE}
-cdef dict _uint_nt = {1: H5T_NATIVE_UINT8, 2: H5T_NATIVE_UINT16, 4: H5T_NATIVE_UINT32, 8: H5T_NATIVE_UINT64} 
+cdef dict _uint_le = {1: H5Tcopy(H5T_STD_U8LE), 2: H5Tcopy(H5T_STD_U16LE), 4: H5Tcopy(H5T_STD_U32LE), 8: H5Tcopy(H5T_STD_U64LE)}
+cdef dict _uint_be = {1: H5Tcopy(H5T_STD_U8BE), 2: H5Tcopy(H5T_STD_U16BE), 4: H5Tcopy(H5T_STD_U32BE), 8: H5Tcopy(H5T_STD_U64BE)}
+cdef dict _uint_nt = {1: H5Tcopy(H5T_NATIVE_UINT8), 2: H5Tcopy(H5T_NATIVE_UINT16), 4: H5Tcopy(H5T_NATIVE_UINT32), 8: H5Tcopy(H5T_NATIVE_UINT64)} 
 
 cdef TypeFloatID _c_float(dtype dt):
     # Floats (single and double)


### PR DESCRIPTION
Between version 1.9.178 and 1.9.222 of HDF5 the type hid_t was changed from int to long int.  h5py now handles this appropriately by modifying it's own hid_t cython declaration based on the HDF5 version number.

Note: this changeset fixes issue #599 and issue #616 
