### PR TITLE
Add support for client classes to automatically yield h5py datasets.

### DIFF
--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -266,6 +266,12 @@ class Group(HLObject, MutableMappingHDF5):
         Numpy dtype
             Commit a copy of the datatype as a named datatype in the file.
 
+        Class that implements __toh5ds__
+            Call obj.__toh5ds__(self, name), to allow client code to support
+            automatic coercion to a dataset. The name is provided to the
+            client for metadata generation, but the client is not permitted
+            to change the name used for the assignment.
+
         Anything else
             Attempt to convert it to an ndarray and store it.  Scalar
             values are stored as scalar datasets. Raise ValueError if we
@@ -287,6 +293,10 @@ class Group(HLObject, MutableMappingHDF5):
         elif isinstance(obj, numpy.dtype):
             htype = h5t.py_create(obj, logical=True)
             htype.commit(self.id, name, lcpl=lcpl)
+
+        elif getattr(obj, '__toh5ds__', None) is not None:
+            ds = obj.__toh5ds__(self, name)
+            h5o.link(ds.id, self.id, name, lcpl=lcpl)
 
         else:
             ds = self.create_dataset(None, data=obj, dtype=base.guess_dtype(obj))


### PR DESCRIPTION
Implement a new case in `Group.__setitem__`, which allows instances of custom classes to automatically convert themselves to h5py datasets. If the right-hand-side of the setitem call has a method `__toh5ds__`, call that method and expect it to return a new, unlinked dataset.

Example code:

````
import h5py
import numpy

class RHS(object):
    
    def __init__(self, arr, attrs):
        
        self.arr = arr
        self.attrs = attrs
    
    def __toh5ds__(self, group, name):
        
        ds = group.create_dataset(None, data=self.arr)
        ds.attrs['name'] = name
        for attr in self.attrs:
            ds.attrs[attr] = self.attrs[attr]
        
        return ds

h5file = h5py.File('test.h5', 'w')
g = h5file.create_group('test')

instance = RHS(numpy.array([1, 2, 3, 4, 5]), {'colour': 'red', 'shape': 'pointy'})

g['a'] = instance
````