### PR TITLE
Use item value in KeyError instead of error message

### DIFF
--- a/h5py/_hl/dims.py
+++ b/h5py/_hl/dims.py
@@ -81,7 +81,7 @@ class DimensionProxy(base.CommonStateObject):
                     
             res = h5ds.iterate(self._id, self._dimension, f, 0)
             if res is None:
-                raise KeyError('%s not found' % item)
+                raise KeyError(item)
             return Dataset(res)
 
     def attach_scale(self, dset):


### PR DESCRIPTION
This is not mentioned in [the docs](https://docs.python.org/3/library/exceptions.html#KeyError), but I think a `KeyError` is supposed to be constructed with the actual key, whose `repr()` is then used in the error message.

If it's constructed with an error message string, this message will be displayed with quotes, which looks strange, especially if the key is a string, and even worse if the key is an empty string, e.g.:

    >>> data['']
    ---------------------------------------------------------------------------
    KeyError                                  Traceback (most recent call last)
    ...
    KeyError: ' not found'

See also http://stackoverflow.com/a/24999035/500098.