### PR TITLE
Clean up versions and testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,27 @@ language: python
 notifications:
   email: false
 
-python:
-  - "2.6"
-  - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
+env:
+# Commented out since setup_requires is controlled by easy_install
+# This should be uncommented when pip can use setup_requires
+#  - TOXENV=py26-test-nodeps
+#  - TOXENV=py27-test-nodeps
+#  - TOXENV=py32-test-nodeps
+#  - TOXENV=py33-test-nodeps
+#  - TOXENV=py34-test-nodeps
+  - TOXENV=py26-test-deps
+  - TOXENV=py27-test-deps
+  - TOXENV=py32-test-deps
+  - TOXENV=py33-test-deps
+  - TOXENV=py34-test-deps
+  - TOXENV=py27-pylint-deps
+  - TOXENV=py33-pylint-deps
+  - TOXENV=py34-pylint-deps
 
 install:
-    - sudo apt-get update -qq
-    - sudo apt-get install -qq libhdf5-serial-dev
-    - if [[ $TRAVIS_PYTHON_VERSION == "2.6" ]]; then pip install unittest2; fi
-    - pip install numpy
-    - pip install --install-option="--no-cython-compile" cython
-    - if [[ $TRAVIS_PYTHON_VERSION != "2.6" && $TRAVIS_PYTHON_VERSION != "3.2" ]]; then pip install pylint; fi
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq libhdf5-serial-dev
+  - pip install tox
 
 script:
-    - if [[ $TRAVIS_PYTHON_VERSION != "2.6" && $TRAVIS_PYTHON_VERSION != "3.2" ]]; then pylint h5py; fi
-    - python setup.py build -f
-    - python setup.py test
+  - tox

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ You need, at a minimum:
 To build on UNIX:
 
 * HDF5 1.8.4 or later (on Windows, HDF5 comes with h5py)
-* Cython 0.17 or later
+* Cython 0.19 or later
 * If using Python 2.6, unittest2 is needed to run the tests
 
 Installing on Windows

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -66,7 +66,7 @@ You will need:
 
 * The h5py tarball from http://www.h5py.org.
 * NumPy 1.6.1 or newer
-* `Cython <http://cython.org>`_ 0.17 or newer
+* `Cython <http://cython.org>`_ 0.19 or newer
 
 ::
 

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,16 @@ import setup_build, setup_configure
 
 VERSION = '2.5.0'
 
+NUMPY_DEP = 'numpy>=1.6.1'
+
+# these are required to use h5py
+RUN_REQUIRES = [NUMPY_DEP, 'six']
+
+# these are required to build h5py
+# RUN_REQUIRES is included as setup.py test needs RUN_REQUIRES for testing
+# RUN_REQUIRES can be removed when setup.py test is removed
+SETUP_REQUIRES = RUN_REQUIRES + [NUMPY_DEP, 'Cython>=0.19', 'pkgconfig']
+
 
 # --- Custom Distutils commands -----------------------------------------------
 
@@ -134,8 +144,7 @@ setup(
   packages = ['h5py', 'h5py._hl', 'h5py.tests', 'h5py.tests.old', 'h5py.tests.hl'],
   package_data = package_data,
   ext_modules = [Extension('h5py.x',['x.c'])],  # To trick build into running build_ext
-  requires = ['numpy (>=1.6.1)', 'Cython (>=0.17)'],
-  install_requires = ['numpy>=1.6.1', 'Cython>=0.17', 'six'],
-  setup_requires = ['numpy>=1.6.1', 'Cython>=0.17', 'pkgconfig', 'six'],
+  install_requires = RUN_REQUIRES,
+  setup_requires = SETUP_REQUIRES,
   cmdclass = CMDCLASS,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,15 @@
 [tox]
-envlist = py26,py27,py32,py33,py34
+envlist = {py26,py27,py32,py33,py34}-{test,pylint}-{nodeps,deps}
+
 [testenv]
 deps =
-    numpy>=1.0.1
-    Cython>=0.13
+    deps: numpy>=1.6.1
+    deps: cython>=0.19
+    pylint: pylint
+    py26: unittest2
 commands =
-    python setup.py test
-[testenv:py26]
-deps =
-    unittest2
-    {[testenv]deps}
+    test: python -c "import h5py; h5py.run_tests()"
+    pylint: pylint h5py
+changedir =
+    test: {toxworkdir}
+    pylint: {toxinidir}


### PR DESCRIPTION
This is the result of https://groups.google.com/forum/#!topic/h5py/CRi4pEeVpdU.
It fixes incorrect versions in setup.py, tox.ini, and in a number of places in the documentation (as per #587 and #577).

It also improves the tox.ini (avoids setup.py test), and uses tox for testing on travis.