### PR TITLE
Move to new travis container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,17 @@ language: python
 notifications:
   email: false
 
+addons:
+  apt:
+    packages:
+      - libhdf5-serial-dev
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.cache/pip
+
 env:
 # Commented out since setup_requires is controlled by easy_install
 # This should be uncommented when pip can use setup_requires
@@ -21,8 +32,6 @@ env:
   - TOXENV=py34-pylint-deps
 
 install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq libhdf5-serial-dev
   - pip install tox
 
 script:


### PR DESCRIPTION
Travis has a new way of running tests, using containers instead of virtual machines. Details can be found at https://docs.travis-ci.com/user/migrating-from-legacy/, but for us it should result in faster testing, as we can keep pip wheel cache (and I plan on testing if we can use it to store the eggs from setup_requires), and it's claimed that the container will start faster than the vm.