### PR TITLE
tox - pin pylint and astroid to last working versions 

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,8 @@ envlist = {py26,py27,py32,py33,py34}-{test,pylint}-{nodeps,deps}
 deps =
     deps: numpy>=1.6.1
     deps: cython>=0.19
-    pylint: pylint
+    pylint: astroid>=1.4
+    pylint: pylint>=1.5
     py26: unittest2
 commands =
     test: python -c "import h5py; h5py.run_tests()"

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = {py26,py27,py32,py33,py34}-{test,pylint}-{nodeps,deps}
 deps =
     deps: numpy>=1.6.1
     deps: cython>=0.19
-    pylint: astroid>=1.4
+    pylint: astroid>=1.3,<1.4
     pylint: pylint>=1.4,<1.5
     py26: unittest2
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ deps =
     deps: numpy>=1.6.1
     deps: cython>=0.19
     pylint: astroid>=1.4
-    pylint: pylint>=1.5
+    pylint: pylint>=1.4,<1.5
     py26: unittest2
 commands =
     test: python -c "import h5py; h5py.run_tests()"


### PR DESCRIPTION
Fixes https://github.com/h5py/h5py/issues/655

Appears the new 1.5.x version `pylint` ignores or badly misinterprets the settings in `pylintrc` and that `astroid` 1.4.x also has some bugs that generate a bunch of false positives. Until this can be addressed, simply use the last known working versions of `pylint` (i.e. 1.4.x) and `astroid` (i.e. 1.3.x), which do not have this problem.