### PR TITLE
Fix failing ndim test

### DIFF
--- a/h5py/tests/hl/test_dataset_getitem.py
+++ b/h5py/tests/hl/test_dataset_getitem.py
@@ -283,7 +283,7 @@ class Test1DZeroFloat(TestCase):
         
     def test_ndim(self):
         """ Verify number of dimensions """
-        self.assertEquals(self.dset.ndim, 0)
+        self.assertEquals(self.dset.ndim, 1)
         
     def test_shape(self):
         """ Verify shape """


### PR DESCRIPTION
This test appears to be skipped on travis (due to an old hdf5 version), but is failing for me. This fixes it.
@jakirkham I guess this is a typo? Or am I missing something?