### PR TITLE
Drop 3.2 support from tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,19 +15,10 @@ cache:
     - $HOME/.cache/pip
 
 env:
-# Commented out since setup_requires is controlled by easy_install
-# This should be uncommented when pip can use setup_requires
-#  - TOXENV=py26-test-nodeps
-#  - TOXENV=py27-test-nodeps
-#  - TOXENV=py33-test-nodeps
-#  - TOXENV=py34-test-nodeps
   - TOXENV=py26-test-deps
   - TOXENV=py27-test-deps
   - TOXENV=py33-test-deps
   - TOXENV=py34-test-deps
-  - TOXENV=py27-pylint-deps
-  - TOXENV=py33-pylint-deps
-  - TOXENV=py34-pylint-deps
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,10 @@ env:
 # This should be uncommented when pip can use setup_requires
 #  - TOXENV=py26-test-nodeps
 #  - TOXENV=py27-test-nodeps
-#  - TOXENV=py32-test-nodeps
 #  - TOXENV=py33-test-nodeps
 #  - TOXENV=py34-test-nodeps
   - TOXENV=py26-test-deps
   - TOXENV=py27-test-deps
-  - TOXENV=py32-test-deps
   - TOXENV=py33-test-deps
   - TOXENV=py34-test-deps
   - TOXENV=py27-pylint-deps

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,12 @@
 [tox]
-envlist = {py26,py27,py33,py34}-{test,pylint}-{nodeps,deps}
+envlist = {py26,py27,py33,py34}-{test}-{deps}
 
 [testenv]
 deps =
     deps: numpy>=1.6.1
     deps: cython>=0.19
-    pylint: astroid>=1.3,<1.4
-    pylint: pylint>=1.4,<1.5
     py26: unittest2
 commands =
     test: python -c "from sys import exit; import h5py; exit(0) if h5py.run_tests().wasSuccessful() else exit(1)"
-    pylint: pylint h5py
 changedir =
     test: {toxworkdir}
-    pylint: {toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py26,py27,py32,py33,py34}-{test,pylint}-{nodeps,deps}
+envlist = {py26,py27,py33,py34}-{test,pylint}-{nodeps,deps}
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 3.2 is not supported by our automatic test suite and dependencies.  Drop from CI testing.