### PR TITLE
support for local python installations

### DIFF
--- a/setup_build.py
+++ b/setup_build.py
@@ -10,6 +10,7 @@ try:
 except ImportError:
     from distutils.extension import Extension
 from distutils.command.build_ext import build_ext
+import distutils.sysconfig
 import sys
 import os
 import os.path as op
@@ -47,7 +48,7 @@ else:
     COMPILER_SETTINGS = {
        'libraries'      : ['hdf5', 'hdf5_hl'],
        'include_dirs'   : [localpath('lzf'), '/opt/local/include', '/usr/local/include'],
-       'library_dirs'   : ['/opt/local/lib', '/usr/local/lib'],
+       'library_dirs'   : [ distutils.sysconfig.get_config_var("LIBDIR"), '/opt/local/lib', '/usr/local/lib'],
        'define_macros'  : [('H5_USE_16_API', None)] }
 
 


### PR DESCRIPTION
I have a local python installation on a RHEL6 system where I don't have sudo rights.

This patch puts the value of distutils.sysconfig.get_config_var("LIBDIR") (before /opt/local/lib and /usr/local/lib) which will give the directory where libpythonX.Y.so is installed. 

This was only added on the non-win platform code part in setup_build.py as I don't have the means to test it on Windows. 