### PR TITLE
Move from six.PY3 to six.PY2

### DIFF
--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -354,21 +354,7 @@ class MappingHDF5(Mapping):
         We don't inherit directly from MutableMapping because certain
         subclasses, for example DimensionManager, are read-only.
     """
-    
-    if six.PY3:
-        def keys(self):
-            """ Get a view object on member names """
-            return KeysView(self)
-
-        def values(self):
-            """ Get a view object on member objects """
-            return ValuesViewHDF5(self)
-
-        def items(self):
-            """ Get a view object on member items """
-            return ItemsViewHDF5(self)
-
-    else:
+    if six.PY2:
         def keys(self):
             """ Get a list containing member names """
             with phil:
@@ -393,7 +379,20 @@ class MappingHDF5(Mapping):
             """ Get an iterator over (name, object) pairs """
             for x in self:
                 yield (x, self.get(x))
-                
+
+    else:
+        def keys(self):
+            """ Get a view object on member names """
+            return KeysView(self)
+
+        def values(self):
+            """ Get a view object on member objects """
+            return ValuesViewHDF5(self)
+
+        def items(self):
+            """ Get a view object on member items """
+            return ItemsViewHDF5(self)
+
 
 class MutableMappingHDF5(MappingHDF5, MutableMapping):
 

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -415,7 +415,7 @@ class Dataset(HLObject):
         # Sort field indices from the rest of the args.
         names = tuple(x for x in args if isinstance(x, six.string_types))
         args = tuple(x for x in args if not isinstance(x, six.string_types))
-        if not six.PY3:
+        if six.PY2:
             names = tuple(x.encode('utf-8') if isinstance(x, six.text_type) else x for x in names)
 
         new_dtype = getattr(self._local, 'astype', None)
@@ -516,7 +516,7 @@ class Dataset(HLObject):
         # Sort field indices from the slicing
         names = tuple(x for x in args if isinstance(x, six.string_types))
         args = tuple(x for x in args if not isinstance(x, six.string_types))
-        if not six.PY3:
+        if six.PY2:
             names = tuple(x.encode('utf-8') if isinstance(x, six.text_type) else x for x in names)
 
         # Generally we try to avoid converting the arrays on the Python
@@ -707,9 +707,9 @@ class Dataset(HLObject):
                     name if name != six.u('') else six.u('/'))
             r = six.u('<HDF5 dataset %s: shape %s, type "%s">') % \
                 (namestr, self.shape, self.dtype.str)
-        if six.PY3:
-            return r
-        return r.encode('utf8')
+        if six.PY2:
+            return r.encode('utf8')
+        return r
         
     if hasattr(h5d.DatasetID, "refresh"):
         @with_phil

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -330,6 +330,6 @@ class File(Group):
             r = six.u('<HDF5 file "%s" (mode %s)>') % (os.path.basename(filename),
                                                  self.mode)
 
-        if six.PY3:
-            return r
-        return r.encode('utf8')
+        if six.PY2:
+            return r.encode('utf8')
+        return r

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -473,9 +473,9 @@ class Group(HLObject, MutableMappingHDF5):
             ) if self.name is not None else six.u("(anonymous)")
             r = six.u('<HDF5 group %s (%d members)>') % (namestr, len(self))
 
-        if six.PY3:
-            return r
-        return r.encode('utf8')
+        if six.PY2:
+            return r.encode('utf8')
+        return r
 
 
 class HardLink(object):

--- a/h5py/tests/old/test_base.py
+++ b/h5py/tests/old/test_base.py
@@ -53,10 +53,10 @@ class TestRepr(BaseTest):
     USTRING = six.unichr(0xfc) + six.unichr(0xdf)
 
     def _check_type(self, obj):
-        if six.PY3:
-            self.assertIsInstance(repr(obj), six.text_type)
-        else:
+        if six.PY2:
             self.assertIsInstance(repr(obj), bytes)
+        else:
+            self.assertIsInstance(repr(obj), six.text_type)
 
     def test_group(self):
         """ Group repr() with unicode """

--- a/h5py/tests/old/test_group.py
+++ b/h5py/tests/old/test_group.py
@@ -418,7 +418,7 @@ class TestPy2Dict(BaseMapping):
         self.assertSameElements([x for x in self.f.iteritems()],
             [(x, self.f.get(x)) for x in self.groups])
 
-@ut.skipIf(not six.PY3, "Py3")
+@ut.skipIf(six.PY2, "Py3")
 class TestPy3Dict(BaseMapping):
 
     def test_keys(self):

--- a/h5py/tests/old/test_slicing.py
+++ b/h5py/tests/old/test_slicing.py
@@ -281,7 +281,7 @@ class TestFieldNames(BaseSlicing):
 
     def test_read(self):
         """ Test read with field selections (bytes and unicode) """
-        if not six.PY3:
+        if six.PY2:
             # Byte strings are only allowed for field names on Py2
             self.assertArrayEqual(self.dset[b'a'], self.data['a'])
         self.assertArrayEqual(self.dset[six.u('a')], self.data['a'])


### PR DESCRIPTION
Switch to checking six.PY2, instead of six.PY3. This should prevent some breakage for a potential python 4 release as per https://astrofrog.github.io/blog/2016/01/12/stop-writing-python-4-incompatible-code/.