### PR TITLE
Direct Chunk Write Functionality Added

### DIFF
--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -111,6 +111,9 @@ hdf5:
   1.9.178   herr_t H5Dflush(hid_t dataset_id)
   1.9.178   herr_t H5Drefresh(hid_t dataset_id)
 
+  # Direct Chunk Writing
+  1.8.11    herr_t H5DOwrite_chunk(hid_t dset_id, hid_t dxpl_id, uint32_t filters, const hsize_t *offset, size_t data_size, const void *buf)
+
 
   # === H5E - Minimal error-handling interface ================================
 

--- a/h5py/h5d.pyx
+++ b/h5py/h5d.pyx
@@ -398,40 +398,35 @@ cdef class DatasetID(ObjectID):
 
     IF HDF5_VERSION >= (1, 8, 11):
 
-        def write_direct_chunk(self, offsets, data, filter_mask=0, PropID dxpl=None):
-            """
-            Direct chunk write to dataset
+        def write_direct_chunk(self, offsets, bytes data, H5Z_filter_t filter_mask=H5Z_FILTER_NONE, PropID dxpl=None):
+            """ no return
+
+            Writes data from a bytes array (as provided e.g. by struct.pack) directly
+            to a chunk at position specified by the offsets argument.
+
+            Feature requires: 1.8.11 HDF5
             """
 
             cdef hid_t dset_id
             cdef hid_t dxpl_id
             cdef hid_t space_id = 0
-            cdef uint32_t filters
-            cdef hsize_t *offset
+            cdef hsize_t *offset = NULL
             cdef size_t data_size
-            cdef char *buf
             cdef int rank
 
+            dset_id = self.id
+            dxpl_id = pdefault(dxpl)
+            space_id = H5Dget_space(self.id)
+            rank = H5Sget_simple_extent_ndims(space_id)
+
+            if len(offsets) != rank:
+                raise TypeError("offset length (%d) must match dataset rank (%d)" % (len(offsets), rank))
+
             try:
-                dset_id = self.id
-                dxpl_id = pdefault(dxpl)
-                filters = filter_mask
-                space_id = H5Dget_space(self.id)
-                rank = H5Sget_simple_extent_ndims(space_id)
-
-                if len(offsets) != rank:
-                    raise TypeError("offset length (%d) must match dataset rank (%d)" % (len(offsets), rank))
-
                 offset = <hsize_t*>emalloc(sizeof(hsize_t)*rank)
                 convert_tuple(offsets, offset, rank)
-                buf = data
-                data_size = len(data)
-
-                H5DOwrite_chunk(dset_id, dxpl_id, filters, offset, data_size, buf)
-            except BaseException as e:
-                print e
+                H5DOwrite_chunk(dset_id, dxpl_id, filter_mask, offset, len(data), <char *> data)
             finally:
                 efree(offset)
                 if space_id:
                     H5Sclose(space_id)
-            pass

--- a/h5py/h5d.pyx
+++ b/h5py/h5d.pyx
@@ -399,7 +399,7 @@ cdef class DatasetID(ObjectID):
     IF HDF5_VERSION >= (1, 8, 11):
 
         def write_direct_chunk(self, offsets, bytes data, H5Z_filter_t filter_mask=H5Z_FILTER_NONE, PropID dxpl=None):
-            """ no return
+            """ (offsets, bytes data, H5Z_filter_t filter_mask=H5Z_FILTER_NONE, PropID dxpl=None)
 
             Writes data from a bytes array (as provided e.g. by struct.pack) directly
             to a chunk at position specified by the offsets argument.

--- a/h5py/tests/old/test_h5d_direct_chunk_write.py
+++ b/h5py/tests/old/test_h5d_direct_chunk_write.py
@@ -1,0 +1,31 @@
+from __future__ import absolute_import
+
+import h5py
+import numpy
+
+from .common import ut, TestCase
+
+
+@ut.skipUnless(h5py.version.hdf5_version_tuple >= (1, 8, 11), 'Direct Chunk Writing requires HDF5 >= 1.8.11')
+class TestWriteDirectChunk(TestCase):
+    def test_write_direct_chunk(self):
+
+        filename = "direct_chunk.hdf"
+        filehandle = h5py.File(filename, "w")
+
+        dataset = filehandle.create_dataset("data", (100, 100, 100), maxshape=(None, 100, 100), chunks=(1, 100, 100), dtype='float32')
+
+        # writing
+        array = numpy.zeros((10, 100, 100))
+        for index in range(10):
+            a = numpy.random.rand(100, 100).astype('float32')
+            dataset.id.write_direct_chunk((index, 0, 0), a.tobytes(), filter_mask=1)
+            array[index] = a
+
+        filehandle.close()
+
+        # checking
+        filehandle = h5py.File(filename, "r")
+        for i in range(10):
+            read_data = filehandle["data"][i]
+            assert(array[i] == read_data).all()

--- a/h5py/tests/old/test_h5d_direct_chunk_write.py
+++ b/h5py/tests/old/test_h5d_direct_chunk_write.py
@@ -10,16 +10,19 @@ from .common import ut, TestCase
 class TestWriteDirectChunk(TestCase):
     def test_write_direct_chunk(self):
 
-        filename = "direct_chunk.hdf"
+        filename = self.mktemp().encode()
         filehandle = h5py.File(filename, "w")
 
-        dataset = filehandle.create_dataset("data", (100, 100, 100), maxshape=(None, 100, 100), chunks=(1, 100, 100), dtype='float32')
+        dataset = filehandle.create_dataset("data", (100, 100, 100),
+                                            maxshape=(None, 100, 100),
+                                            chunks=(1, 100, 100),
+                                            dtype='float32')
 
         # writing
         array = numpy.zeros((10, 100, 100))
         for index in range(10):
             a = numpy.random.rand(100, 100).astype('float32')
-            dataset.id.write_direct_chunk((index, 0, 0), a.tobytes(), filter_mask=1)
+            dataset.id.write_direct_chunk((index, 0, 0), a.tostring(), filter_mask=1)
             array[index] = a
 
         filehandle.close()
@@ -28,4 +31,4 @@ class TestWriteDirectChunk(TestCase):
         filehandle = h5py.File(filename, "r")
         for i in range(10):
             read_data = filehandle["data"][i]
-            assert(array[i] == read_data).all()
+            self.assertTrue(array[i] == read_data).all()


### PR DESCRIPTION
This pull request adds direct chunk writing to h5py. It is fixing issue #690 

To address the issue that direct chunk writing is potentially dangerous for non experts, I did not made this functionality directly available through the dataset api but only if going through dataset.id .

Example of directly writing pre-compressed data using bitshuffle (https://github.com/kiyo-masui/bitshuffle):

```
import h5py
import numpy
import bitshuffle
import bitshuffle.h5
import struct

filename = "direct_chunk.hdf"
filehandle = h5py.File(filename, "w")

block_size = 2048
dataset = filehandle.create_dataset("data", (100, 100, 100), maxshape=(None, 100, 100), compression=32008, compression_opts=(block_size, bitshuffle.h5.H5_COMPRESS_LZ4), chunks=(1,100,100), dtype='float32')

array = numpy.random.rand(100, 100)
array = array.astype('float32')

compressed = bitshuffle.compress_lz4(array, block_size)

# Adding header information according to HDF5 plugin specification
bytes_number_of_elements = struct.pack('>q', (100*100*4))
bytes_block_size = struct.pack('>i', block_size*4)
byte_array = bytes_number_of_elements + bytes_block_size + compressed.tobytes()

index = 0
dataset.id.write_direct_chunk((index, 0, 0), byte_array)

filehandle.close()
```
