### PR TITLE
Try to prevent numpy's dropping of py2.6 and py3.3 from breaking tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,18 @@ envlist = {py26,py27,py33,py34}-{test}-{deps}
 deps =
     deps: numpy>=1.6.1
     deps: cython>=0.19
-    py26: unittest2
 commands =
     test: python -c "from sys import exit; import h5py; exit(0) if h5py.run_tests().wasSuccessful() else exit(1)"
 changedir =
     test: {toxworkdir}
+
+[testenv:py26-test-deps]
+deps =
+    unittest2
+    numpy>=1.6.1,<1.12,!=1.11.0
+    cython>=0.19
+
+[testenv:py33-test-deps]
+deps =
+    numpy>=1.6.1,<1.12
+    cython>=0.19


### PR DESCRIPTION
Based on https://github.com/numpy/numpy/blob/master/doc/release/1.11.0-notes.rst, numpy is dropping support for python 2.6, 3.2 and 3.3 in 1.12. This tells tox to use earlier versions for testing.