### PR TITLE
Fix offsets in aligned compound datatypes

### DIFF
--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -1414,14 +1414,13 @@ cdef TypeCompoundID _c_compound(dtype dt, int logical):
     # Initial size MUST be 1 to avoid segfaults (issue 166)
     tid = H5Tcreate(H5T_COMPOUND, 1)  
 
-    offset = 0
     for name in names:
         ename = name.encode('utf8') if isinstance(name, unicode) else name
         dt_tmp = dt.fields[name][0]
+        offset = dt.fields[name][1]
         type_tmp = py_create(dt_tmp, logical=logical)
         H5Tset_size(tid, offset+type_tmp.get_size())
         H5Tinsert(tid, ename, offset, type_tmp.id)
-        offset += type_tmp.get_size()
 
     return TypeCompoundID(tid)
 


### PR DESCRIPTION
Fixes #698.

This turned out to be incredibly easy.  I also added some relevant tests.

Note that the precise calculation of offsets depends on the machine's architecture / memory model.  My 64-bit linux box aligns to 8 bytes, so both these test datatypes have size == 16 even though the underlying data only need 10.  A 32-bit machine should pad to 12 bytes.