### PR TITLE
Test minimum required versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@ env:
   - TOXENV=py27-test-deps
   - TOXENV=py33-test-deps
   - TOXENV=py34-test-deps
+  - TOXENV=py26-test-mindeps
+  - TOXENV=py27-test-mindeps
+  - TOXENV=py33-test-mindeps
+  - TOXENV=py34-test-mindeps
 
 install:
   - pip install tox

--- a/h5py/tests/common.py
+++ b/h5py/tests/common.py
@@ -162,3 +162,5 @@ class TestCase(ut.TestCase):
         else:
             with self.assertRaises(exc):
                 dset[s]
+
+NUMPY_RELEASE_VERSION = tuple([int(i) for i in np.__version__.split(".")[0:2]])

--- a/h5py/tests/hl/test_datatype.py
+++ b/h5py/tests/hl/test_datatype.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import
 import numpy as np
 import h5py
 
-from ..common import ut, TestCase
+from ..common import ut, TestCase, NUMPY_RELEASE_VERSION
 
 class TestVlen(TestCase):
 
@@ -44,6 +44,7 @@ class TestVlen(TestCase):
         self.assertEqual(h5py.check_dtype(enum=h5py.check_dtype(vlen=dt1)),
                          h5py.check_dtype(enum=h5py.check_dtype(vlen=dt2)))
 
+@ut.skipIf(NUMPY_RELEASE_VERSION < (1, 11), "Requires numpy>=1.11")
 class TestAligned(TestCase):
 
     """

--- a/h5py/tests/hl/test_datatype.py
+++ b/h5py/tests/hl/test_datatype.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import
 import numpy as np
 import h5py
 
-from ..common import ut, TestCase, NUMPY_RELEASE_VERSION
+from ..common import ut, TestCase
 
 class TestVlen(TestCase):
 
@@ -44,7 +44,6 @@ class TestVlen(TestCase):
         self.assertEqual(h5py.check_dtype(enum=h5py.check_dtype(vlen=dt1)),
                          h5py.check_dtype(enum=h5py.check_dtype(vlen=dt2)))
 
-@ut.skipIf(NUMPY_RELEASE_VERSION < (1, 11), "Requires numpy>=1.11")
 class TestAligned(TestCase):
 
     """
@@ -64,7 +63,7 @@ class TestAligned(TestCase):
         dt = np.dtype('i2,f8', align=True)
         data = np.empty(10, dtype=dt)
 
-        data['f0'] = np.random.randint(-100, 100, size=data.size, dtype='i2')
+        data['f0'] = np.array(np.random.randint(-100, 100, size=data.size), dtype='i2')
         data['f1'] = np.random.rand(data.size)
 
         fname = self.mktemp()

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,12 @@
 [tox]
-envlist = {py26,py27,py33,py34}-{test}-{deps}
+envlist = {py26,py27,py33,py34}-{test}-{deps,mindeps}
 
 [testenv]
 deps =
     deps: numpy>=1.6.1
     deps: cython>=0.19
+    mindeps: numpy==1.6.1
+    mindeps: cython==0.19
 commands =
     test: python -c "from sys import exit; import h5py; exit(0) if h5py.run_tests().wasSuccessful() else exit(1)"
 changedir =

--- a/tox.ini
+++ b/tox.ini
@@ -22,3 +22,19 @@ deps =
 deps =
     numpy>=1.6.1,<1.12
     cython>=0.19
+
+[testenv:py26-test-mindeps]
+deps =
+    unittest2
+    numpy==1.6.1
+    cython==0.19
+
+[testenv:py33-test-mindeps]
+deps =
+    numpy==1.7
+    cython==0.19
+
+[testenv:py34-test-mindeps]
+deps =
+    numpy==1.9
+    cython==0.19


### PR DESCRIPTION
It appears #701 added a test which required numpy 1.11 (which is why some tests are failing). This wraps that test in a check against numpy 1.11, and tests the minimum version of numpy and cython required (numpy 1.7 is the earliest version to support python 3.3, numpy 1.9 is the earliest version to support 3.4).