### PR TITLE
Fix pkgconfig handling in setup_configure autodetect_version.

### DIFF
--- a/setup_configure.py
+++ b/setup_configure.py
@@ -204,7 +204,11 @@ def autodetect_version(hdf5_dir=None):
     libdirs = ['/usr/local/lib', '/opt/local/lib']
     try:
         if pkgconfig.exists("hdf5"):
-            libdirs.append(pkgconfig.parse("hdf5")['library_dirs'])
+            hdf5_library_dirs = pkgconfig.parse("hdf5")['library_dirs']
+            if isinstance(hdf5_library_dirs, basestring):
+                libdirs.append(hdf5_library_dirs)
+            else:
+                libdirs.extend(hdf5_library_dirs)
     except EnvironmentError:
         pass
     if hdf5_dir is not None:

--- a/setup_configure.py
+++ b/setup_configure.py
@@ -1,4 +1,3 @@
-
 """
     Implements a new custom Distutils command for handling library
     configuration.
@@ -205,7 +204,7 @@ def autodetect_version(hdf5_dir=None):
     try:
         if pkgconfig.exists("hdf5"):
             hdf5_library_dirs = pkgconfig.parse("hdf5")['library_dirs']
-            if isinstance(hdf5_library_dirs, basestring):
+            if isinstance(hdf5_library_dirs, (type(u""), type(b""))):
                 libdirs.append(hdf5_library_dirs)
             else:
                 libdirs.extend(hdf5_library_dirs)


### PR DESCRIPTION
`autodetect_version` in `setup_configure` is currently broken in cases requiring the use of pkgconfig to resolve the correct libhdf5 libdir. This breaks HDF5 autodetection in the default installation scheme in ubuntu/debian, causing h5py to revert back to '1.8.4' compatibility mode. This prevents the inclusion of the newly introduced `set_file_image` & `get_file_image` apis. This causes a test failure when running `setup.py test` on debian setups.

While #533 may resolve this issue, it appears that this request is currently stalled. This minor fix resolves the default case in ubuntu/debian.