### PR TITLE
update ipy_completer.py for python3 compatibility

### DIFF
--- a/h5py/ipy_completer.py
+++ b/h5py/ipy_completer.py
@@ -109,9 +109,9 @@ def h5py_item_completer(context, command):
 
     path, _ = posixpath.split(item)
     if path:
-        items = (posixpath.join(path, name) for name in obj[path].iterkeys())
+        items = (posixpath.join(path, name) for name in obj[path].keys())
     else:
-        items = obj.iterkeys()
+        items = obj.keys()
     items = list(items)
 
     readline.set_completer_delims(' \t\n`!@#$^&*()=+[{]}\\|;:\'",<>?')

--- a/h5py/ipy_completer.py
+++ b/h5py/ipy_completer.py
@@ -108,12 +108,16 @@ def h5py_item_completer(context, command):
         return []
 
     path, _ = posixpath.split(item)
-    if path:
-        items = (posixpath.join(path, name) for name in obj[path].keys())
-    else:
-        items = obj.keys()
-    items = list(items)
 
+    try:
+        if path:
+            items = (posixpath.join(path, name) for name in obj[path].keys())
+        else:
+            items = obj.keys()
+    except AttributeError:
+        return []
+
+    items = list(items)
     readline.set_completer_delims(' \t\n`!@#$^&*()=+[{]}\\|;:\'",<>?')
 
     return [i for i in items if i[:len(item)] == item]


### PR DESCRIPTION
update ipy_completer to use python3 compatible calls. 
tested on osx el capitan with python 3.5.1 and python 2.7.11