### PR TITLE
Add support for pathlib/PEP519

### DIFF
--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -15,10 +15,18 @@ from __future__ import absolute_import
 
 import posixpath
 import os
-import sys
 import six
 from collections import (Mapping, MutableMapping, KeysView, 
                          ValuesView, ItemsView)
+
+try:
+    from os import fspath
+except ImportError:
+    from .compat import fspath
+try:
+    from os import fsencode
+except ImportError:
+    from .compat import fsencode
 
 from .. import h5d, h5i, h5r, h5p, h5f, h5t, h5s
 
@@ -32,14 +40,10 @@ from .._objects import phil, with_phil
 def is_hdf5(fname):
     """ Determine if a file is valid HDF5 (False if it doesn't exist). """
     with phil:
-        fname = os.path.abspath(fname)
+        fname = os.path.abspath(fspath(fname))
 
         if os.path.isfile(fname):
-            try:
-                fname = fname.encode(sys.getfilesystemencoding())
-            except (UnicodeError, LookupError):
-                pass
-            return h5f.is_hdf5(fname)
+            return h5f.is_hdf5(fsencode(fname))
         return False
 
 

--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -19,14 +19,8 @@ import six
 from collections import (Mapping, MutableMapping, KeysView, 
                          ValuesView, ItemsView)
 
-try:
-    from os import fspath
-except ImportError:
-    from .compat import fspath
-try:
-    from os import fsencode
-except ImportError:
-    from .compat import fsencode
+from .compat import fspath
+from .compat import fsencode
 
 from .. import h5d, h5i, h5r, h5p, h5f, h5t, h5s
 

--- a/h5py/_hl/compat.py
+++ b/h5py/_hl/compat.py
@@ -1,0 +1,79 @@
+"""
+Compatibility module for high-level h5py
+"""
+import sys
+import six
+
+
+def fspath(path):
+    """
+    Return the string representation of the path.
+    If str or bytes is passed in, it is returned unchanged.
+    This code comes from PEP 519, modified to support earlier versions of
+    python.
+
+    This is required for python < 3.6.
+    """
+    if isinstance(path, (six.text_type, six.binary_type)):
+        return path
+
+    # Work from the object's type to match method resolution of other magic
+    # methods.
+    path_type = type(path)
+    try:
+        return path_type.__fspath__(path)
+    except AttributeError:
+        if hasattr(path_type, '__fspath__'):
+            raise
+        try:
+            import pathlib
+        except ImportError:
+            pass
+        else:
+            if isinstance(path, pathlib.PurePath):
+                return six.text_type(path)
+
+        raise TypeError("expected str, bytes or os.PathLike object, not "
+                        + path_type.__name__)
+
+# This is from python 3.5 stdlib (hence lacks PEP 519 changes)
+# This was introduced into python 3.2, so python < 3.2 does not have this
+# Effectively, this is only required for python 2.6 and 2.7, and can be removed
+# once support for them is dropped
+def _fscodec():
+    encoding = sys.getfilesystemencoding()
+    if encoding == 'mbcs':
+        errors = 'strict'
+    else:
+        errors = 'surrogateescape'
+
+    def fsencode(filename):
+        """
+        Encode filename to the filesystem encoding with 'surrogateescape' error
+        handler, return bytes unchanged. On Windows, use 'strict' error handler if
+        the file system encoding is 'mbcs' (which is the default encoding).
+        """
+        if isinstance(filename, six.binary_type):
+            return filename
+        elif isinstance(filename, six.text_type):
+            return filename.encode(encoding, errors)
+        else:
+            raise TypeError("expect bytes or str, not %s" % type(filename).__name__)
+
+    def fsdecode(filename):
+        """
+        Decode filename from the filesystem encoding with 'surrogateescape' error
+        handler, return str unchanged. On Windows, use 'strict' error handler if
+        the file system encoding is 'mbcs' (which is the default encoding).
+        """
+        if isinstance(filename, six.text_type):
+            return filename
+        elif isinstance(filename, six.binary_type):
+            return filename.decode(encoding, errors)
+        else:
+            raise TypeError("expect bytes or str, not %s" % type(filename).__name__)
+
+    return fsencode, fsdecode
+
+fsencode, fsdecode = _fscodec()
+del _fscodec

--- a/h5py/_hl/compat.py
+++ b/h5py/_hl/compat.py
@@ -5,36 +5,39 @@ import sys
 import six
 
 
-def fspath(path):
-    """
-    Return the string representation of the path.
-    If str or bytes is passed in, it is returned unchanged.
-    This code comes from PEP 519, modified to support earlier versions of
-    python.
+try:
+    from os import fspath
+except ImportError:
+    def fspath(path):
+        """
+        Return the string representation of the path.
+        If str or bytes is passed in, it is returned unchanged.
+        This code comes from PEP 519, modified to support earlier versions of
+        python.
 
-    This is required for python < 3.6.
-    """
-    if isinstance(path, (six.text_type, six.binary_type)):
-        return path
+        This is required for python < 3.6.
+        """
+        if isinstance(path, (six.text_type, six.binary_type)):
+            return path
 
-    # Work from the object's type to match method resolution of other magic
-    # methods.
-    path_type = type(path)
-    try:
-        return path_type.__fspath__(path)
-    except AttributeError:
-        if hasattr(path_type, '__fspath__'):
-            raise
+        # Work from the object's type to match method resolution of other magic
+        # methods.
+        path_type = type(path)
         try:
-            import pathlib
-        except ImportError:
-            pass
-        else:
-            if isinstance(path, pathlib.PurePath):
-                return six.text_type(path)
+            return path_type.__fspath__(path)
+        except AttributeError:
+            if hasattr(path_type, '__fspath__'):
+                raise
+            try:
+                import pathlib
+            except ImportError:
+                pass
+            else:
+                if isinstance(path, pathlib.PurePath):
+                    return six.text_type(path)
 
-        raise TypeError("expected str, bytes or os.PathLike object, not "
-                        + path_type.__name__)
+            raise TypeError("expected str, bytes or os.PathLike object, not "
+                            + path_type.__name__)
 
 # This is from python 3.5 stdlib (hence lacks PEP 519 changes)
 # This was introduced into python 3.2, so python < 3.2 does not have this
@@ -75,5 +78,15 @@ def _fscodec():
 
     return fsencode, fsdecode
 
-fsencode, fsdecode = _fscodec()
+_fsencode, _fsdecode = _fscodec()
 del _fscodec
+
+try:
+    from os import fsencode
+except ImportError:
+    fsencode = _fsencode
+
+try:
+    from os import fsdecode
+except ImportError:
+    fsdecode = _fsdecode

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -16,18 +16,9 @@ from __future__ import absolute_import
 import sys
 import os
 
-try:
-    from os import fspath
-except ImportError:
-    from .compat import fspath
-try:
-    from os import fsencode
-except ImportError:
-    from .compat import fsencode
-try:
-    from os import fsdecode
-except ImportError:
-    from .compat import fsdecode
+from .compat import fspath
+from .compat import fsencode
+from .compat import fsdecode
 
 import six
 

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -16,6 +16,19 @@ from __future__ import absolute_import
 import sys
 import os
 
+try:
+    from os import fspath
+except ImportError:
+    from .compat import fspath
+try:
+    from os import fsencode
+except ImportError:
+    from .compat import fsencode
+try:
+    from os import fsdecode
+except ImportError:
+    from .compat import fsdecode
+
 import six
 
 from .base import phil, with_phil
@@ -149,11 +162,7 @@ class File(Group):
     @with_phil
     def filename(self):
         """File name on disk"""
-        name = h5f.get_name(self.fid)
-        try:
-            return name.decode(sys.getfilesystemencoding())
-        except (UnicodeError, LookupError):
-            return name
+        return fsdecode(h5f.get_name(self.fid))
 
     @property
     @with_phil
@@ -260,13 +269,7 @@ class File(Group):
             if isinstance(name, _objects.ObjectID):
                 fid = h5i.get_file_id(name)
             else:
-                try:
-                    # If the byte string doesn't match the default
-                    # encoding, just pass it on as-is.  Note Unicode
-                    # objects can always be encoded.
-                    name = name.encode(sys.getfilesystemencoding())
-                except (UnicodeError, LookupError):
-                    pass
+                name = fsencode(fspath(name))
 
                 fapl = make_fapl(driver, libver, **kwds)
                 fid = make_fid(name, mode, userblock_size, fapl, swmr=swmr)

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -16,7 +16,10 @@ from __future__ import absolute_import
 import posixpath as pp
 import six
 import numpy
-import sys
+try:
+    from os import fsdecode
+except ImportError:
+    from .compat import fsdecode
 
 from .. import h5g, h5i, h5o, h5r, h5t, h5l, h5p
 from . import base
@@ -234,11 +237,7 @@ class Group(HLObject, MutableMappingHDF5):
                     if getclass:
                         return ExternalLink
                     filebytes, linkbytes = self.id.links.get_val(self._e(name))
-                    try:
-                        filetext = filebytes.decode(sys.getfilesystemencoding())
-                    except (UnicodeError, LookupError):
-                        filetext = filebytes
-                    return ExternalLink(filetext, self._d(linkbytes))
+                    return ExternalLink(fsdecode(filebytes), self._d(linkbytes))
                     
                 elif typecode == h5l.TYPE_HARD:
                     return HardLink if getclass else HardLink()

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -20,6 +20,14 @@ try:
     from os import fsdecode
 except ImportError:
     from .compat import fsdecode
+try:
+    from os import fsencode
+except ImportError:
+    from .compat import fsencode
+try:
+    from os import fspath
+except ImportError:
+    from .compat import fspath
 
 from .. import h5g, h5i, h5o, h5r, h5t, h5l, h5p
 from . import base
@@ -280,7 +288,7 @@ class Group(HLObject, MutableMappingHDF5):
                           lcpl=lcpl, lapl=self._lapl)
 
         elif isinstance(obj, ExternalLink):
-            self.id.links.create_external(name, self._e(obj.filename),
+            self.id.links.create_external(name, fsencode(obj.filename),
                           self._e(obj.path), lcpl=lcpl, lapl=self._lapl)
 
         elif isinstance(obj, numpy.dtype):
@@ -525,7 +533,7 @@ class ExternalLink(object):
         return self._filename
 
     def __init__(self, filename, path):
-        self._filename = str(filename)
+        self._filename = fspath(filename)
         self._path = str(path)
 
     def __repr__(self):

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -16,18 +16,10 @@ from __future__ import absolute_import
 import posixpath as pp
 import six
 import numpy
-try:
-    from os import fsdecode
-except ImportError:
-    from .compat import fsdecode
-try:
-    from os import fsencode
-except ImportError:
-    from .compat import fsencode
-try:
-    from os import fspath
-except ImportError:
-    from .compat import fspath
+
+from .compat import fsdecode
+from .compat import fsencode
+from .compat import fspath
 
 from .. import h5g, h5i, h5o, h5r, h5t, h5l, h5p
 from . import base

--- a/h5py/tests/old/test_file.py
+++ b/h5py/tests/old/test_file.py
@@ -16,12 +16,19 @@
 from __future__ import absolute_import, with_statement
 
 import os, stat
+import tempfile
 
 import six
 
 from .common import ut, TestCase, unicode_filenames
 from h5py.highlevel import File
 import h5py
+
+try:
+    import pathlib
+except ImportError:
+    pathlib = None
+
 
 mpi = h5py.get_config().mpi
 
@@ -542,3 +549,25 @@ class TestCloseInvalidatesOpenObjectIDs(TestCase):
             self.assertFalse(bool(f1.id))
             self.assertFalse(bool(g1.id))
 
+@ut.skipIf(pathlib is None, "pathlib module not installed")
+class TestPathlibSupport(TestCase):
+
+    """
+        Check that h5py doesn't break on pathlib
+    """
+    def test_pathlib_accepted_file(self):
+        """ Check that pathlib is accepted by h5py.File """
+        with tempfile.NamedTemporaryFile() as f:
+            path = pathlib.Path(f.name)
+            with File(path) as f2:
+                self.assertTrue(True)
+
+    def test_pathlib_name_match(self):
+        """ Check that using pathlib does not affect naming """
+        with tempfile.NamedTemporaryFile() as f:
+            path = pathlib.Path(f.name)
+            with File(path) as h5f1:
+                pathlib_name = h5f1.filename
+            with File(f.name) as h5f2:
+                normal_name = h5f2.filename
+            self.assertEqual(pathlib_name, normal_name)

--- a/h5py/tests/old/test_group.py
+++ b/h5py/tests/old/test_group.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org
@@ -21,7 +22,9 @@ from __future__ import absolute_import
 import collections
 import numpy as np
 import os
+import os.path
 import sys
+from tempfile import mkdtemp
 
 import six
 
@@ -730,6 +733,28 @@ class TestExternalLinks(TestCase):
         f2 = grp.file
         f2.close()
         self.assertFalse(f2)
+
+    def test_unicode_encode(self):
+        """
+        Check that external links encode unicode filenames properly
+        Testing issue #732
+        """
+        ext_filename = os.path.join(mkdtemp(), "α.hdf5")
+        with File(ext_filename, "w") as ext_file:
+            ext_file.create_group('external')
+        self.f['ext'] = ExternalLink(ext_filename, '/external')
+
+    def test_unicode_decode(self):
+        """
+        Check that external links decode unicode filenames properly
+        Testing issue #732
+        """
+        ext_filename = os.path.join(mkdtemp(), "α.hdf5")
+        with File(ext_filename, "w") as ext_file:
+            ext_file.create_group('external')
+            ext_file["external"].attrs["ext_attr"] = "test"
+        self.f['ext'] = ExternalLink(ext_filename, '/external')
+        self.assertEqual(self.f["ext"].attrs["ext_attr"], "test")
 
 class TestExtLinkBugs(TestCase):
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py26,py27,py33,py34}-{test}-{deps,mindeps}
+envlist = {py26,py27,py33,py34,py35}-{test}-{deps,mindeps}
 
 [testenv]
 deps =


### PR DESCRIPTION
Currently h5py only support strings as paths, this add support for pathlib/PEP519 and simplifies some path related code. 