### PR TITLE
Close #542 Introduce `HDF5_MPI`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ matrix:
       env:
       - TOXENV=py34-test-mpi4py
       - CC="mpicc"
-      - HDF5_PARALLEL="ON"
+      - HDF5_MPI="ON"
       addons:
         apt:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,17 +27,28 @@ env:
 #  - TOXENV=py35-test-mindeps
 # commented out because of https://github.com/travis-ci/travis-ci/issues/4794
 
-# needed to work around https://github.com/travis-ci/travis-ci/issues/4794
 matrix:
   include:
+    # needed to work around https://github.com/travis-ci/travis-ci/issues/4794
     - python: 3.5
       env:
       - TOXENV=py35-test-deps
-matrix:
-  include:
     - python: 3.5
       env:
       - TOXENV=py35-test-mindeps
+    # parallel HDF5 test with HDF5>=1.8.9 for mpio "atomic" support
+    - dist: trusty
+      sudo: required
+      env:
+      - TOXENV=py34-test-mpi4py
+      - CC="mpicc"
+      - HDF5_PARALLEL="ON"
+      addons:
+        apt:
+          packages:
+            - openmpi-bin         # 1.6.5
+            - libopenmpi-dev
+            - libhdf5-openmpi-dev # 1.8.11
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,9 @@ matrix:
       addons:
         apt:
           packages:
-            - openmpi-bin         # 1.6.5
+            - openmpi-bin         # 1.4.3
             - libopenmpi-dev
-            - libhdf5-openmpi-dev # 1.8.11
+            - libhdf5-openmpi-dev # 1.8.4
 
 install:
   - pip install tox

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -77,6 +77,7 @@ when installing via ``pip``, as you don't have direct access to setup.py::
 
     $ HDF5_DIR=/path/to/hdf5 pip install h5py
     $ HDF5_VERSION=X.Y.Z pip install h5py
+    $ CC="mpicc" HDF5_PARALLEL="ON" HDF5_DIR=/path/to/parallel-hdf5 pip install h5py
     
 Here's a list of all the configure options currently supported:
 
@@ -85,7 +86,7 @@ Option                  Via setup.py                Via environment variable
 ======================= =========================== ===========================
 Custom path to HDF5     ``--hdf5=/path/to/hdf5``    ``HDF5_DIR=/path/to/hdf5``
 Force HDF5 version      ``--hdf5-version=X.Y.Z``    ``HDF5_VERSION=X.Y.Z``
-Enable MPI mode         ``--mpi``                   (none)
+Enable MPI mode         ``--mpi``                   ``HDF5_PARALLEL=ON``
 ======================= =========================== ===========================
 
 
@@ -99,16 +100,20 @@ HDF5 features in h5py itself::
     $ python setup.py install
 
 If you want access to the full Parallel HDF5 feature set in h5py
-(:ref:`parallel`), you will have to build in MPI mode.  Right now this must
-be done with command-line options from the h5py tarball.
+(:ref:`parallel`), you will further have to build in MPI mode.  This can either
+be done with command-line options from the h5py tarball or by::
+
+    $ export HDF5_PARALLEL="ON"
 
 **You will need a shared-library build of Parallel HDF5 (i.e. built with
 ./configure --enable-shared --enable-parallel).**
 
-To build in MPI mode, use the ``--mpi`` option to ``setup.py configure``::
+To build in MPI mode, use the ``--mpi`` option to ``setup.py configure`` or
+export ``HDF5_PARALLEL="ON"`` beforehand::
 
     $ export CC=mpicc
-    $ python setup.py configure --mpi
+    $ export HDF5_PARALLEL="ON"
+    $ python setup.py configure
     $ python setup.py build
 
 See also :ref:`parallel`.

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -77,7 +77,7 @@ when installing via ``pip``, as you don't have direct access to setup.py::
 
     $ HDF5_DIR=/path/to/hdf5 pip install h5py
     $ HDF5_VERSION=X.Y.Z pip install h5py
-    $ CC="mpicc" HDF5_PARALLEL="ON" HDF5_DIR=/path/to/parallel-hdf5 pip install h5py
+    $ CC="mpicc" HDF5_MPI="ON" HDF5_DIR=/path/to/parallel-hdf5 pip install h5py
     
 Here's a list of all the configure options currently supported:
 
@@ -86,7 +86,7 @@ Option                  Via setup.py                Via environment variable
 ======================= =========================== ===========================
 Custom path to HDF5     ``--hdf5=/path/to/hdf5``    ``HDF5_DIR=/path/to/hdf5``
 Force HDF5 version      ``--hdf5-version=X.Y.Z``    ``HDF5_VERSION=X.Y.Z``
-Enable MPI mode         ``--mpi``                   ``HDF5_PARALLEL=ON``
+Enable MPI mode         ``--mpi``                   ``HDF5_MPI=ON``
 ======================= =========================== ===========================
 
 
@@ -103,16 +103,16 @@ If you want access to the full Parallel HDF5 feature set in h5py
 (:ref:`parallel`), you will further have to build in MPI mode.  This can either
 be done with command-line options from the h5py tarball or by::
 
-    $ export HDF5_PARALLEL="ON"
+    $ export HDF5_MPI="ON"
 
 **You will need a shared-library build of Parallel HDF5 (i.e. built with
 ./configure --enable-shared --enable-parallel).**
 
 To build in MPI mode, use the ``--mpi`` option to ``setup.py configure`` or
-export ``HDF5_PARALLEL="ON"`` beforehand::
+export ``HDF5_MPI="ON"`` beforehand::
 
     $ export CC=mpicc
-    $ export HDF5_PARALLEL="ON"
+    $ export HDF5_MPI="ON"
     $ python setup.py configure
     $ python setup.py build
 

--- a/h5py/tests/old/test_file.py
+++ b/h5py/tests/old/test_file.py
@@ -249,6 +249,8 @@ class TestDrivers(TestCase):
             self.assertEqual(f.driver, 'mpio')
 
     @ut.skipUnless(mpi, "Parallel HDF5 required")
+    @ut.skipIf(h5py.version.hdf5_version_tuple < (1,8,9),
+               "mpio atomic file operations were added in HDF5 1.8.9+")
     def test_mpi_atomic(self):
         """ Enable atomic mode for MPIO driver """
         from mpi4py import MPI

--- a/setup_configure.py
+++ b/setup_configure.py
@@ -58,7 +58,7 @@ class EnvironmentOptions(object):
     def __init__(self):
         self.hdf5 = os.environ.get('HDF5_DIR')
         self.hdf5_version = os.environ.get('HDF5_VERSION')
-        self.mpi = os.environ.get('HDF5_PARALLEL') == "ON"
+        self.mpi = os.environ.get('HDF5_MPI') == "ON"
         if self.hdf5_version is not None:
             validate_version(self.hdf5_version)
 

--- a/setup_configure.py
+++ b/setup_configure.py
@@ -58,6 +58,7 @@ class EnvironmentOptions(object):
     def __init__(self):
         self.hdf5 = os.environ.get('HDF5_DIR')
         self.hdf5_version = os.environ.get('HDF5_VERSION')
+        self.mpi = os.environ.get('HDF5_PARALLEL') == "ON"
         if self.hdf5_version is not None:
             validate_version(self.hdf5_version)
 
@@ -126,6 +127,8 @@ class configure(Command):
             dct['env_hdf5_version'] = env.hdf5_version
         if self.mpi is not None:
             dct['cmd_mpi'] = self.mpi
+        if env.mpi is not None:
+            dct['env_mpi'] = env.mpi
 
         self.rebuild_required = dct.get('rebuild') or dct != oldsettings
         
@@ -163,9 +166,13 @@ class configure(Command):
                 
         if self.mpi is None:
             self.mpi = oldsettings.get('cmd_mpi')
+        if self.mpi is None:
+            self.mpi = env.mpi
+        if self.mpi is None:
+            self.mpi = oldsettings.get('env_mpi')
                 
         # Step 3: print the resulting configuration to stdout
-        
+
         print('*' * 80)
         print(' ' * 23 + "Summary of the h5py configuration")
         print('')

--- a/tox.ini
+++ b/tox.ini
@@ -43,3 +43,9 @@ deps =
 deps =
     numpy==1.10
     cython==0.19
+
+[testenv:py34-test-mpi4py]
+deps =
+    numpy==1.9
+    cython==0.19
+    mpi4py>=1.3.1


### PR DESCRIPTION
Introduces an environment control variable `HDF5_MPI` to complement the `--mpi` `configure` option as described in #542.

Implemented the same way as the other HDF5 controls to allow easier installs via pip where direct access to `configure` is not possible.

A travis-ci test was added to keep the MPI features stable in the CI.