### PR TITLE
Closes #425. Fix inconsistency when slicing with numpy.array of shape (1,)

### DIFF
--- a/h5py/_hl/selections.py
+++ b/h5py/_hl/selections.py
@@ -83,6 +83,8 @@ def select(shape, args, dsid):
         if not isinstance(a, slice) and a is not Ellipsis:
             try:
                 int(a)
+                if isinstance(a, np.ndarray) and a.shape == (1,):
+                    raise Exception()
             except Exception:
                 sel = FancySelection(shape)
                 sel[args]

--- a/h5py/tests/hl/test_dataset_getitem.py
+++ b/h5py/tests/hl/test_dataset_getitem.py
@@ -395,6 +395,15 @@ class Test1DFloat(TestCase):
         
     def test_indexlist_simple(self):
         self.assertNumpyBehavior(self.dset, self.data, np.s_[[1,2,5]])
+
+    def test_indexlist_single_index_ellipsis(self):
+        self.assertNumpyBehavior(self.dset, self.data, np.s_[[0], ...])
+
+    def test_indexlist_numpyarray_single_index_ellipsis(self):
+        self.assertNumpyBehavior(self.dset, self.data, np.s_[np.array([0]), ...])
+
+    def test_indexlist_numpyarray_ellipsis(self):
+        self.assertNumpyBehavior(self.dset, self.data, np.s_[np.array([1, 2, 5]), ...])
         
     # Another UnboundLocalError
     @ut.expectedFailure


### PR DESCRIPTION
Closes #425. 
The problem is: when converting list [0] to int we get an exception, but converting np.array([0]) to int is allowed in numpy so we don't get an exception and the slicing result is different from slicing with list.
