### PR TITLE
Don't try to test with numpy 1.11.X on py26, it keeps breaking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,11 @@ matrix:
     - python: 3.5
       env:
       - TOXENV=py35-test-deps
+matrix:
+  include:
+    - python: 3.5
+      env:
+      - TOXENV=py35-test-mindeps
 
 install:
   - pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ changedir =
 [testenv:py26-test-deps]
 deps =
     unittest2
-    numpy>=1.6.1,<1.12,!=1.11.0
+    numpy>=1.6.1,<1.11
     cython>=0.19
 
 [testenv:py33-test-deps]


### PR DESCRIPTION
As per https://github.com/numpy/numpy/issues/7498, numpy 1.11.0 and 1.11.1 are broken on python 2.6. Given that there's probably no easy way for numpy to fix this, not testing 1.11.X on python 2.6 is probably the best solution, in that if a user has a working 1.11.X numpy on python 2.6, then h5py will probably work fine (given we do test 1.11.X with other versions, so numpy changes should be picked up).

@andrewcollette Would be able to merge this quickly, so pull requests pass/fail correctly again?