### PR TITLE
Package Config: Fix Detection

### DIFF
--- a/setup_configure.py
+++ b/setup_configure.py
@@ -204,7 +204,7 @@ def autodetect_version(hdf5_dir=None):
     libdirs = ['/usr/local/lib', '/opt/local/lib']
     try:
         if pkgconfig.exists("hdf5"):
-            libdirs.append(pkgconfig.parse("hdf5")['library_dirs'])
+            libdirs.extend(pkgconfig.parse("hdf5")['library_dirs'])
     except EnvironmentError:
         pass
     if hdf5_dir is not None:


### PR DESCRIPTION
Fix the detection of `pkgconfig` to avoid fallbacks to HDF `1.8.4` or non-detection on default installs on Ubuntu/Debian based systems.

This is a fixed version of PR #707 by @asford with the feedback provided by @andreabedini.

The main problem is the mismatch of `list` [append vs. extend](http://stackoverflow.com/questions/252703/append-vs-extend):
`pkgconfig.parse("hdf5")` returns a dictionary of sets of which we take the set of `library_dirs` which should be extending the libdirs list element-wise (and *not* "adding a `set` object to a `list`" via `append`).

(note: it's actually done correctly in `setup_build.py` already.)

Tested on Debian 8.5 "jessie" with default hdf5 libraries (`1.8.13`) installed.