### PR TITLE
Correctly compute size of compound dtype for non-monotonically increasing offsets

### DIFF
--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -1412,14 +1412,21 @@ cdef TypeCompoundID _c_compound(dtype dt, int logical):
     cdef tuple names = dt.names
 
     # Initial size MUST be 1 to avoid segfaults (issue 166)
-    tid = H5Tcreate(H5T_COMPOUND, 1)  
+    tid = H5Tcreate(H5T_COMPOUND, 1)
 
+    max_size = 0
     for name in names:
         ename = name.encode('utf8') if isinstance(name, unicode) else name
         dt_tmp = dt.fields[name][0]
         offset = dt.fields[name][1]
         type_tmp = py_create(dt_tmp, logical=logical)
-        H5Tset_size(tid, offset+type_tmp.get_size())
+
+        # account for out of order fields (as determined by offsets)
+        new_size = offset+type_tmp.get_size()
+        if new_size > max_size:
+            H5Tset_size(tid, new_size)
+            max_size = new_size
+
         H5Tinsert(tid, ename, offset, type_tmp.id)
 
     return TypeCompoundID(tid)

--- a/h5py/tests/hl/test_datatype.py
+++ b/h5py/tests/hl/test_datatype.py
@@ -44,10 +44,11 @@ class TestVlen(TestCase):
         self.assertEqual(h5py.check_dtype(enum=h5py.check_dtype(vlen=dt1)),
                          h5py.check_dtype(enum=h5py.check_dtype(vlen=dt2)))
 
-class TestAligned(TestCase):
 
+class TestOffsets(TestCase):
     """
-        Check that offsets are correctly computed for aligned compound types.
+        Check that compound members with manual offsets are handled
+        correctly.
     """
 
     def test_aligned_offsets(self):
@@ -58,6 +59,7 @@ class TestAligned(TestCase):
             [dt.fields[i][1] for i in dt.names],
             [ht.get_member_offset(i) for i in range(ht.get_nmembers())]
         )
+
 
     def test_aligned_data(self):
         dt = np.dtype('i2,f8', align=True)
@@ -73,3 +75,23 @@ class TestAligned(TestCase):
 
         with h5py.File(fname, 'r') as f:
             self.assertArrayEqual(f['data'], data)
+
+
+    def test_out_of_order_offsets(self):
+        dt = np.dtype({
+            'names' : ['f1', 'f2', 'f3'],
+            'formats' : ['<f4', '<i4', '<f8'],
+            'offsets' : [0, 16, 8]
+        })
+        data = np.empty(10, dtype=dt)
+        data['f1'] = np.random.rand(data.size)
+        data['f2'] = np.random.random_integers(-10, 10, data.size)
+        data['f3'] = np.random.rand(data.size)*-1
+
+        fname = self.mktemp()
+
+        with h5py.File(fname, 'w') as fd:
+            fd.create_dataset('data', data=data)
+
+        with h5py.File(fname, 'r') as fd:
+            self.assertArrayEqual(fd['data'], data)

--- a/h5py/tests/hl/test_datatype.py
+++ b/h5py/tests/hl/test_datatype.py
@@ -47,7 +47,7 @@ class TestVlen(TestCase):
 
 class TestOffsets(TestCase):
     """
-        Check that compound members with manual offsets are handled
+        Check that compound members with aligned or manual offsets are handled
         correctly.
     """
 


### PR DESCRIPTION
Hopefully fixes #737.

If a dtype contains offsets which are not monotonically increasing then the resulting size computed in `h5t._c_compound` is incorrect.  This PR attempts to fix this issue and add a relevant test case.
