### PR TITLE
Check for duplicates in fancy index validation

### DIFF
--- a/h5py/_hl/selections.py
+++ b/h5py/_hl/selections.py
@@ -353,7 +353,9 @@ class FancySelection(Selection):
                 except TypeError:
                     pass
                 else:
-                    if sorted(arg) != list(arg):
+                    list_arg = list(arg)
+                    adjacent = zip(list_arg[:-1], list_arg[1:])
+                    if any(fst >= snd for fst, snd in adjacent):
                         raise TypeError("Indexing elements must be in increasing order")
 
         if len(sequenceargs) > 1:

--- a/h5py/tests/hl/test_dataset_getitem.py
+++ b/h5py/tests/hl/test_dataset_getitem.py
@@ -411,9 +411,6 @@ class Test1DFloat(TestCase):
         with self.assertRaises(TypeError):
             self.dset[[1,3,2]]
         
-    # This results in IOError as the argument is not properly validated.
-    # Suggest IndexError be raised.
-    @ut.expectedFailure
     def test_indexlist_repeated(self):
         """ we forbid repeated index values """
         with self.assertRaises(TypeError):


### PR DESCRIPTION
Currently, a duplicate selection like `dataset[[1, 2, 2, 3]]` yields a cryptic internal error (see discussion in #8). This PR makes h5py raise an error at validation time when duplicate indices are passed instead of waiting until the underlying library chokes on the indices.

Note that I chose `TypeError` instead of `IndexError` for consistency with the existing implementation. `IndexError` would make more sense, but changing from `TypeError` would probably break a lot of existing user code.
