### PR TITLE
Add pypy possible support by avoiding potential race condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,11 @@ matrix:
             - openmpi-bin         # 1.4.3
             - libopenmpi-dev
             - libhdf5-openmpi-dev # 1.8.4
+    - python: pypy
+      env:
+      - TOXENV=pypy-test-deps
+  allow_failures:
+    - python: pypy
 
 install:
   - pip install tox

--- a/h5py/_objects.pxd
+++ b/h5py/_objects.pxd
@@ -15,9 +15,11 @@ cdef class ObjectID:
     cdef readonly hid_t id
     cdef public int locked              # Cannot be closed, explicitly or auto
     cdef object _hash
+    cdef unsigned long _pyid
 
 # Convenience functions
 cdef hid_t pdefault(ObjectID pid)
+cdef int is_h5py_obj_valid(ObjectID obj)
 
 # Inheritance scheme (for top-level cimport and import statements):
 #

--- a/h5py/_objects.pyx
+++ b/h5py/_objects.pyx
@@ -116,7 +116,6 @@ def nonlocal_close():
     cdef ObjectID obj
 
     for python_id, ref in registry.items():
-
         obj = ref()
 
         # Object somehow died without being removed from the registry.
@@ -160,41 +159,32 @@ cdef class ObjectID:
 
     property valid:
         def __get__(self):
-
-            # Locked objects are always valid, regardless of obj.id
-            if self.locked:
-                return True
-
-            # Former zombie object
-            if self.id == 0:
-                return False
-
-            # Ask HDF5.  Note that H5Iis_valid only works for "user"
-            # identifiers, hence the above checks.
-            with _phil:
-                return H5Iis_valid(self.id)
+            return is_h5py_obj_valid(self)
 
 
     def __cinit__(self, id_):
         with _phil:
             self.id = id_
             self.locked = 0
+            self._pyid = id(self)
             IF DEBUG_ID:
-                print("CINIT - registering %d of kind %s HDF5 id %d" % (id(self), type(self), id_))
-            registry[id(self)] = weakref.ref(self)
+                print("CINIT - registering %d of kind %s HDF5 id %d" % (self._pyid, type(self), self.id))
+            registry[self._pyid] = weakref.ref(self)
 
 
     def __dealloc__(self):
         with _phil:
             IF DEBUG_ID:
-                print("DEALLOC - unregistering %d of kind %s HDF5 id %d" % (id(self), type(self), self.id))
-            try:
-                # There's no reason to expect it, but in principle H5Idec_ref
-                # could raise an exception.
-                if self.valid and (not self.locked):
-                    H5Idec_ref(self.id)
-            finally:
-                del registry[id(self)] 
+                print("DEALLOC - unregistering %d HDF5 id %d" % (self._pyid, self.id))
+            if is_h5py_obj_valid(self) and (not self.locked):
+                if H5Idec_ref(self.id) < 0:
+                    warnings.warn(
+                        "Reference counting issue with HDF5 id {}".format(
+                            self.id
+                        )
+                    )
+            if self._pyid is not None:
+                del registry[self._pyid]
 
 
     def _close(self):
@@ -202,14 +192,15 @@ cdef class ObjectID:
 
         with _phil:
             IF DEBUG_ID:
-                print("CLOSE - %d of kind %s HDF5 id %d" % (id(self), type(self), self.id))
-            try:
-                # There's no reason to expect it, but in principle H5Idec_ref
-                # could raise an exception.
-                if self.valid and (not self.locked):
-                    H5Idec_ref(self.id)
-            finally:
-                self.id = 0
+                print("CLOSE - %d HDF5 id %d" % (self._pyid, self.id))
+            if is_h5py_obj_valid(self) and (not self.locked):
+                if H5Idec_ref(self.id) < 0:
+                    warnings.warn(
+                        "Reference counting issue with HDF5 id {}".format(
+                            self.id
+                        )
+                    )
+            self.id = 0
 
 
     def close(self):
@@ -285,3 +276,25 @@ cdef hid_t pdefault(ObjectID pid):
     if pid is None:
         return <hid_t>H5P_DEFAULT
     return pid.id
+
+
+cdef int is_h5py_obj_valid(ObjectID obj):
+    """
+    Check that h5py object is valid, i.e. HDF5 object wrapper is valid and HDF5
+    object is valid
+    """
+    # MUST BE CALLABLE AT ANY TIME, CANNOT USE PROPERTIES ETC. AS PER
+    # http://cython.readthedocs.io/en/latest/src/userguide/special_methods.html
+
+    # Locked objects are always valid, regardless of obj.id
+    if obj.locked:
+        return True
+
+    # Former zombie object
+    if obj.id == 0:
+        return False
+
+    # Ask HDF5.  Note that H5Iis_valid only works for "user"
+    # identifiers, hence the above checks.
+    with _phil:
+        return H5Iis_valid(obj.id)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py26,py27,py33,py34,py35}-{test}-{deps,mindeps}
+envlist = {py26,py27,py33,py34,py35,pypy}-{test}-{deps,mindeps}
 
 [testenv]
 deps =


### PR DESCRIPTION
This probably fixes #720 (I don't have pypy around and I'm not sure what I need to do to make it numpy-compatible, so the tests aren't working at the moment).
Also, I was running into some kind of race condition on cpython 3.5 due to problems in __dealloc__ which seemed to be identical to the problems on pypy, so this isn't just a pypy fix.
I've added pypy to travis, but it's not required to pass.