### PR TITLE
Initial support for appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,78 @@
+# from https://packaging.python.org/en/latest/appveyor/
+environment:
+  HDF5_VERSION: "1.8.17"
+  HDF5_DIR: "C:\\hdf5-%HDF5_VERSION%"
+  TOX_TESTENV_PASSENV: "HDF5_DIR"
+
+  matrix:
+
+    # For Python versions available on Appveyor, see
+    # http://www.appveyor.com/docs/installed-software#python
+    # The list here is complete (excluding Python 2.6, which
+    # isn't covered by this document) at the time of writing.
+
+    - PYTHON: "C:\\Python27"
+      TOXENV: "py27-test-deps"
+      HDF5_VISUAL_STUDIO_VERSION: "Visual Studio 9 2008"
+    - PYTHON: "C:\\Python33"
+      TOXENV: "py33-test-deps"
+      HDF5_VISUAL_STUDIO_VERSION: "Visual Studio 10 2010"
+    - PYTHON: "C:\\Python34"
+      TOXENV: "py34-test-deps"
+      HDF5_VISUAL_STUDIO_VERSION: "Visual Studio 10 2010"
+    - PYTHON: "C:\\Python35"
+      TOXENV: "py35-test-deps"
+      HDF5_VISUAL_STUDIO_VERSION: "Visual Studio 14 2015"
+    - PYTHON: "C:\\Python27-x64"
+      HDF5_VISUAL_STUDIO_VERSION: "Visual Studio 9 2008"
+      TOXENV: "py27-test-deps"
+    - PYTHON: "C:\\Python33-x64"
+      TOXENV: "py33-test-deps"
+      HDF5_VISUAL_STUDIO_VERSION: "Visual Studio 10 2010"
+      DISTUTILS_USE_SDK: "1"
+    - PYTHON: "C:\\Python34-x64"
+      TOXENV: "py34-test-deps"
+      HDF5_VISUAL_STUDIO_VERSION: "Visual Studio 10 2010"
+      DISTUTILS_USE_SDK: "1"
+    - PYTHON: "C:\\Python35-x64"
+      TOXENV: "py35-test-deps"
+      HDF5_VISUAL_STUDIO_VERSION: "Visual Studio 14 2015"
+
+install:
+  # We need wheel installed to build wheels
+  - "%PYTHON%\\python.exe -m pip install --upgrade wheel pip setuptools"
+  - "%PYTHON%\\python.exe -m pip install tox"
+  - "py -3.5 -m pip install requests"
+  - "py -3.5 ci\\get_hdf5.py"
+
+build: off
+
+test_script:
+  # Put your test command here.
+  # If you don't need to build C extensions on 64-bit Python 3.3 or 3.4,
+  # you can remove "build.cmd" from the front of the command, as it's
+  # only needed to support those cases.
+  # Note that you must use the environment variable %PYTHON% to refer to
+  # the interpreter you're using - Appveyor does not do anything special
+  # to put the Python evrsion you want to use on PATH.
+  - "ci\\appveyor\\build.cmd py -3.5 -m tox"
+
+after_test:
+  # This step builds your wheels.
+  # Again, you only need build.cmd if you're building C extensions for
+  # 64-bit Python 3.3/3.4. And you need to use %PYTHON% to get the correct
+  # interpreter
+  - "ci\\appveyor\\build.cmd %PYTHON%\\python.exe setup.py bdist_wheel"
+
+artifacts:
+  # bdist_wheel puts your built wheel in the dist directory
+  - path: dist\*
+
+cache:
+  - "%LOCALAPPDATA%\\pip\\Cache"
+  - "C:\\hdf5-%HDF5_VERSION%"
+
+#on_success:
+#  You can use this step to upload your artifacts to a public website.
+#  See Appveyor's documentation for more details. Or you can simply
+#  access your wheels from the Appveyor "artifacts" tab for your build.

--- a/ci/appveyor/build.cmd
+++ b/ci/appveyor/build.cmd
@@ -1,0 +1,21 @@
+@echo off
+:: To build extensions for 64 bit Python 3, we need to configure environment
+:: variables to use the MSVC 2010 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 4
+::
+:: More details at:
+:: https://github.com/cython/cython/wiki/64BitCythonExtensionsOnWindows
+
+IF "%DISTUTILS_USE_SDK%"=="1" (
+    ECHO Configuring environment to build with MSVC on a 64bit architecture
+    ECHO Using Windows SDK 7.1
+    "C:\Program Files\Microsoft SDKs\Windows\v7.1\Setup\WindowsSdkVer.exe" -q -version:v7.1
+    CALL "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64 /release
+    SET MSSdk=1
+    REM Need the following to allow tox to see the SDK compiler
+    SET TOX_TESTENV_PASSENV=DISTUTILS_USE_SDK MSSdk INCLUDE LIB
+) ELSE (
+    ECHO Using default MSVC build environment
+)
+
+CALL %*

--- a/ci/fix_paths.py
+++ b/ci/fix_paths.py
@@ -1,0 +1,22 @@
+import argparse
+from glob import glob
+from os import environ
+from os.path import join as pjoin
+from shutil import copy
+from sys import platform
+
+def main():
+    """
+    Fix paths to dlls
+    """
+    p = argparse.ArgumentParser()
+    p.add_argument("sitepackagesdir")
+    args = p.parse_args()
+    hdf5_path = environ.get("HDF5_DIR")
+    if platform.startswith('win'):
+        for f in glob(pjoin(hdf5_path, 'lib/*.dll')):
+            copy(f, pjoin(args.sitepackagesdir, 'h5py'))
+
+
+if __name__ == '__main__':
+    main()

--- a/ci/get_hdf5.py
+++ b/ci/get_hdf5.py
@@ -1,0 +1,99 @@
+
+from os import environ, mkdir, walk, listdir, getcwd, chdir
+from os.path import join as pjoin, exists
+from tempfile import TemporaryFile, TemporaryDirectory
+from sys import exit, stderr, platform
+from shutil import copyfileobj, copy
+from glob import glob
+from subprocess import run, PIPE, STDOUT
+from zipfile import ZipFile
+
+import requests
+
+HDF5_URL = "https://www.hdfgroup.org/ftp/HDF5/releases/hdf5-{version}/src/"
+HDF5_FILE = HDF5_URL + "hdf5-{version}.zip"
+CMAKE_CONFIGURE_CMD = [
+    "cmake", "-DBUILD_SHARED_LIBS:BOOL=ON", "-DCMAKE_BUILD_TYPE:STRING=RELEASE",
+    "-DHDF5_BUILD_CPP_LIB=OFF", "-DHDF5_BUILD_HL_LIB=ON",
+    "-DHDF5_BUILD_TOOLS:BOOL=ON",
+]
+CMAKE_BUILD_CMD = ["cmake", "--build"]
+CMAKE_INSTALL_ARG = ["--target", "install", '--config', 'Release']
+CMAKE_INSTALL_PATH_ARG = "-DCMAKE_INSTALL_PREFIX={install_path}"
+REL_PATH_TO_CMAKE_CFG = "hdf5-{version}"
+DEFAULT_VERSION = '1.8.17'
+
+def download_hdf5(version, outfile):
+    r = requests.get(HDF5_FILE.format(version=version), stream=True)
+    try:
+        r.raise_for_status()
+        copyfileobj(r.raw, outfile)
+    except requests.HTTPError:
+        print("Failed to download hdf5 version {version}, exiting".format(
+            version=version
+        ), file=stderr)
+        exit(1)
+
+
+def build_hdf5(version, hdf5_file, install_path, vs_version):
+    with TemporaryDirectory() as hdf5_extract_path:
+        with ZipFile(hdf5_file) as z:
+            z.extractall(hdf5_extract_path)
+        old_dir = getcwd()
+        with TemporaryDirectory() as new_dir:
+            chdir(new_dir)
+            cfg_cmd = CMAKE_CONFIGURE_CMD + [
+                get_cmake_install_path(install_path),
+                get_cmake_config_path(version, hdf5_extract_path),
+            ] + ["-G", vs_version]
+            build_cmd = CMAKE_BUILD_CMD + [
+                '.',
+            ] + CMAKE_INSTALL_ARG
+            print("Configuring HDF5 version {version}...".format(version=version), file=stderr)
+            print(' '.join(cfg_cmd), file=stderr)
+            p = run(cfg_cmd, stdout=PIPE, stderr=STDOUT, universal_newlines=True)
+            print(p.stdout)
+            print("Building HDF5 version {version}...".format(version=version), file=stderr)
+            print(' '.join(build_cmd), file=stderr)
+            p = run(build_cmd, stdout=PIPE, stderr=STDOUT, universal_newlines=True)
+            print(p.stdout)
+            print("Installed HDF5 version {version} to {install_path}".format(
+                version=version, install_path=install_path,
+            ), file=stderr)
+            chdir(old_dir)
+    if platform.startswith('win'):
+        for f in glob(pjoin(install_path, 'bin/*.dll')):
+            copy(f, pjoin(install_path, 'lib'))
+
+
+def get_cmake_config_path(version, extract_point):
+    return pjoin(extract_point, REL_PATH_TO_CMAKE_CFG.format(version=version))
+
+
+def get_cmake_install_path(install_path):
+    if install_path is not None:
+        return CMAKE_INSTALL_PATH_ARG.format(install_path=install_path)
+    return ' '
+
+
+def main():
+    install_path = environ.get("HDF5_DIR")
+    version = environ.get("HDF5_VERSION", DEFAULT_VERSION)
+    vs_version = environ.get("HDF5_VISUAL_STUDIO_VERSION")
+    if install_path is not None:
+        if not exists(install_path):
+            mkdir(install_path)
+    if vs_version is None:
+        raise RuntimeError("Visual Studio version not defined")
+    with TemporaryFile() as f:
+        download_hdf5(version, f)
+        build_hdf5(version, f, install_path, vs_version)
+    if install_path is not None:
+        print("hdf5 files: ", file=stderr)
+        for dirpath, dirnames, filenames in walk(install_path):
+            for file in filenames:
+                print(" * " + pjoin(dirpath, file))
+
+
+if __name__ == '__main__':
+    main()

--- a/h5py/tests/old/test_file.py
+++ b/h5py/tests/old/test_file.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import, with_statement
 
 import os, stat
+from sys import platform
 import tempfile
 
 import six
@@ -52,7 +53,7 @@ class TestFileOpen(TestCase):
         # Running as root (e.g. in a docker container) gives 'r+' as the file
         # mode, even for a read-only file.  See
         # https://github.com/h5py/h5py/issues/696
-        exp_mode = 'r+' if os.stat(fname).st_uid == 0 else 'r'
+        exp_mode = 'r+' if os.stat(fname).st_uid == 0 and platform != "win32" else 'r'
         try:
             with File(fname) as f:
                 self.assertTrue(f)

--- a/setup_build.py
+++ b/setup_build.py
@@ -38,10 +38,15 @@ EXTRA_SRC = {'h5z': [ localpath("lzf/lzf_filter.c"),
 
 if sys.platform.startswith('win'):
     COMPILER_SETTINGS = {
-        'libraries'     : ['h5py_hdf5', 'h5py_hdf5_hl'],
+        'libraries'     : ['hdf5', 'hdf5_hl'],
         'include_dirs'  : [localpath('lzf'), localpath('windows')],
         'library_dirs'  : [],
-        'define_macros' : [('H5_USE_16_API', None), ('_HDF5USEDLL_', None)] }
+        'define_macros' : [
+            ('H5_USE_16_API', None),
+            ('_HDF5USEDLL_', None),
+            ('H5_BUILT_AS_DYNAMIC_LIB', None),
+        ]
+    }
 
 else:
     COMPILER_SETTINGS = {

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,11 @@ deps =
     mindeps: numpy==1.6.1
     mindeps: cython==0.19
 commands =
+    test: python {toxinidir}/ci/fix_paths.py {envsitepackagesdir}
     test: python -c "from sys import exit; import h5py; exit(0) if h5py.run_tests().wasSuccessful() else exit(1)"
 changedir =
     test: {toxworkdir}
+passenv = HDF5_DIR
 
 [testenv:py26-test-deps]
 deps =

--- a/windows/inttypes.h
+++ b/windows/inttypes.h
@@ -1,0 +1,306 @@
+// ISO C9x  compliant inttypes.h for Microsoft Visual Studio
+// Based on ISO/IEC 9899:TC2 Committee draft (May 6, 2005) WG14/N1124 
+// 
+//  Copyright (c) 2006-2013 Alexander Chemeris
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 
+//   1. Redistributions of source code must retain the above copyright notice,
+//      this list of conditions and the following disclaimer.
+// 
+//   2. Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+// 
+//   3. Neither the name of the product nor the names of its contributors may
+//      be used to endorse or promote products derived from this software
+//      without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+// EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _MSC_VER // [
+#error "Use this header only with Microsoft Visual C++ compilers!"
+#endif // _MSC_VER ]
+
+#ifndef _MSC_INTTYPES_H_ // [
+#define _MSC_INTTYPES_H_
+
+#if _MSC_VER > 1000
+#pragma once
+#endif
+
+#include "stdint.h"
+
+// 7.8 Format conversion of integer types
+
+typedef struct {
+   intmax_t quot;
+   intmax_t rem;
+} imaxdiv_t;
+
+// 7.8.1 Macros for format specifiers
+
+#if !defined(__cplusplus) || defined(__STDC_FORMAT_MACROS) // [   See footnote 185 at page 198
+
+// The fprintf macros for signed integers are:
+#define PRId8       "d"
+#define PRIi8       "i"
+#define PRIdLEAST8  "d"
+#define PRIiLEAST8  "i"
+#define PRIdFAST8   "d"
+#define PRIiFAST8   "i"
+
+#define PRId16       "hd"
+#define PRIi16       "hi"
+#define PRIdLEAST16  "hd"
+#define PRIiLEAST16  "hi"
+#define PRIdFAST16   "hd"
+#define PRIiFAST16   "hi"
+
+#define PRId32       "I32d"
+#define PRIi32       "I32i"
+#define PRIdLEAST32  "I32d"
+#define PRIiLEAST32  "I32i"
+#define PRIdFAST32   "I32d"
+#define PRIiFAST32   "I32i"
+
+#define PRId64       "I64d"
+#define PRIi64       "I64i"
+#define PRIdLEAST64  "I64d"
+#define PRIiLEAST64  "I64i"
+#define PRIdFAST64   "I64d"
+#define PRIiFAST64   "I64i"
+
+#define PRIdMAX     "I64d"
+#define PRIiMAX     "I64i"
+
+#define PRIdPTR     "Id"
+#define PRIiPTR     "Ii"
+
+// The fprintf macros for unsigned integers are:
+#define PRIo8       "o"
+#define PRIu8       "u"
+#define PRIx8       "x"
+#define PRIX8       "X"
+#define PRIoLEAST8  "o"
+#define PRIuLEAST8  "u"
+#define PRIxLEAST8  "x"
+#define PRIXLEAST8  "X"
+#define PRIoFAST8   "o"
+#define PRIuFAST8   "u"
+#define PRIxFAST8   "x"
+#define PRIXFAST8   "X"
+
+#define PRIo16       "ho"
+#define PRIu16       "hu"
+#define PRIx16       "hx"
+#define PRIX16       "hX"
+#define PRIoLEAST16  "ho"
+#define PRIuLEAST16  "hu"
+#define PRIxLEAST16  "hx"
+#define PRIXLEAST16  "hX"
+#define PRIoFAST16   "ho"
+#define PRIuFAST16   "hu"
+#define PRIxFAST16   "hx"
+#define PRIXFAST16   "hX"
+
+#define PRIo32       "I32o"
+#define PRIu32       "I32u"
+#define PRIx32       "I32x"
+#define PRIX32       "I32X"
+#define PRIoLEAST32  "I32o"
+#define PRIuLEAST32  "I32u"
+#define PRIxLEAST32  "I32x"
+#define PRIXLEAST32  "I32X"
+#define PRIoFAST32   "I32o"
+#define PRIuFAST32   "I32u"
+#define PRIxFAST32   "I32x"
+#define PRIXFAST32   "I32X"
+
+#define PRIo64       "I64o"
+#define PRIu64       "I64u"
+#define PRIx64       "I64x"
+#define PRIX64       "I64X"
+#define PRIoLEAST64  "I64o"
+#define PRIuLEAST64  "I64u"
+#define PRIxLEAST64  "I64x"
+#define PRIXLEAST64  "I64X"
+#define PRIoFAST64   "I64o"
+#define PRIuFAST64   "I64u"
+#define PRIxFAST64   "I64x"
+#define PRIXFAST64   "I64X"
+
+#define PRIoMAX     "I64o"
+#define PRIuMAX     "I64u"
+#define PRIxMAX     "I64x"
+#define PRIXMAX     "I64X"
+
+#define PRIoPTR     "Io"
+#define PRIuPTR     "Iu"
+#define PRIxPTR     "Ix"
+#define PRIXPTR     "IX"
+
+// The fscanf macros for signed integers are:
+#define SCNd8       "d"
+#define SCNi8       "i"
+#define SCNdLEAST8  "d"
+#define SCNiLEAST8  "i"
+#define SCNdFAST8   "d"
+#define SCNiFAST8   "i"
+
+#define SCNd16       "hd"
+#define SCNi16       "hi"
+#define SCNdLEAST16  "hd"
+#define SCNiLEAST16  "hi"
+#define SCNdFAST16   "hd"
+#define SCNiFAST16   "hi"
+
+#define SCNd32       "ld"
+#define SCNi32       "li"
+#define SCNdLEAST32  "ld"
+#define SCNiLEAST32  "li"
+#define SCNdFAST32   "ld"
+#define SCNiFAST32   "li"
+
+#define SCNd64       "I64d"
+#define SCNi64       "I64i"
+#define SCNdLEAST64  "I64d"
+#define SCNiLEAST64  "I64i"
+#define SCNdFAST64   "I64d"
+#define SCNiFAST64   "I64i"
+
+#define SCNdMAX     "I64d"
+#define SCNiMAX     "I64i"
+
+#ifdef _WIN64 // [
+#  define SCNdPTR     "I64d"
+#  define SCNiPTR     "I64i"
+#else  // _WIN64 ][
+#  define SCNdPTR     "ld"
+#  define SCNiPTR     "li"
+#endif  // _WIN64 ]
+
+// The fscanf macros for unsigned integers are:
+#define SCNo8       "o"
+#define SCNu8       "u"
+#define SCNx8       "x"
+#define SCNX8       "X"
+#define SCNoLEAST8  "o"
+#define SCNuLEAST8  "u"
+#define SCNxLEAST8  "x"
+#define SCNXLEAST8  "X"
+#define SCNoFAST8   "o"
+#define SCNuFAST8   "u"
+#define SCNxFAST8   "x"
+#define SCNXFAST8   "X"
+
+#define SCNo16       "ho"
+#define SCNu16       "hu"
+#define SCNx16       "hx"
+#define SCNX16       "hX"
+#define SCNoLEAST16  "ho"
+#define SCNuLEAST16  "hu"
+#define SCNxLEAST16  "hx"
+#define SCNXLEAST16  "hX"
+#define SCNoFAST16   "ho"
+#define SCNuFAST16   "hu"
+#define SCNxFAST16   "hx"
+#define SCNXFAST16   "hX"
+
+#define SCNo32       "lo"
+#define SCNu32       "lu"
+#define SCNx32       "lx"
+#define SCNX32       "lX"
+#define SCNoLEAST32  "lo"
+#define SCNuLEAST32  "lu"
+#define SCNxLEAST32  "lx"
+#define SCNXLEAST32  "lX"
+#define SCNoFAST32   "lo"
+#define SCNuFAST32   "lu"
+#define SCNxFAST32   "lx"
+#define SCNXFAST32   "lX"
+
+#define SCNo64       "I64o"
+#define SCNu64       "I64u"
+#define SCNx64       "I64x"
+#define SCNX64       "I64X"
+#define SCNoLEAST64  "I64o"
+#define SCNuLEAST64  "I64u"
+#define SCNxLEAST64  "I64x"
+#define SCNXLEAST64  "I64X"
+#define SCNoFAST64   "I64o"
+#define SCNuFAST64   "I64u"
+#define SCNxFAST64   "I64x"
+#define SCNXFAST64   "I64X"
+
+#define SCNoMAX     "I64o"
+#define SCNuMAX     "I64u"
+#define SCNxMAX     "I64x"
+#define SCNXMAX     "I64X"
+
+#ifdef _WIN64 // [
+#  define SCNoPTR     "I64o"
+#  define SCNuPTR     "I64u"
+#  define SCNxPTR     "I64x"
+#  define SCNXPTR     "I64X"
+#else  // _WIN64 ][
+#  define SCNoPTR     "lo"
+#  define SCNuPTR     "lu"
+#  define SCNxPTR     "lx"
+#  define SCNXPTR     "lX"
+#endif  // _WIN64 ]
+
+#endif // __STDC_FORMAT_MACROS ]
+
+// 7.8.2 Functions for greatest-width integer types
+
+// 7.8.2.1 The imaxabs function
+#define imaxabs _abs64
+
+// 7.8.2.2 The imaxdiv function
+
+// This is modified version of div() function from Microsoft's div.c found
+// in %MSVC.NET%\crt\src\div.c
+#ifdef STATIC_IMAXDIV // [
+static
+#else // STATIC_IMAXDIV ][
+_inline
+#endif // STATIC_IMAXDIV ]
+imaxdiv_t __cdecl imaxdiv(intmax_t numer, intmax_t denom)
+{
+   imaxdiv_t result;
+
+   result.quot = numer / denom;
+   result.rem = numer % denom;
+
+   if (numer < 0 && result.rem > 0) {
+      // did division wrong; must fix up
+      ++result.quot;
+      result.rem -= denom;
+   }
+
+   return result;
+}
+
+// 7.8.2.3 The strtoimax and strtoumax functions
+#define strtoimax _strtoi64
+#define strtoumax _strtoui64
+
+// 7.8.2.4 The wcstoimax and wcstoumax functions
+#define wcstoimax _wcstoi64
+#define wcstoumax _wcstoui64
+
+
+#endif // _MSC_INTTYPES_H_ ]

--- a/windows/stdint.h
+++ b/windows/stdint.h
@@ -1,7 +1,7 @@
 // ISO C9x  compliant stdint.h for Microsoft Visual Studio
 // Based on ISO/IEC 9899:TC2 Committee draft (May 6, 2005) WG14/N1124 
 // 
-//  Copyright (c) 2006-2008 Alexander Chemeris
+//  Copyright (c) 2006-2013 Alexander Chemeris
 // 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -13,8 +13,9 @@
 //      notice, this list of conditions and the following disclaimer in the
 //      documentation and/or other materials provided with the distribution.
 // 
-//   3. The name of the author may be used to endorse or promote products
-//      derived from this software without specific prior written permission.
+//   3. Neither the name of the product nor the names of its contributors may
+//      be used to endorse or promote products derived from this software
+//      without specific prior written permission.
 // 
 // THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
 // WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
@@ -40,17 +41,22 @@
 #pragma once
 #endif
 
+#if _MSC_VER > 1900 // [
+#include <stdint.h>
+#else // ] _MSC_VER > 1900 [
+
 #include <limits.h>
 
-// For Visual Studio 6 in C++ mode wrap <wchar.h> include with 'extern "C++" {}'
+// For Visual Studio 6 in C++ mode and for many Visual Studio versions when
+// compiling for ARM we should wrap <wchar.h> include with 'extern "C++" {}'
 // or compiler give many errors like this:
 //   error C2733: second C linkage of overloaded function 'wmemchr' not allowed
-#if (_MSC_VER < 1300) && defined(__cplusplus)
-   extern "C++" {
-#endif 
-#     include <wchar.h>
-#if (_MSC_VER < 1300) && defined(__cplusplus)
-   }
+#ifdef __cplusplus
+extern "C" {
+#endif
+#  include <wchar.h>
+#ifdef __cplusplus
+}
 #endif
 
 // Define _W64 macros to mark types changing their size, like intptr_t.
@@ -66,14 +72,28 @@
 // 7.18.1 Integer types
 
 // 7.18.1.1 Exact-width integer types
-typedef __int8            int8_t;
-typedef __int16           int16_t;
-typedef __int32           int32_t;
-typedef __int64           int64_t;
-typedef unsigned __int8   uint8_t;
-typedef unsigned __int16  uint16_t;
-typedef unsigned __int32  uint32_t;
-typedef unsigned __int64  uint64_t;
+
+// Visual Studio 6 and Embedded Visual C++ 4 doesn't
+// realize that, e.g. char has the same size as __int8
+// so we give up on __intX for them.
+#if (_MSC_VER < 1300)
+   typedef signed char       int8_t;
+   typedef signed short      int16_t;
+   typedef signed int        int32_t;
+   typedef unsigned char     uint8_t;
+   typedef unsigned short    uint16_t;
+   typedef unsigned int      uint32_t;
+#else
+   typedef signed __int8     int8_t;
+   typedef signed __int16    int16_t;
+   typedef signed __int32    int32_t;
+   typedef unsigned __int8   uint8_t;
+   typedef unsigned __int16  uint16_t;
+   typedef unsigned __int32  uint32_t;
+#endif
+typedef signed __int64       int64_t;
+typedef unsigned __int64     uint64_t;
+
 
 // 7.18.1.2 Minimum-width integer types
 typedef int8_t    int_least8_t;
@@ -97,11 +117,11 @@ typedef uint64_t  uint_fast64_t;
 
 // 7.18.1.4 Integer types capable of holding object pointers
 #ifdef _WIN64 // [
-   typedef __int64           intptr_t;
+   typedef signed __int64    intptr_t;
    typedef unsigned __int64  uintptr_t;
 #else // _WIN64 ][
-   typedef _W64 int               intptr_t;
-   typedef _W64 unsigned int      uintptr_t;
+   typedef _W64 signed int   intptr_t;
+   typedef _W64 unsigned int uintptr_t;
 #endif // _WIN64 ]
 
 // 7.18.1.5 Greatest-width integer types
@@ -223,10 +243,17 @@ typedef uint64_t  uintmax_t;
 #define UINT64_C(val) val##ui64
 
 // 7.18.4.2 Macros for greatest-width integer constants
-#define INTMAX_C   INT64_C
-#define UINTMAX_C  UINT64_C
+// These #ifndef's are needed to prevent collisions with <boost/cstdint.hpp>.
+// Check out Issue 9 for the details.
+#ifndef INTMAX_C //   [
+#  define INTMAX_C   INT64_C
+#endif // INTMAX_C    ]
+#ifndef UINTMAX_C //  [
+#  define UINTMAX_C  UINT64_C
+#endif // UINTMAX_C   ]
 
 #endif // __STDC_CONSTANT_MACROS ]
 
+#endif // _MSC_VER > 1900 ]
 
 #endif // _MSC_STDINT_H_ ]


### PR DESCRIPTION
This adds some initial support for testing h5py on appveyor (I've squashed the commits so we don't have all my attempts making a really messy history). I haven't got it working, so maybe someone who knows windows/appveyor better than me will be able to identify the problem.

Currently:
- HDF5 builds from source (using cmake, 1.8.17 seems to be the first version where this is properly supported)
- h5py kinda finds HDF5 (it knows that 1.8.17 is installed, but fails to find the header files)
- Support for tox is done (assuming that we can get h5py working)
- h5py wheels are generated (but don't include HDF5, I don't know how linking works on windows)
- There's some caching going on, currently just wheels via pip, but we should also cache HDF5 (especially as appveyor is much slower than travis).

UPDATE:
h5py now finds HDF5, but there's symbols missing, I'm not sure what's going on there...

UPDATE:
h5py now installs, but tests are failing