### PR TITLE
Use size_t to store Python object id

### DIFF
--- a/h5py/_objects.pxd
+++ b/h5py/_objects.pxd
@@ -15,7 +15,7 @@ cdef class ObjectID:
     cdef readonly hid_t id
     cdef public int locked              # Cannot be closed, explicitly or auto
     cdef object _hash
-    cdef unsigned long _pyid
+    cdef size_t _pyid
 
 # Convenience functions
 cdef hid_t pdefault(ObjectID pid)


### PR DESCRIPTION
`unsigned long` is not large enough to store the address of a Python object on Windows 64-bit.

See also https://github.com/h5py/h5py/blob/master/h5py/_objects.pyx#L169 and https://docs.python.org/3/library/functions.html#id