### PR TITLE
WIP: Workaround NumPy index array bug

### DIFF
--- a/h5py/tests/hl/test_dataset_getitem.py
+++ b/h5py/tests/hl/test_dataset_getitem.py
@@ -392,10 +392,16 @@ class Test1DFloat(TestCase):
     def test_index_outofrange(self):
         with self.assertRaises(ValueError):
             self.dset[100]
-        
+
     def test_indexlist_simple(self):
         self.assertNumpyBehavior(self.dset, self.data, np.s_[[1,2,5]])
-        
+
+    def test_indexarray_singleton(self):
+        self.assertNumpyBehavior(self.dset, self.data, np.array([1]))
+
+    def test_indexarray_multiple(self):
+        self.assertNumpyBehavior(self.dset, self.data, np.array([1, 2]))
+
     # Another UnboundLocalError
     @ut.expectedFailure
     def test_indexlist_empty(self):


### PR DESCRIPTION
Fixes https://github.com/h5py/h5py/issues/584

Fixes a deviation from NumPy behavior when using NumPy index arrays. Namely indexing by a singleton NumPy index arrays result in the index dimension being dropped when it should remain as a singleton dimension. We add a workaround and some tests to ensure this behavior is fixed.