### PR TITLE
fix append mode file create exception swallowing

### DIFF
--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -112,7 +112,12 @@ def make_fid(name, mode, userblock_size, fapl, fcpl=None, swmr=False):
         try:
             fid = h5f.open(name, h5f.ACC_RDWR, fapl=fapl)
         except IOError:
-            fid = h5f.create(name, h5f.ACC_EXCL, fapl=fapl, fcpl=fcpl)
+            exc_info = sys.exc_info()  # save the root cause
+            try:
+                fid = h5f.create(name, h5f.ACC_EXCL, fapl=fapl, fcpl=fcpl)
+            except:
+                # reraise the original root cause
+                raise exc_info[0], exc_info[1], exc_info[2]
     elif mode is None:
         # Try to open in append mode (read/write).
         # If that fails, try readonly, and finally create a new file only


### PR DESCRIPTION
For some reason, on my MacOSX, I get an error when trying to `h5py.File(..., mode='a')`.
The error seemed non-sensical, until I dug into the code and saw that the root cause error was getting swallowed.
This patch reraises the original exception on the append mode create.

FYI, this is the error I get (I haven't yet figured out why I get this, but that is a different problem).

IOError: Unable to open file (Unable to flock file, errno = 35, error message = 'resource temporarily unavailable')

