### PR TITLE
Fix complex256 on systems with missing support

### DIFF
--- a/h5py/api_compat.h
+++ b/h5py/api_compat.h
@@ -30,13 +30,19 @@ typedef void *PyMPI_MPI_Message;
 
 #define h5py_size_n64 (sizeof(npy_complex64))
 #define h5py_size_n128 (sizeof(npy_complex128))
+
+#ifdef NPY_COMPLEX256
 #define h5py_size_n256 (sizeof(npy_complex256))
+#endif
 
 #define h5py_offset_n64_real (HOFFSET(npy_complex64, real))
 #define h5py_offset_n64_imag (HOFFSET(npy_complex64, imag))
 #define h5py_offset_n128_real (HOFFSET(npy_complex128, real))
 #define h5py_offset_n128_imag (HOFFSET(npy_complex128, imag))
+
+#ifdef NPY_COMPLEX256
 #define h5py_offset_n256_real (HOFFSET(npy_complex256, real))
 #define h5py_offset_n256_imag (HOFFSET(npy_complex256, imag))
+#endif
 
 #endif

--- a/h5py/api_types_ext.pxd
+++ b/h5py/api_types_ext.pxd
@@ -63,13 +63,15 @@ cdef extern from "api_compat.h":
 
   size_t h5py_size_n64
   size_t h5py_size_n128
-  size_t h5py_size_n256
   size_t h5py_offset_n64_real
   size_t h5py_offset_n64_imag
   size_t h5py_offset_n128_real
   size_t h5py_offset_n128_imag
-  size_t h5py_offset_n256_real
-  size_t h5py_offset_n256_imag
+
+  IF COMPLEX256_SUPPORT:
+    size_t h5py_size_n256
+    size_t h5py_offset_n256_real
+    size_t h5py_offset_n256_imag
 
 cdef extern from "lzf_filter.h":
 

--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -16,6 +16,7 @@
 """
 
 # Pyrex compile-time imports
+include "config.pxi"
 from _objects cimport pdefault
 
 from numpy cimport dtype, ndarray
@@ -1394,10 +1395,13 @@ cdef TypeCompoundID _c_complex(dtype dt):
             tid_sub = H5T_NATIVE_DOUBLE
 
     elif length == 32:
-        size = h5py_size_n256
-        off_r = h5py_offset_n256_real
-        off_i = h5py_offset_n256_imag
-        tid_sub = H5T_NATIVE_LDOUBLE
+        IF COMPLEX256_SUPPORT:
+            size = h5py_size_n256
+            off_r = h5py_offset_n256_real
+            off_i = h5py_offset_n256_imag
+            tid_sub = H5T_NATIVE_LDOUBLE
+        ELSE:
+            raise TypeError("Illegal length %d for complex dtype" % length)
     else:
         raise TypeError("Illegal length %d for complex dtype" % length)
 

--- a/h5py/tests/old/test_dataset.py
+++ b/h5py/tests/old/test_dataset.py
@@ -93,6 +93,7 @@ class TestCreateShape(BaseDataset):
         dset = self.f.create_dataset('foo', (63,), dtype=np.longdouble)
         self.assertEqual(dset.dtype, np.longdouble)
 
+    @ut.skipIf(not hasattr(np, "complex256"), "No support for complex256")
     def test_complex256(self):
         """ Confirm that the default dtype is float """
         dset = self.f.create_dataset('foo', (63,),

--- a/setup_build.py
+++ b/setup_build.py
@@ -145,6 +145,7 @@ class h5py_build_ext(build_ext):
         """ Distutils calls this method to run the command """
 
         from Cython.Build import cythonize
+        import numpy
 
         # Provides all of our build options
         config = self.distribution.get_command_obj('configure')
@@ -176,10 +177,14 @@ DEF MPI4PY_V2 = %(mpi4py_v2)s
 DEF HDF5_VERSION = %(version)s
 DEF SWMR_MIN_HDF5_VERSION = (1,9,178)
 DEF VDS_MIN_HDF5_VERSION = (1,9,233)
+DEF COMPLEX256_SUPPORT = %(complex256_support)s
 """
-                s %= {'mpi': bool(config.mpi),
-                      'mpi4py_v2': bool(v2),
-                      'version': tuple(int(x) for x in config.hdf5_version.split('.'))}
+                s %= {
+                    'mpi': bool(config.mpi),
+                    'mpi4py_v2': bool(v2),
+                    'version': tuple(int(x) for x in config.hdf5_version.split('.')),
+                    'complex256_support': hasattr(numpy, 'complex256')
+                }
                 s = s.encode('utf-8')
                 f.write(s)
 


### PR DESCRIPTION
This fixes building h5py on Windows due to the lack of complex256 support. Closes #779. 