### PR TITLE
Fix filemode test on windows

### DIFF
--- a/h5py/tests/old/test_file.py
+++ b/h5py/tests/old/test_file.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import, with_statement
 
 import os, stat
+from sys import platform
 import tempfile
 
 import six
@@ -52,7 +53,7 @@ class TestFileOpen(TestCase):
         # Running as root (e.g. in a docker container) gives 'r+' as the file
         # mode, even for a read-only file.  See
         # https://github.com/h5py/h5py/issues/696
-        exp_mode = 'r+' if os.stat(fname).st_uid == 0 else 'r'
+        exp_mode = 'r+' if os.stat(fname).st_uid == 0 and platform != "win32" else 'r'
         try:
             with File(fname) as f:
                 self.assertTrue(f)


### PR DESCRIPTION
This test is broken on appveyor, as uid 0 doesn't give the same permissions on windows.