### PR TITLE
Fix pathlib tests on windows

### DIFF
--- a/h5py/tests/common.py
+++ b/h5py/tests/common.py
@@ -13,6 +13,7 @@ import sys
 import os
 import shutil
 import tempfile
+from contextlib import contextmanager
 
 from six import unichr
 
@@ -164,3 +165,20 @@ class TestCase(ut.TestCase):
                 dset[s]
 
 NUMPY_RELEASE_VERSION = tuple([int(i) for i in np.__version__.split(".")[0:2]])
+
+@contextmanager
+def closed_tempfile(suffix='', text=None):
+    """
+    Context manager which yields the path to a closed temporary file with the
+    suffix `suffix`. The file will be deleted on exiting the context. An
+    additional argument `text` can be provided to have the file contain `text`.
+    """
+    with tempfile.NamedTemporaryFile(
+        'w+t', suffix=suffix, delete=False
+    ) as test_file:
+        file_name = test_file.name
+        if text is not None:
+            test_file.write(text)
+            test_file.flush()
+    yield file_name
+    shutil.rmtree(file_name, ignore_errors=True)

--- a/h5py/tests/old/test_file.py
+++ b/h5py/tests/old/test_file.py
@@ -21,6 +21,7 @@ import tempfile
 import six
 
 from .common import ut, TestCase, unicode_filenames
+from ..common import closed_tempfile
 from h5py.highlevel import File
 import h5py
 
@@ -559,17 +560,17 @@ class TestPathlibSupport(TestCase):
     """
     def test_pathlib_accepted_file(self):
         """ Check that pathlib is accepted by h5py.File """
-        with tempfile.NamedTemporaryFile() as f:
-            path = pathlib.Path(f.name)
+        with closed_tempfile() as f:
+            path = pathlib.Path(f)
             with File(path) as f2:
                 self.assertTrue(True)
 
     def test_pathlib_name_match(self):
         """ Check that using pathlib does not affect naming """
-        with tempfile.NamedTemporaryFile() as f:
-            path = pathlib.Path(f.name)
+        with closed_tempfile() as f:
+            path = pathlib.Path(f)
             with File(path) as h5f1:
                 pathlib_name = h5f1.filename
-            with File(f.name) as h5f2:
+            with File(f) as h5f2:
                 normal_name = h5f2.filename
             self.assertEqual(pathlib_name, normal_name)


### PR DESCRIPTION
Windows does not like repeatedly opening an already open tempfile, this works around this.