### PR TITLE
Skip tests which assume unicode filenames on systems lacking them

### DIFF
--- a/h5py/tests/old/test_group.py
+++ b/h5py/tests/old/test_group.py
@@ -33,6 +33,17 @@ import h5py
 from h5py.highlevel import File, Group, SoftLink, HardLink, ExternalLink
 from h5py.highlevel import Dataset, Datatype
 from h5py import h5t
+from h5py._hl.compat import fsencode
+
+# If we can't encode unicode filenames, there's not much point failing tests
+# which must fail
+try:
+    fsencode(u"α")
+except UnicodeEncodeError:
+    NO_FS_UNICODE = True
+else:
+    NO_FS_UNICODE = False
+
 
 class BaseGroup(TestCase):
 
@@ -734,6 +745,7 @@ class TestExternalLinks(TestCase):
         f2.close()
         self.assertFalse(f2)
 
+    @ut.skipIf(NO_FS_UNICODE, "No unicode filename support")
     def test_unicode_encode(self):
         """
         Check that external links encode unicode filenames properly
@@ -744,6 +756,7 @@ class TestExternalLinks(TestCase):
             ext_file.create_group('external')
         self.f['ext'] = ExternalLink(ext_filename, '/external')
 
+    @ut.skipIf(NO_FS_UNICODE, "No unicode filename support")
     def test_unicode_decode(self):
         """
         Check that external links decode unicode filenames properly


### PR DESCRIPTION
It appears that on some windows setups with python 3, unicode paths do not work (i.e. python 3 enforces using the Windows unicode api, not the POSIX-like one), this skips tests which will fail because we can't use unicode filenames.