### PR TITLE
Don't build wheels on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -80,16 +80,18 @@ test_script:
   # to put the Python evrsion you want to use on PATH.
   - "ci\\appveyor\\build.cmd py -3.5 -m tox"
 
-after_test:
-  # This step builds your wheels.
-  # Again, you only need build.cmd if you're building C extensions for
-  # 64-bit Python 3.3/3.4. And you need to use %PYTHON% to get the correct
-  # interpreter
-  - "ci\\appveyor\\build.cmd %PYTHON%\\python.exe setup.py bdist_wheel"
-
-artifacts:
-  # bdist_wheel puts your built wheel in the dist directory
-  - path: dist\*
+# This is commented out as there's no easy way to deal with numpy dropping
+# older python versions without a recent pip/setuptools.
+#after_test:
+#  # This step builds your wheels.
+#  # Again, you only need build.cmd if you're building C extensions for
+#  # 64-bit Python 3.3/3.4. And you need to use %PYTHON% to get the correct
+#  # interpreter
+#  - "ci\\appveyor\\build.cmd %PYTHON%\\python.exe setup.py bdist_wheel"
+#
+#artifacts:
+#  # bdist_wheel puts your built wheel in the dist directory
+#  - path: dist\*
 
 cache:
   - "%LOCALAPPDATA%\\pip\\Cache"


### PR DESCRIPTION
Currently wheels were being built on appveyor. These wheels weren't designed for upload to PyPI, but were for debugging if the code built but tests failed. Since these fail to build due to numpy dropping support for older versions of Python, building these wheels doesn't have any benefits (and slow down the build).