### PR TITLE
Work around Python 2 not having surrogateescape handler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,22 @@ env:
 #  - TOXENV=py35-test-deps
 #  - TOXENV=py35-test-mindeps
 # commented out because of https://github.com/travis-ci/travis-ci/issues/4794
+  - TOXENV=py26-test-deps
+    TOX_TESTENV_PASSENV=LANG LC_ALL
+    LANG=C
+    LC_ALL=C
+  - TOXENV=py27-test-deps
+    TOX_TESTENV_PASSENV=LANG LC_ALL
+    LANG=C
+    LC_ALL=C
+  - TOXENV=py33-test-deps
+    TOX_TESTENV_PASSENV=LANG LC_ALL
+    LANG=C
+    LC_ALL=C
+  - TOXENV=py34-test-deps
+    TOX_TESTENV_PASSENV=LANG LC_ALL
+    LANG=C
+    LC_ALL=C
 
 matrix:
   include:
@@ -36,6 +52,12 @@ matrix:
     - python: 3.5
       env:
       - TOXENV=py35-test-mindeps
+    - python: 3.5
+      env:
+      - TOXENV=py35-test-deps
+        TOX_TESTENV_PASSENV=LANG LC_ALL
+        LANG=C
+        LC_ALL=C
     # parallel HDF5 test with HDF5>=1.8.9 for mpio "atomic" support
     - dist: trusty
       sudo: required

--- a/h5py/_hl/compat.py
+++ b/h5py/_hl/compat.py
@@ -48,7 +48,13 @@ def _fscodec():
     if encoding == 'mbcs':
         errors = 'strict'
     else:
-        errors = 'surrogateescape'
+        try:
+            from codecs import lookup_error
+            lookup_error('surrogateescape')
+        except LookupError:
+            errors = 'strict'
+        else:
+            errors = 'surrogateescape'
 
     def fsencode(filename):
         """


### PR DESCRIPTION
This should fix #803. I've also added additional checks to travis to test for issues when LC_ALL=C/LANG=C, which should prevent breaking on systems without unicode support.