### PR TITLE
Add What's New for h5py 2.5 and 2.6

### DIFF
--- a/docs/whatsnew/2.5.rst
+++ b/docs/whatsnew/2.5.rst
@@ -1,0 +1,62 @@
+What's new in h5py 2.5
+======================
+
+Experimental support for Single Writer Multiple Reader (SWMR)
+-------------------------------------------------------------
+
+This release introduces experimental support for the highly-anticipated
+"Single Writer Multiple Reader" (SWMR) feature in the upcoming HDF5 1.10
+release.  SWMR allows sharing of a single HDF5 file between multiple processes
+without the complexity of MPI or multiprocessing-based solutions.  
+
+This is an experimental feature that should NOT be used in production code.
+We are interested in getting feedback from the broader community with respect
+to performance and the API design.
+
+For more details, check out the h5py user guide:
+http://docs.h5py.org/en/latest/swmr.html
+
+SWMR support was contributed by Ulrik Pedersen (`#551`_).
+
+Changes
+-------
+
+* Cython warning cleanups related to `const`
+
+
+Other changes
+-------------
+* Use system Cython as a fallback if `cythonize()` fails (`#541`_ by Ulrik Pedersen)
+* Use pkg-config for builing/linking against hdf5 (`#505`_ by James Tocknell)
+* Disable building Cython on Travis (`#513`_ by Andrew Collette)
+* Add user and API docs to release tarball (`#555`_ by Ghislain Antony Vaillant)
+* Remove extra `DS_Store` files from release tarball (`#560`_ by Ghislain Antony Vaillant)
+
+* Entire code base ported to "six"; 2to3 removed from setup.py (`#508`_ by James Tocknell)
+
+* Add python 3.4 to tox (`#507`_ by James Tocknell)
+
+* Warn when importing from inside install dir (`#558`_ by Andrew Collette)
+* Tweak installation docs with reference to Anaconda and other Python package managers (`#546`_ by Andrew Collette)
+* Fix incompatible function pointer types (`#526`_, `#524`_ by Peter H. Li)
+* Add explicit `vlen is not None` check to work around https://github.com/numpy/numpy/issues/2190 (`#538` by Will Parkin)
+* Group and AttributeManager classes now inherit from the appropriate ABCs (`#527`_ by James Tocknell)
+* Don't strip metadata from special dtypes on read (`#512`_ by Antony Lee)
+* Add 'x' mode as an alias for 'w-' (`#510`_ by Antony Lee)
+* Support dynamical loading of LZF filter plugin (`#506`_ by Peter Colberg)
+* Fix accessing attributes with array type (`#501`_ by Andrew Collette)
+* Don't leak types in enum converter (`#503`_ by Andrew Collette)
+
+
+Acknowlegements
+---------------
+
+This release incorporates changes from, among others:
+
+* Ulrik Pedersen
+* James Tocknell
+* Will Parkin
+* Antony Lee
+* Peter H. Li
+* Peter Colberg
+* Ghislain Antony Vaillant

--- a/docs/whatsnew/2.5.rst
+++ b/docs/whatsnew/2.5.rst
@@ -7,7 +7,7 @@ Experimental support for Single Writer Multiple Reader (SWMR)
 This release introduces experimental support for the highly-anticipated
 "Single Writer Multiple Reader" (SWMR) feature in the upcoming HDF5 1.10
 release.  SWMR allows sharing of a single HDF5 file between multiple processes
-without the complexity of MPI or multiprocessing-based solutions.  
+without the complexity of MPI or multiprocessing-based solutions.
 
 This is an experimental feature that should NOT be used in production code.
 We are interested in getting feedback from the broader community with respect
@@ -18,45 +18,50 @@ http://docs.h5py.org/en/latest/swmr.html
 
 SWMR support was contributed by Ulrik Pedersen (`#551`_).
 
-Changes
--------
-
-* Cython warning cleanups related to `const`
-
-
 Other changes
 -------------
-* Use system Cython as a fallback if `cythonize()` fails (`#541`_ by Ulrik Pedersen)
-* Use pkg-config for builing/linking against hdf5 (`#505`_ by James Tocknell)
-* Disable building Cython on Travis (`#513`_ by Andrew Collette)
-* Add user and API docs to release tarball (`#555`_ by Ghislain Antony Vaillant)
-* Remove extra `DS_Store` files from release tarball (`#560`_ by Ghislain Antony Vaillant)
+* Use system Cython as a fallback if `cythonize()` fails (`#541`_ by Ulrik Pedersen).
+* Use pkg-config for builing/linking against hdf5 (`#505`_ by James Tocknell).
+* Disable building Cython on Travis (`#513`_ by Andrew Collette).
+* Improvements to release tarball (`#555`_, `#560`_ by Ghislain Antony
+  Vaillant).
+* h5py now has one codebase for both Python 2 and 3; 2to3 removed from setup.py
+  (`#508`_ by James Tocknell).
+* Add python 3.4 to tox (`#507`_ by James Tocknell).
+* Warn when importing from inside install dir (`#558`_ by Andrew Collette).
+* Tweak installation docs with reference to Anaconda and other Python package
+  managers (`#546`_ by Andrew Collette).
+* Fix incompatible function pointer types (`#526`_, `#524`_ by Peter H. Li).
+* Add explicit `vlen is not None` check to work around
+  https://github.com/numpy/numpy/issues/2190 (`#538` by Will Parkin).
+* Group and AttributeManager classes now inherit from the appropriate ABCs
+  (`#527`_ by James Tocknell).
+* Don't strip metadata from special dtypes on read (`#512`_ by Antony Lee).
+* Add 'x' mode as an alias for 'w-' (`#510`_ by Antony Lee).
+* Support dynamical loading of LZF filter plugin (`#506`_ by Peter Colberg).
+* Fix accessing attributes with array type (`#501`_ by Andrew Collette).
+* Don't leak types in enum converter (`#503`_ by Andrew Collette).
 
-* Entire code base ported to "six"; 2to3 removed from setup.py (`#508`_ by James Tocknell)
-
-* Add python 3.4 to tox (`#507`_ by James Tocknell)
-
-* Warn when importing from inside install dir (`#558`_ by Andrew Collette)
-* Tweak installation docs with reference to Anaconda and other Python package managers (`#546`_ by Andrew Collette)
-* Fix incompatible function pointer types (`#526`_, `#524`_ by Peter H. Li)
-* Add explicit `vlen is not None` check to work around https://github.com/numpy/numpy/issues/2190 (`#538` by Will Parkin)
-* Group and AttributeManager classes now inherit from the appropriate ABCs (`#527`_ by James Tocknell)
-* Don't strip metadata from special dtypes on read (`#512`_ by Antony Lee)
-* Add 'x' mode as an alias for 'w-' (`#510`_ by Antony Lee)
-* Support dynamical loading of LZF filter plugin (`#506`_ by Peter Colberg)
-* Fix accessing attributes with array type (`#501`_ by Andrew Collette)
-* Don't leak types in enum converter (`#503`_ by Andrew Collette)
-
+.. _`#551` : https://github.com/h5py/h5py/pull/551
+.. _`#541` : https://github.com/h5py/h5py/pull/541
+.. _`#505` : https://github.com/h5py/h5py/pull/505
+.. _`#513` : https://github.com/h5py/h5py/pull/513
+.. _`#555` : https://github.com/h5py/h5py/pull/555
+.. _`#560` : https://github.com/h5py/h5py/pull/560
+.. _`#508` : https://github.com/h5py/h5py/pull/508
+.. _`#507` : https://github.com/h5py/h5py/pull/507
+.. _`#558` : https://github.com/h5py/h5py/pull/558
+.. _`#546` : https://github.com/h5py/h5py/pull/546
+.. _`#526` : https://github.com/h5py/h5py/pull/526
+.. _`#524` : https://github.com/h5py/h5py/pull/524
+.. _`#538` : https://github.com/h5py/h5py/pull/538
+.. _`#527` : https://github.com/h5py/h5py/pull/527
+.. _`#512` : https://github.com/h5py/h5py/pull/512
+.. _`#510` : https://github.com/h5py/h5py/pull/510
+.. _`#506` : https://github.com/h5py/h5py/pull/506
+.. _`#501` : https://github.com/h5py/h5py/pull/501
+.. _`#503` : https://github.com/h5py/h5py/pull/503
 
 Acknowlegements
 ---------------
 
-This release incorporates changes from, among others:
-
-* Ulrik Pedersen
-* James Tocknell
-* Will Parkin
-* Antony Lee
-* Peter H. Li
-* Peter Colberg
-* Ghislain Antony Vaillant

--- a/docs/whatsnew/2.6.rst
+++ b/docs/whatsnew/2.6.rst
@@ -1,0 +1,90 @@
+What's new in h5py 2.6
+======================
+
+Support for HDF5 Virtual Dataset API
+------------------------------------
+Initial support for the HDF5 Virtual Dataset API, which was introduced in
+HDF5 1.10, was added to the low-level API. Ideas and input for how this should
+work as part of the high-level interface are welcome.
+
+This work was added in `#663`_ by Aleksandar Jelenak.
+
+Add MPI Collective I/O Support
+------------------------------
+(`#648`_ by Jialin Liu)
+
+Numerous build/testing/CI improvements
+--------------------------------------
+There were a number of improvements to the setup.py file, which should mean that
+`pip install h5py` should work in most places. Work was also done to clean up
+the current testing system, using tox is the recommended way of testing h5py
+across different Python versions. See `#576`_ by Jakob Lombacher, `#640`_ by
+Lawrence Mitchell, and `#650`_, `#651`_ and `#658`_ by James Tocknell.
+
+Cleanup of codebase based on pylint
+-----------------------------------
+There was a large cleanup of pylint-identified problems by Andrew Collette
+(`#578`_, `#579`_).
+
+Fixes to low-level API
+----------------------
+* Correct return types on attribute open low-level API functions (`#597`_ by Ulrik Kofoed Pedersen)
+* Correct return type of `H5Pget_class` (`#589`_ by Peter Chang)
+* Construct Python dtype with correct offsets for compound types (`#639`_ by @nevion)
+* Fix hid_t typing in Cython (`#625`_ by Spaghetti Sort)
+* Fix enumeration within variable-length arrays (`#621`_ by Sam Mason)
+* Use correct destination type when committing (`#614`_ by Andrew Collette)
+* Add support for assigning a vector to a component of a compound dataset (`#606`_ by Yu Feng)
+
+Documentation improvements
+--------------------------
+* Update FAQ section on variable length arrays (`#608`_ by Dan Guest)
+* Update list of supported types in FAQ (`#607`_ by Peter Hill)
+* Update MPI setup instructions (`#604`_ by Jens Timmerman)
+* Update MPI example (`#572`_ by Matthias König)
+* Update PyTables link (`#574`_ by Dominik Kriegner)
+* Add File opening modes to docstring (`#563`_ by Antony Lee)
+* Fix apidoc build on Python 3 (`#562`_ by Ghislain Antony Vaillant)
+* Fix shipping doc build in release tarball (`#561`_ by Ghislain Antony Vaillant)
+
+Other changes
+-------------
+* Add `Dataset.ndim` (`#649`_, `#660`_ by @jakirkham, `#661`_ by James Tocknell)
+* Fix import errors in IPython completer (`#605`_ by Niru Maheswaranathan)
+* Turn off error printing in new threads (`#583`_ by Andrew Collette)
+* Use item value in `KeyError` instead of error message (`#642`_ by Matthias Geier)
+
+
+.. _`#561` : https://github.com/h5py/h5py/pull/561
+.. _`#562` : https://github.com/h5py/h5py/pull/562
+.. _`#563` : https://github.com/h5py/h5py/pull/563
+.. _`#572` : https://github.com/h5py/h5py/pull/572
+.. _`#574` : https://github.com/h5py/h5py/pull/574
+.. _`#576` : https://github.com/h5py/h5py/pull/576
+.. _`#578` : https://github.com/h5py/h5py/pull/578
+.. _`#579` : https://github.com/h5py/h5py/pull/579
+.. _`#583` : https://github.com/h5py/h5py/pull/583
+.. _`#589` : https://github.com/h5py/h5py/pull/589
+.. _`#597` : https://github.com/h5py/h5py/pull/597
+.. _`#604` : https://github.com/h5py/h5py/pull/604
+.. _`#605` : https://github.com/h5py/h5py/pull/605
+.. _`#606` : https://github.com/h5py/h5py/pull/606
+.. _`#607` : https://github.com/h5py/h5py/pull/607
+.. _`#608` : https://github.com/h5py/h5py/pull/608
+.. _`#614` : https://github.com/h5py/h5py/pull/614
+.. _`#621` : https://github.com/h5py/h5py/pull/621
+.. _`#625` : https://github.com/h5py/h5py/pull/625
+.. _`#639` : https://github.com/h5py/h5py/pull/639
+.. _`#640` : https://github.com/h5py/h5py/pull/640
+.. _`#642` : https://github.com/h5py/h5py/pull/642
+.. _`#648` : https://github.com/h5py/h5py/pull/648
+.. _`#649` : https://github.com/h5py/h5py/pull/649
+.. _`#650` : https://github.com/h5py/h5py/pull/650
+.. _`#651` : https://github.com/h5py/h5py/pull/651
+.. _`#658` : https://github.com/h5py/h5py/pull/658
+.. _`#660` : https://github.com/h5py/h5py/pull/660
+.. _`#661` : https://github.com/h5py/h5py/pull/661
+.. _`#663` : https://github.com/h5py/h5py/pull/663
+
+Acknowlegements
+---------------

--- a/docs/whatsnew/2.6.rst
+++ b/docs/whatsnew/2.6.rst
@@ -11,7 +11,11 @@ This work was added in `#663`_ by Aleksandar Jelenak.
 
 Add MPI Collective I/O Support
 ------------------------------
-(`#648`_ by Jialin Liu)
+Support for using MPI Collective I/O in both low-level and high-level code has
+been added. See the collective_io.py example for a simple demonstration of how
+to use MPI Collective I/O with the high level API.
+
+This work was added in `#648`_ by Jialin Liu.
 
 Numerous build/testing/CI improvements
 --------------------------------------
@@ -28,24 +32,21 @@ There was a large cleanup of pylint-identified problems by Andrew Collette
 
 Fixes to low-level API
 ----------------------
-* Correct return types on attribute open low-level API functions (`#597`_ by Ulrik Kofoed Pedersen)
-* Correct return type of `H5Pget_class` (`#589`_ by Peter Chang)
-* Construct Python dtype with correct offsets for compound types (`#639`_ by @nevion)
-* Fix hid_t typing in Cython (`#625`_ by Spaghetti Sort)
-* Fix enumeration within variable-length arrays (`#621`_ by Sam Mason)
-* Use correct destination type when committing (`#614`_ by Andrew Collette)
-* Add support for assigning a vector to a component of a compound dataset (`#606`_ by Yu Feng)
+Fixes to the typing of functions were added in `#597`_ by Ulrik Kofoed
+Pedersen, `#589`_ by Peter Chang, and `#625`_ by Spaghetti Sort. A fix for
+variable-length arrays was added in `#621`_ by Sam Mason. Fixes to compound
+types were added in `#639`_ by @nevion and `#606`_ by Yu Feng. Finally, a fix
+to type conversion was added in `#614`_ by Andrew Collette.
 
 Documentation improvements
 --------------------------
-* Update FAQ section on variable length arrays (`#608`_ by Dan Guest)
-* Update list of supported types in FAQ (`#607`_ by Peter Hill)
-* Update MPI setup instructions (`#604`_ by Jens Timmerman)
-* Update MPI example (`#572`_ by Matthias König)
+* Updates to FAQ by Dan Guest (`#608`_) and Peter Hill (`#607`_).
+* Updates MPI-releated documentation by Jens Timmerman (`#604`_) and
+  Matthias König (`#572`_).
+* Fixes to documentation building by Ghislain Antony Vaillant (`#562`_,
+  `#561`_).
 * Update PyTables link (`#574`_ by Dominik Kriegner)
 * Add File opening modes to docstring (`#563`_ by Antony Lee)
-* Fix apidoc build on Python 3 (`#562`_ by Ghislain Antony Vaillant)
-* Fix shipping doc build in release tarball (`#561`_ by Ghislain Antony Vaillant)
 
 Other changes
 -------------

--- a/docs/whatsnew/index.rst
+++ b/docs/whatsnew/index.rst
@@ -8,6 +8,8 @@ These document the changes between minor (or major) versions of h5py.
 
 .. toctree::
 
+    2.6
+    2.5
     2.4
     2.3
     2.2


### PR DESCRIPTION
This adds "What's New" for h5py 2.5 and 2.6, since they don't exist. They're based on pull requests between 2.4 and 2.5, and 2.5 and 2.6 respectively. If I've missed anything, comment and I'll fix it. Closes #571. The format isn't set in stone, I've tried basing it on previous ones, but including links to the pull requests.