### PR TITLE
Update classifiers to include supported python version and interpreters

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,16 @@ Intended Audience :: Developers
 Intended Audience :: Information Technology
 Intended Audience :: Science/Research
 License :: OSI Approved :: BSD License
+Programming Language :: Cython
 Programming Language :: Python
+Programming Language :: Python :: 2
+Programming Language :: Python :: 2.6
+Programming Language :: Python :: 2.7
+Programming Language :: Python :: 3
+Programming Language :: Python :: 3.3
+Programming Language :: Python :: 3.4
+Programming Language :: Python :: 3.5
+Programming Language :: Python :: Implementation :: CPython
 Topic :: Scientific/Engineering
 Topic :: Database
 Topic :: Software Development :: Libraries :: Python Modules


### PR DESCRIPTION
Fixes #810, doesn't include python 3.2 (as we dropped it) or python 3.6 (as we haven't started testing on it), but includes pythons 2.6, 2.7, 3.3-3.5.

Also adds Cython classifier (as other Cython-using projects do, e.g. pandas), and CPython interpreter classifier.