### PR TITLE
Add H5T_NATIVE_B8 -> bool support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -149,9 +149,6 @@ matrix:
             - libhdf5-openmpi-dev # 1.8.11 based on trusty
 
     # PyTables compatibility tests
-    - python: 2.7
-      env:
-      - TOXENV=py27-test-mindeps-tables
     - python: 3.7
       env:
       - TOXENV=py37-test-mindeps-tables

--- a/.travis.yml
+++ b/.travis.yml
@@ -148,6 +148,14 @@ matrix:
             - libopenmpi-dev
             - libhdf5-openmpi-dev # 1.8.11 based on trusty
 
+    # PyTables compatibility tests
+    - python: 2.7
+      env:
+      - TOXENV=py27-test-mindeps-tables
+    - python: 3.7
+      env:
+      - TOXENV=py37-test-mindeps-tables
+
     # Additional python versions which are not officially supported
     - python: "nightly"
       env:

--- a/h5py/_conv.pyx
+++ b/h5py/_conv.pyx
@@ -821,6 +821,19 @@ cdef herr_t boolenum2b8(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata,
     return 0
 
 # =============================================================================
+# B8 to UINT8 routines
+
+cdef herr_t b82uint8(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata,
+                     size_t nl, size_t buf_stride, size_t bkg_stride, void *buf_i,
+                     void *bkg_i, hid_t dxpl) except -1:
+    return 0
+
+cdef herr_t uint82b8(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata,
+                     size_t nl, size_t buf_stride, size_t bkg_stride, void *buf_i,
+                     void *bkg_i, hid_t dxpl) except -1:
+    return 0
+
+# =============================================================================
 
 cpdef int register_converters() except -1:
 
@@ -866,6 +879,9 @@ cpdef int register_converters() except -1:
     H5Tregister(H5T_PERS_HARD, "boolenum2b8", boolenum, H5T_NATIVE_B8, boolenum2b8)
     H5Tregister(H5T_PERS_HARD, "b82boolenum", H5T_NATIVE_B8, boolenum, b82boolenum)
 
+    H5Tregister(H5T_PERS_HARD, "uint82b8", H5T_NATIVE_UINT8, H5T_NATIVE_B8, uint82b8)
+    H5Tregister(H5T_PERS_HARD, "b82uint8", H5T_NATIVE_B8, H5T_NATIVE_UINT8, b82uint8)
+
     H5Tclose(vlstring)
     H5Tclose(vlentype)
     H5Tclose(enum)
@@ -895,5 +911,8 @@ cpdef int unregister_converters() except -1:
 
     H5Tunregister(H5T_PERS_HARD, "boolenum2b8", -1, -1, boolenum2b8)
     H5Tunregister(H5T_PERS_HARD, "b82boolenum", -1, -1, b82boolenum)
+
+    H5Tunregister(H5T_PERS_HARD, "uint82b8", -1, -1, uint82b8)
+    H5Tunregister(H5T_PERS_HARD, "b82uint8", -1, -1, b82uint8)
 
     return 0

--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -784,19 +784,12 @@ cdef class TypeTimeID(TypeID):
     """
     pass
 
-
 cdef class TypeBitfieldID(TypeID):
 
     """
         HDF5 bitfield type
     """
-
-    cdef object py_dtype(self):
-        if H5Tequal(self.id, H5T_NATIVE_B8):
-            return dtype('?')
-        else:
-            raise TypeError("No NumPy equivalent for %s exists" % self.__class__.__name__)
-
+    pass
 
 cdef class TypeReferenceID(TypeID):
 

--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -784,12 +784,19 @@ cdef class TypeTimeID(TypeID):
     """
     pass
 
+
 cdef class TypeBitfieldID(TypeID):
 
     """
         HDF5 bitfield type
     """
-    pass
+
+    cdef object py_dtype(self):
+        if H5Tequal(self.id, H5T_NATIVE_B8):
+            return dtype('?')
+        else:
+            raise TypeError("No NumPy equivalent for %s exists" % self.__class__.__name__)
+
 
 cdef class TypeReferenceID(TypeID):
 

--- a/h5py/tests/hl/test_datatype.py
+++ b/h5py/tests/hl/test_datatype.py
@@ -308,7 +308,7 @@ class TestB8Bool(TestCase):
 
     def _test_b8(self, arr1):
         path = self.mktemp()
-        with tables.open_file(path, 'a') as f:
+        with tables.open_file(path, 'w') as f:
             if arr1.dtype.names:
                 f.create_table('/', 'test', obj=arr1)
             else:

--- a/h5py/tests/hl/test_datatype.py
+++ b/h5py/tests/hl/test_datatype.py
@@ -316,5 +316,20 @@ class TestB8Bool(TestCase):
 
         with h5py.File(path, 'r') as f:
             dset = f['test']
-            arr2 = dset[:]
+
+            # read uncast dset to make sure it raises as before
+            with self.assertRaises(
+                TypeError, msg='No NumPy equivalent for TypeBitfieldID exists'
+            ):
+                dset[:]
+
+            # read cast dset and make sure it's equal
+            with dset.astype(arr1.dtype):
+                arr2 = dset[:]
             self.assertArrayEqual(arr1, arr2)
+
+            # read uncast dataset again to ensure nothing changed permanantly
+            with self.assertRaises(
+                TypeError, msg='No NumPy equivalent for TypeBitfieldID exists'
+            ):
+                dset[:]

--- a/h5py/tests/hl/test_datatype.py
+++ b/h5py/tests/hl/test_datatype.py
@@ -316,20 +316,5 @@ class TestB8Bool(TestCase):
 
         with h5py.File(path, 'r') as f:
             dset = f['test']
-
-            # read uncast dset to make sure it raises as before
-            with self.assertRaises(
-                TypeError, msg='No NumPy equivalent for TypeBitfieldID exists'
-            ):
-                dset[:]
-
-            # read cast dset and make sure it's equal
-            with dset.astype(arr1.dtype):
-                arr2 = dset[:]
+            arr2 = dset[:]
             self.assertArrayEqual(arr1, arr2)
-
-            # read uncast dataset again to ensure nothing changed permanantly
-            with self.assertRaises(
-                TypeError, msg='No NumPy equivalent for TypeBitfieldID exists'
-            ):
-                dset[:]

--- a/tox.ini
+++ b/tox.ini
@@ -6,20 +6,32 @@ envlist = {py27,py34,py35,py36,py37,pypy3}-{test}-{deps,mindeps},nightly,docs,ch
 
 [testenv]
 deps =
+    test: pytest
+    test: pytest-cov
     py27-test: unittest2
+
     py{27,34,35,36}-deps: cython>=0.23
-    py37-deps: cython>=0.28
-    py{27,34,35,36,37}-deps: numpy>=1.7
-    mindeps: cython==0.23
+    py37-deps: cython>=0.27.2
+
+    py27-deps: numpy>=1.7
+    py34-deps: numpy>=1.9
+    py35-deps: numpy>=1.10.0.post2
+    py36-deps: numpy>=1.12
+    py37-deps: numpy>=1.12
+
+    py{27,34,35,36}-mindeps: cython==0.23
+    py37-mindeps: cython==0.27.2
+
     py27-mindeps: numpy==1.7
     py34-mindeps: numpy==1.9
     py35-mindeps: numpy==1.10.0.post2
     py36-mindeps: numpy==1.12
     py37-mindeps: numpy==1.12
+
     mpi4py: mpi4py>=1.3.1
-    test: pytest
-    test: pytest-cov
+
     tables: tables>=3.5.1
+
 commands =
     test: python {toxinidir}/ci/fix_paths.py {envsitepackagesdir}
     test: python -m pytest --pyargs h5py --cov={envsitepackagesdir}/h5py --cov-config={toxinidir}/.coveragerc {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     py27-test: unittest2
 
     py{27,34,35,36}-deps: cython>=0.23
-    py37-deps: cython>=0.27.2
+    py37-deps: cython>=0.27.3
 
     py27-deps: numpy>=1.7
     py34-deps: numpy>=1.9
@@ -20,7 +20,7 @@ deps =
     py37-deps: numpy>=1.12
 
     py{27,34,35,36}-mindeps: cython==0.23
-    py37-mindeps: cython==0.27.2
+    py37-mindeps: cython==0.27.3
 
     py27-mindeps: numpy==1.7
     py34-mindeps: numpy==1.9

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     py27-test: unittest2
 
     py{27,34,35,36}-deps: cython>=0.23
-    py37-deps: cython>=0.27.3
+    py37-deps: cython>=0.29
 
     py27-deps: numpy>=1.7
     py34-deps: numpy>=1.9
@@ -20,7 +20,7 @@ deps =
     py37-deps: numpy>=1.12
 
     py{27,34,35,36}-mindeps: cython==0.23
-    py37-mindeps: cython==0.27.3
+    py37-mindeps: cython==0.29
 
     py27-mindeps: numpy==1.7
     py34-mindeps: numpy==1.9

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps =
     py34-deps: numpy>=1.9
     py35-deps: numpy>=1.10.0.post2
     py36-deps: numpy>=1.12
-    py37-deps: numpy>=1.12
+    py37-deps: numpy>=1.14.3
 
     py{27,34,35,36}-mindeps: cython==0.23
     py37-mindeps: cython==0.29
@@ -26,11 +26,12 @@ deps =
     py34-mindeps: numpy==1.9
     py35-mindeps: numpy==1.10.0.post2
     py36-mindeps: numpy==1.12
-    py37-mindeps: numpy==1.12
+    py37-mindeps: numpy==1.14.3
 
     mpi4py: mpi4py>=1.3.1
 
-    tables: tables>=3.5.1
+    tables-deps: tables>=3.4.4
+    tables-mindeps: tables==3.4.4
 
 commands =
     test: python {toxinidir}/ci/fix_paths.py {envsitepackagesdir}

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ deps =
     mpi4py: mpi4py>=1.3.1
     test: pytest
     test: pytest-cov
+    tables: tables
 commands =
     test: python {toxinidir}/ci/fix_paths.py {envsitepackagesdir}
     test: python -m pytest --pyargs h5py --cov={envsitepackagesdir}/h5py --cov-config={toxinidir}/.coveragerc {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,8 @@ envlist = {py27,py34,py35,py36,py37,pypy3}-{test}-{deps,mindeps},nightly,docs,ch
 [testenv]
 deps =
     py27-test: unittest2
-    deps: cython>=0.23
+    py{27,34,35,36}-deps: cython>=0.23
+    py37-deps: cython>=0.28
     py{27,34,35,36,37}-deps: numpy>=1.7
     mindeps: cython==0.23
     py27-mindeps: numpy==1.7
@@ -18,7 +19,7 @@ deps =
     mpi4py: mpi4py>=1.3.1
     test: pytest
     test: pytest-cov
-    tables: tables
+    tables: tables>=3.5.1
 commands =
     test: python {toxinidir}/ci/fix_paths.py {envsitepackagesdir}
     test: python -m pytest --pyargs h5py --cov={envsitepackagesdir}/h5py --cov-config={toxinidir}/.coveragerc {posargs}


### PR DESCRIPTION
This adds `H5T_NATIVE_B8` -> `bool` support. The primary motivation for this is PyTables interop (they encode bools as 0/1 in a `H5T_NATIVE_B8` field).

A new `b8_to_bool` flag is added to the `H5PYConfig` object to enable this feature. It's off by default to preserve the old exception-raising behavior in case anyone relies on that. If we don't care about preserving that we can set it to True by default.

Comments are welcome. This is my first time working with the h5py source so it's possible I'm doing something unconventional.

Addresses #641