### PR TITLE
Fix version_tuple to make it PEP440 compliant

### DIFF
--- a/h5py/version.py
+++ b/h5py/version.py
@@ -13,22 +13,30 @@
 
 from __future__ import absolute_import
 
+from collections import namedtuple
 from . import h5 as _h5
-from distutils.version import StrictVersion as _sv
 import sys
 import numpy
 
-version = "2.7.0rc3"
+# All should be integers, except pre, as validating versions is more than is
+# needed for our use case
+_H5PY_VERSION_CLS = namedtuple("_H5PY_VERSION_CLS", "major minor bugfix pre post dev")
 
-_exp = _sv(version)
+version_tuple = _H5PY_VERSION_CLS(2, 7, 0, "rc3", None, None)
 
-version_tuple = _exp.version + ((''.join(str(x) for x in _exp.prerelease),) if _exp.prerelease is not None else ('',))
+version = "{0.major:d}.{0.minor:d}.{0.bugfix:d}".format(version_tuple)
+if version_tuple.pre is not None:
+    version += version_tuple.pre
+if version_tuple.post is not None:
+    version += ".post{0.post:d}".format(version_tuple)
+if version_tuple.dev is not None:
+    version += ".dev{0.dev:d}".format(version_tuple)
 
 hdf5_version_tuple = _h5.get_libversion()
 hdf5_version = "%d.%d.%d" % hdf5_version_tuple
 
 api_version_tuple = (1,8)
-api_version = "1.8"
+api_version = "%d.%d" % api_version_tuple
 
 info = """\
 Summary of the h5py configuration


### PR DESCRIPTION
Fixes #834. We could switch to https://github.com/warner/python-versioneer, which would simplify releases, and actually validate versions (unlike what I've done), but that's a decision for after 2.7 is released.