### PR TITLE
Fix encoding error on Windows with Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ env:
   - TOXENV=py34-test-mindeps
 #  - TOXENV=py35-test-deps
 #  - TOXENV=py35-test-mindeps
+#  - TOXENV=py36-test-deps
+#  - TOXENV=py36-test-mindeps
 # commented out because of https://github.com/travis-ci/travis-ci/issues/4794
   - TOXENV=py26-test-deps
     TOX_TESTENV_PASSENV=LANG LC_ALL
@@ -55,6 +57,18 @@ matrix:
     - python: 3.5
       env:
       - TOXENV=py35-test-deps
+        TOX_TESTENV_PASSENV=LANG LC_ALL
+        LANG=C
+        LC_ALL=C
+    - python: 3.6
+      env:
+      - TOXENV=py36-test-deps
+    - python: 3.6
+      env:
+      - TOXENV=py36-test-mindeps
+    - python: 3.6
+      env:
+      - TOXENV=py36-test-deps
         TOX_TESTENV_PASSENV=LANG LC_ALL
         LANG=C
         LC_ALL=C

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,12 @@ environment:
       HDF5_VSVERSION: "14"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
 
+    - PYTHON: "C:\\Python36"
+      TOXENV: "py35-test-deps"
+      TOXPYTHON: "%PYTHON%\\python.exe"
+      HDF5_VSVERSION: "14"
+      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
+
     - PYTHON: "C:\\Python27-x64"
       TOXENV: "py27-test-deps"
       TOXPYTHON: "%PYTHON%\\python.exe"
@@ -61,7 +67,7 @@ environment:
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
 
     - PYTHON: "C:\\Python36-x64"
-      TOXENV: "py36-test-deps"
+      TOXENV: "py35-test-deps"
       TOXPYTHON: "%PYTHON%\\python.exe"
       HDF5_VSVERSION: "14-64"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,6 +60,12 @@ environment:
       HDF5_VSVERSION: "14-64"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
 
+    - PYTHON: "C:\\Python36-x64"
+      TOXENV: "py36-test-deps"
+      TOXPYTHON: "%PYTHON%\\python.exe"
+      HDF5_VSVERSION: "14-64"
+      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
+
 install:
   # We need wheel installed to build wheels
   - "%PYTHON%\\python.exe -m pip install --upgrade wheel pip setuptools"

--- a/h5py/_hl/compat.py
+++ b/h5py/_hl/compat.py
@@ -39,60 +39,87 @@ except ImportError:
             raise TypeError("expected str, bytes or os.PathLike object, not "
                             + path_type.__name__)
 
-# This is from python 3.5 stdlib (hence lacks PEP 519 changes)
-# This was introduced into python 3.2, so python < 3.2 does not have this
-# Effectively, this is only required for python 2.6 and 2.7, and can be removed
-# once support for them is dropped
-def _fscodec():
-    encoding = sys.getfilesystemencoding()
-    if encoding == 'mbcs':
-        errors = 'strict'
-    else:
-        try:
-            from codecs import lookup_error
-            lookup_error('surrogateescape')
-        except LookupError:
+            
+try:
+    from os import fsencode as os_fsencode
+    from os import fsdecode as os_fsdecode
+except ImportError:
+    # This is from python 3.5 stdlib (hence lacks PEP 519 changes)
+    # This was introduced into python 3.2, so python < 3.2 does not have this
+    # Effectively, this is only required for python 2.6 and 2.7, and can be removed
+    # once support for them is dropped
+    def _fscodec():
+        encoding = sys.getfilesystemencoding()
+        if encoding == 'mbcs':
             errors = 'strict'
         else:
-            errors = 'surrogateescape'
+            try:
+                from codecs import lookup_error
+                lookup_error('surrogateescape')
+            except LookupError:
+                errors = 'strict'
+            else:
+                errors = 'surrogateescape'
 
+        def fsencode(filename):
+            """
+            Encode filename to the filesystem encoding with 'surrogateescape' error
+            handler, return bytes unchanged. On Windows, use 'strict' error handler if
+            the file system encoding is 'mbcs' (which is the default encoding).
+            """
+            if isinstance(filename, six.binary_type):
+                return filename
+            elif isinstance(filename, six.text_type):
+                return filename.encode(encoding, errors)
+            else:
+                raise TypeError("expect bytes or str, not %s" % type(filename).__name__)
+
+        def fsdecode(filename):
+            """
+            Decode filename from the filesystem encoding with 'surrogateescape' error
+            handler, return str unchanged. On Windows, use 'strict' error handler if
+            the file system encoding is 'mbcs' (which is the default encoding).
+            """
+            if isinstance(filename, six.text_type):
+                return filename
+            elif isinstance(filename, six.binary_type):
+                return filename.decode(encoding, errors)
+            else:
+                raise TypeError("expect bytes or str, not %s" % type(filename).__name__)
+
+        return fsencode, fsdecode
+
+    os_fsencode, os_fsdecode = _fscodec()
+    del _fscodec
+
+# Python 3.6 change Windows encoding to UTF-8 (See PEP 529) but HDF library still use 'mcbs'
+if sys.platform == 'win32' and sys.version_info.major >= 3 and sys.version_info.minor >= 6:
+    # This is from python 3.6.0 stdlib, with encoding and errors changed to 'mbcs' and 'strict'
     def fsencode(filename):
+        """Encode filename (an os.PathLike, bytes, or str) to the filesystem
+        encoding with 'surrogateescape' error handler, return bytes unchanged.
+        On Windows, use 'strict' error handler if the file system encoding is
+        'mbcs' (which is the default encoding).
         """
-        Encode filename to the filesystem encoding with 'surrogateescape' error
-        handler, return bytes unchanged. On Windows, use 'strict' error handler if
-        the file system encoding is 'mbcs' (which is the default encoding).
-        """
-        if isinstance(filename, six.binary_type):
-            return filename
-        elif isinstance(filename, six.text_type):
-            return filename.encode(encoding, errors)
+        filename = fspath(filename)  # Does type-checking of `filename`.
+        if isinstance(filename, str):
+            return filename.encode('mbcs', 'strict')
         else:
-            raise TypeError("expect bytes or str, not %s" % type(filename).__name__)
+            return filename
 
     def fsdecode(filename):
+        """Decode filename (an os.PathLike, bytes, or str) from the filesystem
+        encoding with 'surrogateescape' error handler, return str unchanged. On
+        Windows, use 'strict' error handler if the file system encoding is
+        'mbcs' (which is the default encoding).
         """
-        Decode filename from the filesystem encoding with 'surrogateescape' error
-        handler, return str unchanged. On Windows, use 'strict' error handler if
-        the file system encoding is 'mbcs' (which is the default encoding).
-        """
-        if isinstance(filename, six.text_type):
-            return filename
-        elif isinstance(filename, six.binary_type):
-            return filename.decode(encoding, errors)
+        filename = fspath(filename)  # Does type-checking of `filename`.
+        if isinstance(filename, bytes):
+            return filename.decode('mbcs', 'strict')
         else:
-            raise TypeError("expect bytes or str, not %s" % type(filename).__name__)
+            return filename
 
-    return fsencode, fsdecode
-
-_fsencode, _fsdecode = _fscodec()
-del _fscodec
-
-try:
-    from os import fsencode
-except ImportError:
-    fsencode = _fsencode
-
-try:
-    from os import fsdecode
-except ImportError:
-    fsdecode = _fsdecode
+# In all other cases, use stdlib os.fsencode/os.fsdecode
+else:
+    fsencode = os_fsencode
+    fsdecode = os_fsdecode

--- a/h5py/tests/hl/test_file.py
+++ b/h5py/tests/hl/test_file.py
@@ -83,7 +83,7 @@ class TestDealloc(TestCase):
         # bad filename in dir if encoding error
         f = h5py.File(os.path.join(tmpdir, in_filename), 'w')
         f.close()
-        out_filename = os.listdir(tmpdir)
+        out_filename = os.listdir(tmpdir)[0]
         self.assertEqual(in_filename, out_filename)  
         
         # Use the same file with correct filename for read test

--- a/h5py/tests/hl/test_file.py
+++ b/h5py/tests/hl/test_file.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org
@@ -67,3 +69,29 @@ class TestDealloc(TestCase):
         
         self.assertEqual(nfiles(), start_nfiles)
         self.assertEqual(ngroups(), start_ngroups)
+        
+    def test_fileencoding(self):
+        """Test file encoding with non ASCII characters
+        (See issue #818 with Python 3.6 and PEP529 on Windows)"""
+        from tempfile import mkdtemp
+        import os
+
+        tmpdir = mkdtemp()
+        in_filename = 'test_é.h5'
+        
+        # Write Test
+        # bad filename in dir if encoding error
+        f = h5py.File(os.path.join(tmpdir, in_filename), 'w')
+        f.close()
+        out_filename = os.listdir(tmpdir)
+        self.assertEqual(in_filename, out_filename)  
+        
+        # Use the same file with correct filename for read test
+        if in_filename != out_filename:
+            os.rename(os.path.join(tmpdir, out_filename),
+                      os.path.join(tmpdir, in_filename))
+
+        # Read Test : 
+        # Raise Exception if encoding error
+        f = h5py.File(in_filename, 'r')
+        f.close()

--- a/h5py/tests/hl/test_file.py
+++ b/h5py/tests/hl/test_file.py
@@ -78,20 +78,20 @@ class TestDealloc(TestCase):
 
         tmpdir = mkdtemp()
         in_filename = 'test_é.h5'
+        in_filepath = os.path.join(tmpdir, in_filename)
         
         # Write Test
         # bad filename in dir if encoding error
-        f = h5py.File(os.path.join(tmpdir, in_filename), 'w')
+        f = h5py.File(in_filepath, 'w')
         f.close()
         out_filename = os.listdir(tmpdir)[0]
         self.assertEqual(in_filename, out_filename)  
         
         # Use the same file with correct filename for read test
         if in_filename != out_filename:
-            os.rename(os.path.join(tmpdir, out_filename),
-                      os.path.join(tmpdir, in_filename))
+            os.rename(os.path.join(tmpdir, out_filename), in_filepath)
 
         # Read Test : 
         # Raise Exception if encoding error
-        f = h5py.File(in_filename, 'r')
+        f = h5py.File(in_filepath, 'r')
         f.close()

--- a/h5py/tests/hl/test_file.py
+++ b/h5py/tests/hl/test_file.py
@@ -77,7 +77,7 @@ class TestDealloc(TestCase):
         import os
 
         tmpdir = mkdtemp()
-        in_filename = 'test_é.h5'
+        in_filename = u'test_é.h5'
         in_filepath = os.path.join(tmpdir, in_filename)
         
         # Write Test

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ deps =
 
 [testenv:py36-test-mindeps]
 deps =
-    numpy==1.10.0.post2
+    numpy==1.12
     cython==0.19
 
 [testenv:py34-test-mpi4py]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py26,py27,py33,py34,py35,pypy}-{test}-{deps,mindeps}
+envlist = {py26,py27,py33,py34,py35,py36,pypy}-{test}-{deps,mindeps}
 
 [testenv]
 deps =
@@ -22,6 +22,7 @@ basepython =
     py33: {env:TOXPYTHON:python3.3}
     py34: {env:TOXPYTHON:python3.4}
     py35: {env:TOXPYTHON:python3.5}
+    py36: {env:TOXPYTHON:python3.6}
 
 [testenv:py26-test-deps]
 deps =
@@ -51,6 +52,11 @@ deps =
     cython==0.19
 
 [testenv:py35-test-mindeps]
+deps =
+    numpy==1.10.0.post2
+    cython==0.19
+
+[testenv:py36-test-mindeps]
 deps =
     numpy==1.10.0.post2
     cython==0.19


### PR DESCRIPTION
Fix for #818 

And tried to add Python 3.6 to AppVeyor test.