### PR TITLE
Add python 3.6 to tests, CIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ env:
   - TOXENV=py34-test-mindeps
 #  - TOXENV=py35-test-deps
 #  - TOXENV=py35-test-mindeps
+#  - TOXENV=py36-test-deps
+#  - TOXENV=py36-test-mindeps
 # commented out because of https://github.com/travis-ci/travis-ci/issues/4794
   - TOXENV=py26-test-deps
     TOX_TESTENV_PASSENV=LANG LC_ALL
@@ -55,6 +57,18 @@ matrix:
     - python: 3.5
       env:
       - TOXENV=py35-test-deps
+        TOX_TESTENV_PASSENV=LANG LC_ALL
+        LANG=C
+        LC_ALL=C
+    - python: 3.6
+      env:
+      - TOXENV=py36-test-deps
+    - python: 3.6
+      env:
+      - TOXENV=py36-test-mindeps
+    - python: 3.6
+      env:
+      - TOXENV=py36-test-deps
         TOX_TESTENV_PASSENV=LANG LC_ALL
         LANG=C
         LC_ALL=C

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,12 @@ environment:
       HDF5_VSVERSION: "14"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
 
+    - PYTHON: "C:\\Python36"
+      TOXENV: "py35-test-deps"
+      TOXPYTHON: "%PYTHON%\\python.exe"
+      HDF5_VSVERSION: "14"
+      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
+
     - PYTHON: "C:\\Python27-x64"
       TOXENV: "py27-test-deps"
       TOXPYTHON: "%PYTHON%\\python.exe"
@@ -55,6 +61,12 @@ environment:
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
 
     - PYTHON: "C:\\Python35-x64"
+      TOXENV: "py35-test-deps"
+      TOXPYTHON: "%PYTHON%\\python.exe"
+      HDF5_VSVERSION: "14-64"
+      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
+
+    - PYTHON: "C:\\Python36-x64"
       TOXENV: "py35-test-deps"
       TOXPYTHON: "%PYTHON%\\python.exe"
       HDF5_VSVERSION: "14-64"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py26,py27,py33,py34,py35,pypy}-{test}-{deps,mindeps}
+envlist = {py26,py27,py33,py34,py35,py36,pypy}-{test}-{deps,mindeps}
 
 [testenv]
 deps =
@@ -22,6 +22,7 @@ basepython =
     py33: {env:TOXPYTHON:python3.3}
     py34: {env:TOXPYTHON:python3.4}
     py35: {env:TOXPYTHON:python3.5}
+    py36: {env:TOXPYTHON:python3.6}
 
 [testenv:py26-test-deps]
 deps =
@@ -53,6 +54,11 @@ deps =
 [testenv:py35-test-mindeps]
 deps =
     numpy==1.10.0.post2
+    cython==0.19
+
+[testenv:py36-test-mindeps]
+deps =
+    numpy==1.12
     cython==0.19
 
 [testenv:py34-test-mpi4py]


### PR DESCRIPTION
This adds the necessary support to tox, travis and appveyor to test python 3.6.