### PR TITLE
Use u prefix instead of six.u

### DIFF
--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -697,16 +697,16 @@ class Dataset(HLObject):
     @with_phil
     def __repr__(self):
         if not self:
-            r = six.u('<Closed HDF5 dataset>')
+            r = u'<Closed HDF5 dataset>'
         else:
             if self.name is None:
-                namestr = six.u('("anonymous")')
+                namestr = u'("anonymous")'
             else:
                 name = pp.basename(pp.normpath(self.name))
-                namestr = six.u('"%s"') % (
-                    name if name != six.u('') else six.u('/'))
-            r = six.u('<HDF5 dataset %s: shape %s, type "%s">') % \
-                (namestr, self.shape, self.dtype.str)
+                namestr = u'"%s"' % (name if name != u'' else u'/')
+            r = u'<HDF5 dataset %s: shape %s, type "%s">' % (
+                namestr, self.shape, self.dtype.str
+            )
         if six.PY2:
             return r.encode('utf8')
         return r

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -319,14 +319,14 @@ class File(Group):
     @with_phil
     def __repr__(self):
         if not self.id:
-            r = six.u('<Closed HDF5 file>')
+            r = u'<Closed HDF5 file>'
         else:
             # Filename has to be forced to Unicode if it comes back bytes
             # Mode is always a "native" string
             filename = self.filename
             if isinstance(filename, bytes):  # Can't decode fname
                 filename = filename.decode('utf8', 'replace')
-            r = six.u('<HDF5 file "%s" (mode %s)>') % (os.path.basename(filename),
+            r = u'<HDF5 file "%s" (mode %s)>' % (os.path.basename(filename),
                                                  self.mode)
 
         if six.PY2:

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -465,12 +465,12 @@ class Group(HLObject, MutableMappingHDF5):
     @with_phil
     def __repr__(self):
         if not self:
-            r = six.u("<Closed HDF5 group>")
+            r = u"<Closed HDF5 group>"
         else:
             namestr = (
-                six.u('"%s"') % self.name
-            ) if self.name is not None else six.u("(anonymous)")
-            r = six.u('<HDF5 group %s (%d members)>') % (namestr, len(self))
+                u'"%s"' % self.name
+            ) if self.name is not None else u"(anonymous)"
+            r = u'<HDF5 group %s (%d members)>' % (namestr, len(self))
 
         if six.PY2:
             return r.encode('utf8')

--- a/h5py/tests/old/test_attrs.py
+++ b/h5py/tests/old/test_attrs.py
@@ -116,7 +116,7 @@ class TestUnicode(BaseAttrs):
 
     def test_unicode(self):
         """ Access via Unicode string with non-ascii characters """
-        name = six.u("Omega") + six.unichr(0x03A9)
+        name = u"Omega" + six.unichr(0x03A9)
         self.f.attrs[name] = 42
         out = self.f.attrs[name]
         self.assertEqual(out, 42)

--- a/h5py/tests/old/test_attrs_data.py
+++ b/h5py/tests/old/test_attrs_data.py
@@ -178,9 +178,9 @@ class TestTypes(BaseAttrs):
     def test_unicode_scalar(self):
         """ Storage of variable-length unicode strings (auto-creation) """
 
-        self.f.attrs['x'] = six.u("Hello") + six.unichr(0x2340) + six.u("!!")
+        self.f.attrs['x'] = u"Hello" + six.unichr(0x2340) + u"!!"
         out = self.f.attrs['x']
-        self.assertEqual(out, six.u("Hello") + six.unichr(0x2340) + six.u("!!"))
+        self.assertEqual(out, u"Hello" + six.unichr(0x2340) + u"!!")
         self.assertEqual(type(out), six.text_type)
 
         aid = h5py.h5a.open(self.f.id, b"x")
@@ -223,7 +223,7 @@ class TestEmpty(BaseAttrs):
     def test_items(self):
         items = list(self.f.attrs.items())
         self.assertEqual(
-            [(six.u("x"), self.empty_obj)], items
+            [(u"x", self.empty_obj)], items
         )
 
     def test_itervalues(self):
@@ -235,7 +235,7 @@ class TestEmpty(BaseAttrs):
     def test_iteritems(self):
         items = list(six.iteritems(self.f.attrs))
         self.assertEqual(
-            [(six.u("x"), self.empty_obj)], items
+            [(u"x", self.empty_obj)], items
         )
 
 

--- a/h5py/tests/old/test_base.py
+++ b/h5py/tests/old/test_base.py
@@ -77,7 +77,7 @@ class TestRepr(BaseTest):
     @ut.skipIf(not unicode_filenames, "Filesystem unicode support required")
     def test_file(self):
         """ File object repr() with unicode """
-        fname = tempfile.mktemp(self.USTRING+six.u('.hdf5'))
+        fname = tempfile.mktemp(self.USTRING+u'.hdf5')
         try:
             with File(fname,'w') as f:
                 self._check_type(f)

--- a/h5py/tests/old/test_dataset.py
+++ b/h5py/tests/old/test_dataset.py
@@ -546,7 +546,7 @@ class TestAutoCreate(BaseDataset):
 
     def test_vlen_unicode(self):
         """ Assignment of a unicode string produces a vlen unicode dataset """
-        self.f['x'] = six.u("Hello there") + six.unichr(0x2034)
+        self.f['x'] = u"Hello there" + six.unichr(0x2034)
         ds = self.f['x']
         tid = ds.id.get_type()
         self.assertEqual(type(tid), h5py.h5t.TypeStringID)
@@ -728,7 +728,7 @@ class TestStrings(BaseDataset):
         """
         dt = h5py.special_dtype(vlen=six.text_type)
         ds = self.f.create_dataset('x', (100,), dtype=dt)
-        data = six.u("Hello") + six.unichr(0x2034)
+        data = u"Hello" + six.unichr(0x2034)
         ds[0] = data
         out = ds[0]
         self.assertEqual(type(out), six.text_type)
@@ -760,7 +760,7 @@ class TestStrings(BaseDataset):
         """
         dt = h5py.special_dtype(vlen=six.text_type)
         ds = self.f.create_dataset('x', (100,), dtype=dt)
-        data = six.u("Hello there") + six.unichr(0x2034)
+        data = u"Hello there" + six.unichr(0x2034)
         ds[0] = data.encode('utf8')
         out = ds[0]
         self.assertEqual(type(out), six.text_type)

--- a/h5py/tests/old/test_group.py
+++ b/h5py/tests/old/test_group.py
@@ -91,7 +91,7 @@ class TestCreate(BaseGroup):
 
     def test_unicode(self):
         """ Unicode names are correctly stored """
-        name = six.u("/Name") + six.unichr(0x4500)
+        name = u"/Name" + six.unichr(0x4500)
         group = self.f.create_group(name)
         self.assertEqual(group.name, name)
         self.assertEqual(group.id.links.get_info(name.encode('utf8')).cset, h5t.CSET_UTF8)
@@ -99,7 +99,7 @@ class TestCreate(BaseGroup):
     def test_unicode_default(self):
         """ Unicode names convertible to ASCII are stored as ASCII (issue 239)
         """
-        name = six.u("/Hello, this is a name")
+        name = u"/Hello, this is a name"
         group = self.f.create_group(name)
         self.assertEqual(group.name, name)
         self.assertEqual(group.id.links.get_info(name.encode('utf8')).cset, h5t.CSET_ASCII)
@@ -311,33 +311,33 @@ class TestContains(BaseGroup):
         """ "in" builtin works for containership (byte and Unicode) """
         self.f.create_group('a')
         self.assertIn(b'a', self.f)
-        self.assertIn(six.u('a'), self.f)
+        self.assertIn(u'a', self.f)
         self.assertIn(b'/a', self.f)
-        self.assertIn(six.u('/a'), self.f)
+        self.assertIn(u'/a', self.f)
         self.assertNotIn(b'mongoose', self.f)
-        self.assertNotIn(six.u('mongoose'), self.f)
+        self.assertNotIn(u'mongoose', self.f)
 
     def test_exc(self):
         """ "in" on closed group returns False (see also issue 174) """
         self.f.create_group('a')
         self.f.close()
         self.assertFalse(b'a' in self.f)
-        self.assertFalse(six.u('a') in self.f)
+        self.assertFalse(u'a' in self.f)
 
     def test_empty(self):
         """ Empty strings work properly and aren't contained """
-        self.assertNotIn(six.u(''), self.f)
+        self.assertNotIn(u'', self.f)
         self.assertNotIn(b'', self.f)
 
     def test_dot(self):
         """ Current group "." is always contained """
         self.assertIn(b'.', self.f)
-        self.assertIn(six.u('.'), self.f)
+        self.assertIn(u'.', self.f)
 
     def test_root(self):
         """ Root group (by itself) is contained """
         self.assertIn(b'/', self.f)
-        self.assertIn(six.u('/'), self.f)
+        self.assertIn(u'/', self.f)
 
     def test_trailing_slash(self):
         """ Trailing slashes are unconditionally ignored """

--- a/h5py/tests/old/test_slicing.py
+++ b/h5py/tests/old/test_slicing.py
@@ -284,15 +284,15 @@ class TestFieldNames(BaseSlicing):
         if six.PY2:
             # Byte strings are only allowed for field names on Py2
             self.assertArrayEqual(self.dset[b'a'], self.data['a'])
-        self.assertArrayEqual(self.dset[six.u('a')], self.data['a'])
+        self.assertArrayEqual(self.dset[u'a'], self.data['a'])
 
     def test_unicode_names(self):
         """ Unicode field names for for read and write """
-        self.assertArrayEqual(self.dset[six.u('a')], self.data['a'])
-        self.dset[six.u('a')] = 42
+        self.assertArrayEqual(self.dset[u'a'], self.data['a'])
+        self.dset[u'a'] = 42
         data = self.data.copy()
         data['a'] = 42
-        self.assertArrayEqual(self.dset[six.u('a')], data['a'])
+        self.assertArrayEqual(self.dset[u'a'], data['a'])
 
     def test_write(self):
         """ Test write with field selections """


### PR DESCRIPTION
As we dropped Python 3.2 support in 2.7, it makes sense to remove unneeded compatibility code. This removes calling six.u, which is only needed for Python 3.0-3.2.