### PR TITLE
Work around changes in PEP 529, and document how to pass filenames to h5py

### DIFF
--- a/docs/high/file.rst
+++ b/docs/high/file.rst
@@ -118,6 +118,52 @@ of the HDF5 library.  However, once the file is closed you are free to read and
 write data at the start of the file, provided your modifications don't leave
 the user block region.
 
+
+.. _file_filenames:
+
+Filenames on different systems
+------------------------------
+
+Different operating systems (and different file systems) store filenames with
+different encodings. Additionally, in Python there are at least two different
+representations of filenames, as encoded bytes (via str on Python 2, bytes on
+Python 3) or as a unicode string (via unicode on Python 2 and str on Python 3).
+The safest bet when creating a new file is to use unicode strings on all
+systems.
+
+macOS (OSX)
+...........
+macOS is the simplest system to deal with, it only accepts UTF-8, so using
+unicode paths will just work (and should be preferred).
+
+Linux (and non-macOS Unix)
+..........................
+Unix-like systems use locale settings to determine the correct encoding to use.
+These are set via a number of different environment variables, of which ``LANG``
+and ``LC_ALL`` are the ones of most interest. Of special interest is the ``C``
+locale, which Python will interpret as only allowing ASCII, meaning unicode
+paths should be preencoded. This will likely change in Python 3.7 with
+https://www.python.org/dev/peps/pep-0538/, but this will likely be backported by
+distributions to earlier versions.
+
+To summarise, use unicode strings where possible, but be aware that sometimes
+using encoded bytes may be necessary to read incorrectly encoded filenames.
+
+Windows
+.......
+Windows systems have two different APIs to perform file-related operations, a
+ANSI (char, legacy) interface and a unicode (wchar) interface. HDF5 currently
+only supports the ANSI interface, which is limited in what it can encode. This
+means that it may not be possible to open certain files, and because
+:ref:`group_extlinks` do not specify their encoding, it is possible that opening an
+external link may not work. There is work being done to fix this (see
+https://github.com/h5py/h5py/issues/839), but it is likely there will need to be
+breaking changes make to allow Windows to have the same level of support for
+unicode filenames as other operating systems.
+
+The best suggestion is to use unicode strings, but to keep to ASCII for
+filenames to avoid possible breakage.
+
 Reference
 ---------
 

--- a/docs/high/group.rst
+++ b/docs/high/group.rst
@@ -147,6 +147,13 @@ link resides.
     already open.  This is related to how HDF5 manages file permissions
     internally.
 
+.. note::
+
+    How the filename is processed is operating system dependent, it is
+    recommended to read :ref:`file_filenames` to understand potential limitations on
+    filenames on your operating system. Note especially that Windows is
+    particularly susceptible to problems with external links, due to possible
+    encoding errors and how filenames are structured.
 
 Reference
 ---------

--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -19,8 +19,7 @@ import six
 from collections import (Mapping, MutableMapping, KeysView, 
                          ValuesView, ItemsView)
 
-from .compat import fspath
-from .compat import fsencode
+from .compat import fspath, filename_encode
 
 from .. import h5d, h5i, h5r, h5p, h5f, h5t, h5s
 
@@ -37,7 +36,7 @@ def is_hdf5(fname):
         fname = os.path.abspath(fspath(fname))
 
         if os.path.isfile(fname):
-            return h5f.is_hdf5(fsencode(fname))
+            return h5f.is_hdf5(filename_encode(fname))
         return False
 
 

--- a/h5py/_hl/compat.py
+++ b/h5py/_hl/compat.py
@@ -4,6 +4,8 @@ Compatibility module for high-level h5py
 import sys
 import six
 
+WINDOWS_ENCODING = "mbcs"
+
 
 try:
     from os import fspath
@@ -96,3 +98,37 @@ try:
     from os import fsdecode
 except ImportError:
     fsdecode = _fsdecode
+
+
+def filename_encode(filename):
+    """
+    Encode filename for use in the HDF5 library.
+
+    Due to how HDF5 handles filenames on different systems, this should be
+    called on any filenames passed to the HDF5 library. See the documentation on
+    filenames in h5py for more information.
+    """
+    filename = fspath(filename)
+    if sys.platform == "win32":
+        if isinstance(filename, six.text_type):
+            return filename.encode(WINDOWS_ENCODING, "strict")
+        return filename
+    return fsencode(filename)
+
+
+def filename_decode(filename):
+    """
+    Decode filename used by HDF5 library.
+
+    Due to how HDF5 handles filenames on different systems, this should be
+    called on any filenames passed from the HDF5 library. See the documentation
+    on filenames in h5py for more information.
+    """
+    if sys.platform == "win32":
+        if isinstance(filename, six.binary_type):
+            return filename.decode(WINDOWS_ENCODING, "strict")
+        elif isinstance(filename, six.text_type):
+            return filename
+        else:
+            raise TypeError("expect bytes or str, not %s" % type(filename).__name__)
+    return fsdecode(filename)

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -16,9 +16,7 @@ from __future__ import absolute_import
 import sys
 import os
 
-from .compat import fspath
-from .compat import fsencode
-from .compat import fsdecode
+from .compat import filename_decode, filename_encode
 
 import six
 
@@ -158,7 +156,7 @@ class File(Group):
     @with_phil
     def filename(self):
         """File name on disk"""
-        return fsdecode(h5f.get_name(self.fid))
+        return filename_decode(h5f.get_name(self.fid))
 
     @property
     @with_phil
@@ -265,7 +263,7 @@ class File(Group):
             if isinstance(name, _objects.ObjectID):
                 fid = h5i.get_file_id(name)
             else:
-                name = fsencode(fspath(name))
+                name = filename_encode(name)
 
                 fapl = make_fapl(driver, libver, **kwds)
                 fid = make_fid(name, mode, userblock_size, fapl, swmr=swmr)

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -17,9 +17,7 @@ import posixpath as pp
 import six
 import numpy
 
-from .compat import fsdecode
-from .compat import fsencode
-from .compat import fspath
+from .compat import filename_decode, filename_encode
 
 from .. import h5g, h5i, h5o, h5r, h5t, h5l, h5p
 from . import base
@@ -237,7 +235,9 @@ class Group(HLObject, MutableMappingHDF5):
                     if getclass:
                         return ExternalLink
                     filebytes, linkbytes = self.id.links.get_val(self._e(name))
-                    return ExternalLink(fsdecode(filebytes), self._d(linkbytes))
+                    return ExternalLink(
+                        filename_decode(filebytes), self._d(linkbytes)
+                    )
                     
                 elif typecode == h5l.TYPE_HARD:
                     return HardLink if getclass else HardLink()
@@ -280,7 +280,7 @@ class Group(HLObject, MutableMappingHDF5):
                           lcpl=lcpl, lapl=self._lapl)
 
         elif isinstance(obj, ExternalLink):
-            self.id.links.create_external(name, fsencode(obj.filename),
+            self.id.links.create_external(name, filename_encode(obj.filename),
                           self._e(obj.path), lcpl=lcpl, lapl=self._lapl)
 
         elif isinstance(obj, numpy.dtype):
@@ -525,7 +525,7 @@ class ExternalLink(object):
         return self._filename
 
     def __init__(self, filename, path):
-        self._filename = fspath(filename)
+        self._filename = filename_decode(filename_encode(filename))
         self._path = str(path)
 
     def __repr__(self):

--- a/h5py/tests/old/test_file.py
+++ b/h5py/tests/old/test_file.py
@@ -401,13 +401,13 @@ class TestContextManager(TestCase):
             self.assertTrue(fid)
         self.assertTrue(not fid)
 
+@ut.skipIf(not unicode_filenames, "Filesystem unicode support required")
 class TestUnicode(TestCase):
 
     """
         Feature: Unicode filenames are supported
     """
 
-    @ut.skipIf(not unicode_filenames, "Filesystem unicode support required")
     def test_unicode(self):
         """ Unicode filenames can be used, and retrieved properly via .filename
         """
@@ -418,6 +418,14 @@ class TestUnicode(TestCase):
             self.assertIsInstance(fid.filename, six.text_type)
         finally:
             fid.close()
+
+    def test_unicode_hdf5_python_consistent(self):
+        """ Unicode filenames can be used, and seen correctly from python
+        """
+        fname = self.mktemp(prefix = six.unichr(0x201a))
+        with File(fname, 'w') as f:
+            self.assertTrue(os.path.exists(fname))
+
 
 class TestFileProperty(TestCase):
 

--- a/h5py/tests/old/test_group.py
+++ b/h5py/tests/old/test_group.py
@@ -33,12 +33,12 @@ import h5py
 from h5py.highlevel import File, Group, SoftLink, HardLink, ExternalLink
 from h5py.highlevel import Dataset, Datatype
 from h5py import h5t
-from h5py._hl.compat import fsencode
+from h5py._hl.compat import filename_encode
 
 # If we can't encode unicode filenames, there's not much point failing tests
 # which must fail
 try:
-    fsencode(u"α")
+    filename_encode(u"α")
 except UnicodeEncodeError:
     NO_FS_UNICODE = True
 else:


### PR DESCRIPTION
This is a smaller version of #836, which will allow easier cleanup in compat.py, and makes it easier to fix #839.