### PR TITLE
Fix ppc64le longdouble type conversion

### DIFF
--- a/h5py/tests/old/test_h5t.py
+++ b/h5py/tests/old/test_h5t.py
@@ -67,8 +67,6 @@ class TestTypeFloatID(TestCase):
 
     def test_custom_float_promotion(self):
         """Custom floats are correctly promoted to standard floats on read."""
-        if h5t.MACHINE == 'ppc64le':
-            return
 
         test_filename = self.mktemp()
         dataset = 'DS1'


### PR DESCRIPTION
This PR fixes the conversion to longdouble. The problem lies in the erroneous bit-size of the components by hdf5, hence requiring some hardcoding for longdoubles (double double implementation in this case).

Signed-off-by: Martin Raspaud <martin.raspaud@smhi.se>