### PR TITLE
Test that docs build without failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ env:
     TOX_TESTENV_PASSENV=LANG LC_ALL
     LANG=C
     LC_ALL=C
+  - TOXENV=docs
 
 matrix:
   include:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py26,py27,py33,py34,py35,py36,pypy}-{test}-{deps,mindeps}
+envlist = {py26,py27,py33,py34,py35,py36,pypy}-{test}-{deps,mindeps},docs
 
 [testenv]
 deps =
@@ -66,3 +66,12 @@ deps =
     numpy==1.9
     cython==0.19
     mpi4py>=1.3.1
+
+[testenv:docs]
+skip_install=True
+basepython = {env:TOXPYTHON:python}
+changedir=docs
+deps=
+    sphinx
+commands=
+    sphinx-build -W -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html


### PR DESCRIPTION
Adds sphinx build to tox and travis (I'm not going to worry about appveyor, as this should be OS independent, and it would slow down appveyor, which is always slower than travis.)