### PR TITLE
Test correctness of sdist with check-manifest and checkreadme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,8 @@ env:
     LANG=C
     LC_ALL=C
   - TOXENV=docs
+  - TOXENV=check-manifest
+  - TOXENV=checkreadme
 
 matrix:
   include:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,19 +1,32 @@
-recursive-include h5py *.h *.pyx *.pxd *.pxi *.py *.txt
-exclude h5py/defs.pyx
-exclude h5py/defs.pxd
-exclude h5py/config.pxi
-recursive-include examples *.py
-recursive-include lzf *
-recursive-include windows *
-recursive-include licenses *
-include MANIFEST.in
+include ANN.rst
 include api_gen.py
+include MANIFEST.in
+include pylintrc
+include README.rst
 include setup_build.py
 include setup_configure.py
-include ANN.rst
-include README.rst
+include tox.ini
+
 recursive-include docs *
 prune docs/_build
 recursive-include docs_api *
 prune docs_api/_build
+recursive-include examples *.py
+
+recursive-include h5py *.h *.pyx *.pxd *.pxi *.py *.txt
+exclude h5py/config.pxi
+exclude h5py/defs.pxd
+exclude h5py/defs.pyx
+
+recursive-include licenses *
+recursive-include lzf *
+recursive-include windows *
+
 recursive-exclude * .DS_Store
+
+exclude ci other .github
+recursive-exclude ci *
+recursive-exclude other *
+recursive-exclude .github *
+exclude pavement.py
+exclude *.yml

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ SETUP_REQUIRES = RUN_REQUIRES + [NUMPY_DEP, 'Cython>=0.19', 'pkgconfig']
 
 # Needed to avoid trying to install numpy/cython on pythons which the latest
 # versions don't support
-if "sdist" in sys.argv and "bdist_wheel" not in sys.argv and "install" not in sys.argv:
+if ("sdist" in sys.argv and "bdist_wheel" not in sys.argv and
+    "install" not in sys.argv) or "check" in sys.argv:
     use_setup_requires = False
 else:
     use_setup_requires = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py26,py27,py33,py34,py35,py36,pypy}-{test}-{deps,mindeps},docs
+envlist = {py26,py27,py33,py34,py35,py36,pypy}-{test}-{deps,mindeps},docs,check-manifest,checkreadme
 
 [testenv]
 deps =
@@ -75,3 +75,19 @@ deps=
     sphinx
 commands=
     sphinx-build -W -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html
+
+[testenv:check-manifest]
+skip_install=True
+basepython = {env:TOXPYTHON:python}
+deps=check-manifest
+setenv =
+    CHECK_MANIFEST=true
+commands=
+    check-manifest
+
+[testenv:checkreadme]
+skip_install=True
+basepython = {env:TOXPYTHON:python}
+deps=readme_renderer
+commands=
+    python setup.py check -s -r


### PR DESCRIPTION
More sanity checking stuff, check-manifest makes sure that the MANIFEST.in matches what we have in version control (it found some things we missed, so it's already doing it's job), and checkreadme makes sure that the README will render correctly on PyPI (e.g. no rst errors). Like the docs, only runs on travis, as we don't want to slow appveyor down.