### PR TITLE
Warn when HDF5 differs from compiled version

### DIFF
--- a/h5py/__init__.py
+++ b/h5py/__init__.py
@@ -14,6 +14,8 @@
 
 from __future__ import absolute_import
 
+from warnings import warn as _warn
+
 
 # --- Library setup -----------------------------------------------------------
 
@@ -58,6 +60,14 @@ from . import version
 from .version import version as __version__
 
 from .tests import run_tests
+
+if version.hdf5_version_tuple != version.hdf5_built_version_tuple:
+    _warn(("h5py is running against HDF5 {0} when it was built against {1}, "
+        "this may cause problems").format(
+            '.'.join(version.hdf5_version_tuple),
+            '.'.join(version.hdf5_built_version_tuple)
+    ))
+
 
 def enable_ipython_completer():
     """ Call this from an interactive IPython session to enable tab-completion

--- a/h5py/h5.pyx
+++ b/h5py/h5.pyx
@@ -19,6 +19,8 @@ ITER_NATIVE = H5_ITER_NATIVE  # No particular order, whatever is fastest
 INDEX_NAME      = H5_INDEX_NAME       # Index on names
 INDEX_CRT_ORDER = H5_INDEX_CRT_ORDER  # Index on creation order
 
+HDF5_VERSION_COMPILED_AGAINST = HDF5_VERSION
+
 class ByteStringContext(object):
 
     def __init__(self):

--- a/h5py/version.py
+++ b/h5py/version.py
@@ -22,6 +22,8 @@ import numpy
 # needed for our use case
 _H5PY_VERSION_CLS = namedtuple("_H5PY_VERSION_CLS", "major minor bugfix pre post dev")
 
+hdf5_built_version_tuple = _h5.HDF5_VERSION_COMPILED_AGAINST
+
 version_tuple = _H5PY_VERSION_CLS(2, 7, 0, None, 0, None)
 
 version = "{0.major:d}.{0.minor:d}.{0.bugfix:d}".format(version_tuple)


### PR DESCRIPTION
Fixes #855, #856.
There's also now a runtime way of inspecting what version of HDF5 h5py was compiled against.