### PR TITLE
Ensure scalar ASCII decodes to strings on Python 3

### DIFF
--- a/h5py/_hl/attrs.py
+++ b/h5py/_hl/attrs.py
@@ -16,6 +16,8 @@
 
 from __future__ import absolute_import
 
+import warnings
+
 import six
 import numpy
 
@@ -81,13 +83,21 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
 
         if len(arr.shape) == 0:
             value = arr[()]
-            if not six.PY2 and isinstance(value, bytes):
+            if isinstance(value, bytes):
                 # The low-level interface gives HDF5 strings with ASCII
                 # character sets NumPy's 'S' dtype, for which the corresponding
                 # builtin scalar type is bytes. Decode them as ASCII to convert
                 # these values to strings on Python 3 (on Python 2, bytes is
                 # already a string type).
-                value = value.decode('ascii')
+                try:
+                    value = value.decode('utf-8')
+                except UnicodeDecodeError:
+                    warnings.warn(
+                        'Decoding ASCII attribute failed, falling back to '
+                        'return bytes. This behavior is deprecated: in the '
+                        'future this will be an error and you will need to '
+                        'explicitly read these values with the low-level '
+                        'h5py.h5a interface.', DeprecationWarning)
             return value
         return arr
 

--- a/h5py/_hl/attrs.py
+++ b/h5py/_hl/attrs.py
@@ -9,13 +9,14 @@
 
 """
     Implements high-level operations for attributes.
-    
+
     Provides the AttributeManager class, available on high-level objects
     as <obj>.attrs.
 """
 
 from __future__ import absolute_import
 
+import six
 import numpy
 
 from .. import h5s, h5t, h5a
@@ -62,7 +63,7 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
 
         dtype = readtime_dtype(attr.dtype, [])
         shape = attr.shape
-        
+
         # Do this first, as we'll be fiddling with the dtype for top-level
         # array types
         htype = h5t.py_create(dtype)
@@ -74,12 +75,20 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
             subdtype, subshape = dtype.subdtype
             shape = attr.shape + subshape   # (5, 3)
             dtype = subdtype                # 'f'
-            
+
         arr = numpy.ndarray(shape, dtype=dtype, order='C')
         attr.read(arr, mtype=htype)
 
         if len(arr.shape) == 0:
-            return arr[()]
+            value = arr[()]
+            if not six.PY2 and isinstance(value, bytes):
+                # The low-level interface gives HDF5 strings with ASCII
+                # character sets NumPy's 'S' dtype, for which the corresponding
+                # builtin scalar type is bytes. Decode them as ASCII to convert
+                # these values to strings on Python 3 (on Python 2, bytes is
+                # already a string type).
+                value = value.decode('ascii')
+            return value
         return arr
 
     @with_phil
@@ -113,20 +122,20 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
         """
 
         import uuid
-        
+
         with phil:
-                
+
             # First, make sure we have a NumPy array.  We leave the data
             # type conversion for HDF5 to perform.
             if not isinstance(data, Empty):
                 data = numpy.asarray(data, order='C')
-    
+
             if shape is None:
                 shape = data.shape
-                
+
             use_htype = None    # If a committed type is given, we must use it
                                 # in the call to h5a.create.
-                                            
+
             if isinstance(dtype, Datatype):
                 use_htype = dtype.id
                 dtype = dtype.dtype
@@ -134,16 +143,16 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
                 dtype = data.dtype
             else:
                 dtype = numpy.dtype(dtype) # In case a string, e.g. 'i8' is passed
- 
+
             original_dtype = dtype  # We'll need this for top-level array types
 
             # Where a top-level array type is requested, we have to do some
             # fiddling around to present the data as a smaller array of
-            # subarrays. 
+            # subarrays.
             if dtype.subdtype is not None:
-            
+
                 subdtype, subshape = dtype.subdtype
-                
+
                 # Make sure the subshape matches the last N axes' sizes.
                 if shape[-len(subshape):] != subshape:
                     raise ValueError("Array dtype shape %s is incompatible with data shape %s" % (subshape, shape))
@@ -151,11 +160,11 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
                 # New "advertised" shape and dtype
                 shape = shape[0:len(shape)-len(subshape)]
                 dtype = subdtype
-                
+
             # Not an array type; make sure to check the number of elements
             # is compatible, and reshape if needed.
             else:
-               
+
                 if shape is not None and numpy.product(shape) != numpy.product(data.shape):
                     raise ValueError("Shape of new attribute conflicts with shape of data")
 
@@ -165,7 +174,7 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
             # We need this to handle special string types.
             if not isinstance(data, Empty):
                 data = numpy.asarray(data, dtype=dtype)
-    
+
             # Make HDF5 datatype and dataspace for the H5A calls
             if use_htype is None:
                 htype = h5t.py_create(original_dtype, logical=True)
@@ -173,7 +182,7 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
             else:
                 htype = use_htype
                 htype2 = None
-                
+
             if isinstance(data, Empty):
                 space = h5s.create(h5s.NULL)
             else:
@@ -181,7 +190,7 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
 
             # This mess exists because you can't overwrite attributes in HDF5.
             # So we write to a temporary attribute first, and then rename.
-            
+
             tempname = uuid.uuid4().hex
 
             try:
@@ -206,7 +215,7 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
                         attr.close()
                         h5a.delete(self._id, self._e(tempname))
                         raise
-                        
+
     def modify(self, name, value):
         """ Change the value of an attribute while preserving its type.
 
@@ -242,7 +251,7 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
     def __iter__(self):
         """ Iterate over the names of attributes. """
         with phil:
-        
+
             attrlist = []
             def iter_cb(name, *args):
                 """ Callback to gather attribute names """

--- a/h5py/tests/old/test_attrs_data.py
+++ b/h5py/tests/old/test_attrs_data.py
@@ -30,7 +30,7 @@ class BaseAttrs(TestCase):
 
     def setUp(self):
         self.f = File(self.mktemp(), 'w')
- 
+
     def tearDown(self):
         if self.f:
             self.f.close()
@@ -103,42 +103,42 @@ class TestTypes(BaseAttrs):
     def test_float(self):
         """ Storage of floating point types """
         dtypes = tuple(np.dtype(x) for x in ('<f4','>f4','<f8','>f8'))
-        
+
         for dt in dtypes:
             data = np.ndarray((1,), dtype=dt)
             data[...] = 42.3
             self.f.attrs['x'] = data
-            out = self.f.attrs['x'] 
+            out = self.f.attrs['x']
             self.assertEqual(out.dtype, dt)
             self.assertArrayEqual(out, data)
 
     def test_complex(self):
         """ Storage of complex types """
         dtypes = tuple(np.dtype(x) for x in ('<c8','>c8','<c16','>c16'))
-        
+
         for dt in dtypes:
             data = np.ndarray((1,), dtype=dt)
             data[...] = -4.2j+35.9
             self.f.attrs['x'] = data
-            out = self.f.attrs['x'] 
+            out = self.f.attrs['x']
             self.assertEqual(out.dtype, dt)
             self.assertArrayEqual(out, data)
 
     def test_string(self):
         """ Storage of fixed-length strings """
         dtypes = tuple(np.dtype(x) for x in ('|S1', '|S10'))
-        
+
         for dt in dtypes:
             data = np.ndarray((1,), dtype=dt)
             data[...] = 'h'
             self.f.attrs['x'] = data
-            out = self.f.attrs['x'] 
+            out = self.f.attrs['x']
             self.assertEqual(out.dtype, dt)
             self.assertEqual(out[0], data[0])
 
     def test_bool(self):
         """ Storage of NumPy booleans """
-        
+
         data = np.ndarray((2,), dtype=np.bool_)
         data[...] = True, False
         self.f.attrs['x'] = data
@@ -150,7 +150,7 @@ class TestTypes(BaseAttrs):
     def test_vlen_string_array(self):
         """ Storage of vlen byte string arrays"""
         dt = h5py.special_dtype(vlen=bytes)
-        
+
         data = np.ndarray((2,), dtype=dt)
         data[...] = b"Hello", b"Hi there!  This is HDF5!"
 
@@ -166,8 +166,8 @@ class TestTypes(BaseAttrs):
         self.f.attrs['x'] = b'Hello'
         out = self.f.attrs['x']
 
-        self.assertEqual(out,b'Hello')
-        self.assertEqual(type(out), bytes)
+        self.assertEqual(out, u'Hello')
+        self.assertIsInstance(out, six.string_types)
 
         aid = h5py.h5a.open(self.f.id, b"x")
         tid = aid.get_type()

--- a/h5py/tests/old/test_dimension_scales.py
+++ b/h5py/tests/old/test_dimension_scales.py
@@ -63,7 +63,7 @@ class TestH5DSBindings(BaseDataset):
         """ Create a dimension scale from existing dataset """
         self.assertTrue(h5py.h5ds.is_scale(self.f['x1'].id))
         self.assertEqual(h5py.h5ds.get_scale_name(self.f['x1'].id), b'')
-        self.assertEqual(self.f['x1'].attrs['CLASS'], b"DIMENSION_SCALE")
+        self.assertEqual(self.f['x1'].attrs['CLASS'], "DIMENSION_SCALE")
         self.assertEqual(h5py.h5ds.get_scale_name(self.f['x2'].id), b'x2 name')
 
     def test_attach_dimensionscale(self):


### PR DESCRIPTION
Fixes https://github.com/h5py/h5py/issues/379

This is consistent with the documented behavior for strings under [Exceptions for Python 3]( http://docs.h5py.org/en/latest/strings.html#exceptions-for-python-3) and the discussion over in #379, so in principle this could be considered a bug fix -- but it's a bug that's been in the wild for quite some time.

I do have one unresolved concern. For "Fixed-length ASCII", the documentation says:

> Technically, these strings are supposed to store only ASCII-encoded text, although in practice anything you can store in NumPy will round-trip. But for compatibility with other progams using HDF5 (IDL, MATLAB, etc.), you should use ASCII only.

The current version of my fix will break this guarantee on Python 3, because the scalar version of fixed-length ASCII is `bytes`, which this fix will try (and fail) to decode. I see a few options:

1. Keep my current fix and update the documentation to note that you can no longer read arbitrary bytes on Python 3.
2. Update my fix to explicitly decode only variable length ASCII, by using the low level API. This will also require a documentation update, because it won't be true that "when reading or writing scalar string attributes, on Python 3 they will always be returned as type str".
3. Add some sort of terrible fallback logic that *attempts* to decode ASCII, returning the original scalar (`np.string_`) if decoding fails. This is maximally backwards compatible, but also results in difficult to predict behavior (though we can document it).

Reluctantly, I think option (3) is probably the most pragmatic choice. Any other opinions?

Finally, it might be time to update the strings documentation to special case "Exceptions for Python 2" rather than Python 3. I'll update that if I have time.