### PR TITLE
Fix tox env used for py36 on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ environment:
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
 
     - PYTHON: "C:\\Python36"
-      TOXENV: "py35-test-deps"
+      TOXENV: "py36-test-deps"
       TOXPYTHON: "%PYTHON%\\python.exe"
       HDF5_VSVERSION: "14"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
@@ -67,7 +67,7 @@ environment:
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
 
     - PYTHON: "C:\\Python36-x64"
-      TOXENV: "py35-test-deps"
+      TOXENV: "py36-test-deps"
       TOXPYTHON: "%PYTHON%\\python.exe"
       HDF5_VSVERSION: "14-64"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"


### PR DESCRIPTION
Missed in #838, test using py36 env on python 3.6 instead of py35 env.