### PR TITLE
API: raise if kwds are ignored in require_dataset

### DIFF
--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -123,8 +123,11 @@ class Group(HLObject, MutableMappingHDF5):
         shape or dtype don't match according to the above rules.
         """
         with phil:
-            if not name in self:
+            if name not in self:
                 return self.create_dataset(name, *(shape, dtype), **kwds)
+
+            if kwds:
+                raise RuntimeError('Keyword arguments are ignored')
 
             dset = self[name]
             if not isinstance(dset, dataset.Dataset):

--- a/h5py/tests/old/test_dataset.py
+++ b/h5py/tests/old/test_dataset.py
@@ -170,6 +170,12 @@ class TestCreateRequire(BaseDataset):
         dset2 = self.f.require_dataset('foo', (10, 3), 'f')
         self.assertEqual(dset, dset2)
 
+    def test_kwds_fail(self):
+        """ require_dataset yields existing dataset """
+        self.f.require_dataset('foo', (10, 3), 'f', data=np.ones((10, 3)))
+        with self.assertRaises(RuntimeError):
+            self.f.require_dataset('foo', (10, 3), 'f', data=np.ones((10, 3)))
+
     def test_shape_conflict(self):
         """ require_dataset with shape conflict yields TypeError """
         self.f.create_dataset('foo', (10, 3), 'f')


### PR DESCRIPTION
This raises if user kwds will be silently ignored.

This is prompted by a mailing list question about automatically resizing when I noticed the new data is simply ignored!

A better solution may be to check _all_ of the kwargs?

A less disruptive change would be to put a huge warning in the docstring.