### PR TITLE
Specify dtype to avoid Dataset size overflow on Windows

### DIFF
--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -233,7 +233,7 @@ class Dataset(HLObject):
     @with_phil
     def size(self):
         """Numpy-style attribute giving the total dataset size"""
-        return numpy.prod(self.shape)
+        return numpy.prod(self.shape, dtype=numpy.intp)
 
     @property
     @with_phil

--- a/h5py/tests/hl/test_dataset_getitem.py
+++ b/h5py/tests/hl/test_dataset_getitem.py
@@ -472,7 +472,7 @@ class TestVeryLargeArray(TestCase):
 
     def setUp(self):
         TestCase.setUp(self)
-        self.data = np.ones((2**15, 2**16), dtype='i4')
+        self.data = np.empty((2**15, 2**16), dtype=np.bool)
         self.dset = self.f.create_dataset('x', data=self.data)
 
     @ut.skipIf(sys.maxsize < 2**31, 'Maximum integer size >= 2**31 required')

--- a/h5py/tests/hl/test_dataset_getitem.py
+++ b/h5py/tests/hl/test_dataset_getitem.py
@@ -472,8 +472,7 @@ class TestVeryLargeArray(TestCase):
 
     def setUp(self):
         TestCase.setUp(self)
-        self.data = np.empty((2**15, 2**16), dtype=np.bool)
-        self.dset = self.f.create_dataset('x', data=self.data)
+        self.dset = self.f.create_dataset('x', shape=(2**15, 2**16))
 
     @ut.skipIf(sys.maxsize < 2**31, 'Maximum integer size >= 2**31 required')
     def test_size(self):

--- a/h5py/tests/hl/test_dataset_getitem.py
+++ b/h5py/tests/hl/test_dataset_getitem.py
@@ -41,6 +41,7 @@
 """
 
 from __future__ import absolute_import
+import sys
 
 import numpy as np
 import h5py
@@ -452,18 +453,28 @@ class Test2DZeroFloat(TestCase):
         TestCase.setUp(self)
         self.data = np.ones((0,3), dtype='f')
         self.dset = self.f.create_dataset('x', data=self.data)
-        
+
     def test_ndim(self):
         """ Verify number of dimensions """
         self.assertEquals(self.dset.ndim, 2)
-        
+
     def test_shape(self):
         """ Verify shape """
         self.assertEquals(self.dset.shape, (0, 3))
-        
+
     @ut.expectedFailure
     def test_indexlist(self):
         """ see issue #473 """
         self.assertNumpyBehavior(self.dset, self.data, np.s_[:,[0,1,2]])
 
-        
+
+class TestVeryLargeArray(TestCase):
+
+    def setUp(self):
+        TestCase.setUp(self)
+        self.data = np.ones((2**15, 2**16), dtype='i4')
+        self.dset = self.f.create_dataset('x', data=self.data)
+
+    @ut.skipIf(sys.maxsize < 2**31, 'Maximum integer size >= 2**31 required')
+    def test_size(self):
+        self.assertEqual(self.dset.size, 2**31)


### PR DESCRIPTION
Fix #901 
