### PR TITLE
Workaround cyclic gc messing with registry

### DIFF
--- a/h5py/_objects.pyx
+++ b/h5py/_objects.pyx
@@ -115,12 +115,15 @@ def nonlocal_close():
     """ Find dead ObjectIDs and set their integer identifiers to 0.
     """
     cdef ObjectID obj
+    cdef list reg_ids
 
     # create a cached list of ids whilst the gc is disabled to avoid hitting
     # the cyclic gc while iterating through the registry dict
     gc.disable()
-    reg_ids = list(registry)
-    gc.enable()
+    try:
+        reg_ids = list(registry)
+    finally:
+        gc.enable()
 
     for python_id in reg_ids:
         ref = registry.get(python_id)

--- a/h5py/_objects.pyx
+++ b/h5py/_objects.pyx
@@ -88,6 +88,7 @@ def with_phil(func):
 #
 # See also __cinit__ and __dealloc__ for class ObjectID.
 
+import gc
 import weakref
 import warnings
 
@@ -115,8 +116,19 @@ def nonlocal_close():
     """
     cdef ObjectID obj
 
-    # list() needed because the registry can be mutated concurrently
-    for python_id, ref in list(registry.items()):
+    # create a cached list of ids whilst the gc is disabled to avoid hitting
+    # the cyclic gc while iterating through the registry dict
+    gc.disable()
+    reg_ids = list(registry)
+    gc.enable()
+
+    for python_id in reg_ids:
+        ref = registry.get(python_id)
+
+        # registry dict has changed underneath us, skip to next item
+        if ref is None:
+            continue
+
         obj = ref()
 
         # Object died while walking the registry list, presumably because


### PR DESCRIPTION
This should fix #888 (or at least I hope so...). The idea is to disable the gc while we're getting the registry ids, so the cyclic gc shouldn't activate.

Questions (as I'm not familiar with the Python gc):
 1. Is `gc.enable/disable` the safest way of doing this?
 2. Can this leak in any way (does disabling the gc stop it tracking items, or just prevent deallocation)?