### PR TITLE
HDF5 1.8 path changed, update download script to new url

### DIFF
--- a/ci/get_hdf5.py
+++ b/ci/get_hdf5.py
@@ -11,8 +11,8 @@ from zipfile import ZipFile
 
 import requests
 
-HDF5_URL = "https://www.hdfgroup.org/ftp/HDF5/releases/hdf5-{version}/src/"
-HDF5_FILE = HDF5_URL + "hdf5-{version}.zip"
+HDF5_18_URL = "https://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-{version}/src/"
+HDF5_FILE = HDF5_18_URL + "hdf5-{version}.zip"
 CMAKE_CONFIGURE_CMD = [
     "cmake", "-DBUILD_SHARED_LIBS:BOOL=ON", "-DCMAKE_BUILD_TYPE:STRING=RELEASE",
     "-DHDF5_BUILD_CPP_LIB=OFF", "-DHDF5_BUILD_HL_LIB=ON",


### PR DESCRIPTION
What the title says, it appears that the urls have changed (to match the 1.10 url), which is why #904 has flaky testing on appveyor (it appears if the caching works, then we don't hit an issue).