### PR TITLE
BUG: support slices with stop < start

### DIFF
--- a/h5py/_hl/selections.py
+++ b/h5py/_hl/selections.py
@@ -485,7 +485,8 @@ def _translate_slice(exp, length):
     if step < 1:
         raise ValueError("Step must be >= 1 (got %d)" % step)
     if stop < start:
-        raise ValueError("Reverse-order selections are not allowed")
+        # list/tuple and numpy consider stop < start to be an empty selection
+        return 0, 0, 1
 
     count = 1 + (stop - start - 1) // step
 

--- a/h5py/tests/hl/test_dataset_getitem.py
+++ b/h5py/tests/hl/test_dataset_getitem.py
@@ -301,6 +301,9 @@ class Test1DZeroFloat(TestCase):
         """ slice -> ndarray of shape (0,) """
         self.assertNumpyBehavior(self.dset, self.data, np.s_[0:4])
 
+    def test_slice_stop_less_than_start(self):
+        self.assertNumpyBehavior(self.dset, self.data, np.s_[7:5])
+
     # FIXME: NumPy raises IndexError
     def test_index(self):
         """ index -> out of range """
@@ -358,6 +361,9 @@ class Test1DFloat(TestCase):
 
     def test_slice_negindexes(self):
         self.assertNumpyBehavior(self.dset, self.data, np.s_[-8:-2:3])
+
+    def test_slice_stop_less_than_start(self):
+        self.assertNumpyBehavior(self.dset, self.data, np.s_[7:5])
 
     def test_slice_outofrange(self):
         self.assertNumpyBehavior(self.dset, self.data, np.s_[100:400:3])


### PR DESCRIPTION
I was building indexing logic on top of h5py and ran into an issue where I needed to explicitly guard against stop < start in my slices. Python lists/tuples and numpy arrays treat this as an empty selection.