### PR TITLE
ENH: Deal with multiple float types of the same size

### DIFF
--- a/h5py/h5py_warnings.py
+++ b/h5py/h5py_warnings.py
@@ -1,0 +1,19 @@
+# This file is part of h5py, a Python interface to the HDF5 library.
+#
+# http://www.h5py.org
+#
+# Copyright 2008-2013 Andrew Collette and contributors
+#
+# License:  Standard 3-clause BSD; see "license.txt" for full license terms
+#           and contributor agreement.
+
+"""
+    This module contains the warning classes for h5py. These classes are part of
+    the public API of h5py, and should be imported from this module.
+"""
+
+class H5pyWarning(UserWarning):
+    pass
+
+class H5pyDeprecationWarning(H5pyWarning):
+    pass

--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -32,12 +32,14 @@ from warnings import warn
 from h5 import get_config
 import numpy as np
 from ._objects import phil, with_phil
+from .h5py_warnings import H5pyDeprecationWarning
 import platform
 
 try:
     from collections.abc import Mapping
 except ImportError:
     from collections import Mapping
+
 
 cfg = get_config()
 
@@ -269,15 +271,15 @@ class _DeprecatedMapping(Mapping):
         self._message = message
 
     def __len__(self):
-        warn(self._message, DeprecationWarning)
+        warn(self._message, H5pyDeprecationWarning)
         return len(self._mapping)
 
     def __iter__(self):
-        warn(self._message, DeprecationWarning)
+        warn(self._message, H5pyDeprecationWarning)
         return iter(self._mapping)
 
     def __getitem__(self, key):
-        warn(self._message, DeprecationWarning)
+        warn(self._message, H5pyDeprecationWarning)
         return self._mapping[key]
 
 available_ftypes = dict()
@@ -1841,14 +1843,13 @@ def find(TypeID src not None, TypeID dst not None):
 # ============================================================================
 # Deprecated functions
 
-import warnings
-
 cpdef dtype py_new_enum(object dt_in, dict enum_vals):
     """ (DTYPE dt_in, DICT enum_vals) => DTYPE
 
     Deprecated; use special_dtype() instead.
     """
-    #warnings.warn("Deprecated; use special_dtype(enum=(dtype, values)) instead", DeprecationWarning)
+    warn("Deprecated; use special_dtype(enum=(dtype, values)) instead",
+        H5pyDeprecationWarning)
     return special_dtype(enum = (dt_in, enum_vals))
 
 cpdef dict py_get_enum(object dt):
@@ -1856,7 +1857,8 @@ cpdef dict py_get_enum(object dt):
 
     Deprecated; use check_dtype() instead.
     """
-    #warnings.warn("Deprecated; use check_dtype(enum=dtype) instead", DeprecationWarning)
+    warn("Deprecated; use check_dtype(enum=dtype) instead",
+        H5pyDeprecationWarning)
     return check_dtype(enum=dt)
 
 cpdef dtype py_new_vlen(object kind):
@@ -1864,7 +1866,8 @@ cpdef dtype py_new_vlen(object kind):
 
     Deprecated; use special_dtype() instead.
     """
-    #warnings.warn("Deprecated; use special_dtype(vlen=basetype) instead", DeprecationWarning)
+    warn("Deprecated; use special_dtype(vlen=basetype) instead",
+        H5pyDeprecationWarning)
     return special_dtype(vlen=kind)
 
 cpdef object py_get_vlen(object dt_in):
@@ -1872,7 +1875,8 @@ cpdef object py_get_vlen(object dt_in):
 
     Deprecated; use check_dtype() instead.
     """
-    #warnings.warn("Deprecated; use check_dtype(vlen=dtype) instead", DeprecationWarning)
+    warn("Deprecated; use check_dtype(vlen=dtype) instead",
+        H5pyDeprecationWarning)
     return check_dtype(vlen=dt_in)
 
 

--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -251,7 +251,7 @@ def _get_available_ftypes():
                 sorted_ftypes.append((ftype, np.finfo(ftype), size))
     return tuple(sorted_ftypes)
 
-available_ftypes = _get_available_ftypes()
+_available_ftypes = _get_available_ftypes()
 
 # === General datatype operations =============================================
 
@@ -983,7 +983,7 @@ cdef class TypeFloatID(TypeAtomicID):
         e_bias = self.get_ebias()
 
         # Handle non-standard exponent and mantissa sizes.
-        for ftype_, finfo, size in available_ftypes:
+        for ftype_, finfo, size in _available_ftypes:
             nmant = finfo.nmant
             maxexp = finfo.maxexp
             minexp = finfo.minexp
@@ -1319,7 +1319,7 @@ def _get_float_dtype_to_hdf5():
     float_be = {}
     h5_be_list = [IEEE_F16BE, IEEE_F32BE, IEEE_F64BE, IEEE_F128BE]
     h5_le_list = [IEEE_F16LE, IEEE_F32LE, IEEE_F64LE, IEEE_F128LE]
-    for ftype_, finfo, size in available_ftypes:
+    for ftype_, finfo, size in _available_ftypes:
         for h5type in h5_be_list:
             spos, epos, esize, mpos, msize = h5type.get_fields()
             ebias = h5type.get_ebias()

--- a/h5py/tests/common.py
+++ b/h5py/tests/common.py
@@ -20,11 +20,11 @@ from six import unichr
 import numpy as np
 import h5py
 
-if sys.version_info[:2] == (2, 6):
+if sys.version_info[0] == 2:
     try:
         import unittest2 as ut
     except ImportError:
-        raise ImportError( "unittest2 is required to run tests with Python 2.6")
+        raise ImportError( "unittest2 is required to run tests with Python 2")
 else:
     import unittest as ut
 

--- a/h5py/tests/old/test_h5t.py
+++ b/h5py/tests/old/test_h5t.py
@@ -16,6 +16,7 @@ from six import PY2, text_type
 
 import h5py
 from h5py import h5t
+from h5py.h5py_warnings import H5pyDeprecationWarning
 
 from ..common import TestCase, ut
 
@@ -214,6 +215,6 @@ class TestDeprecation(TestCase):
         warning_message = ("Do not use available_ftypes, this is not part of "
             "the public API of h5py. See "
             "https://github.com/h5py/h5py/pull/926 for details.")
-        with self.assertWarnsRegex(DeprecationWarning, warning_message) as warning:
+        with self.assertWarnsRegex(H5pyDeprecationWarning, warning_message) as warning:
             from h5py.h5t import available_ftypes
             available_ftypes[np.dtype(np.float).itemsize]

--- a/h5py/tests/old/test_h5t.py
+++ b/h5py/tests/old/test_h5t.py
@@ -207,3 +207,13 @@ class TestTypeFloatID(TestCase):
 
         dset = f[dataset5]
         self.assertEqual(dset.dtype, np.longdouble)
+
+
+class TestDeprecation(TestCase):
+    def test_deprecation_available_ftypes(self):
+        warning_message = ("Do not use available_ftypes, this is not part of "
+            "the public API of h5py. See "
+            "https://github.com/h5py/h5py/pull/926 for details.")
+        with self.assertWarnsRegex(DeprecationWarning, warning_message) as warning:
+            from h5py.h5t import available_ftypes
+            available_ftypes[np.dtype(np.float).itemsize]

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist = {py26,py27,py33,py34,py35,py36,pypy}-{test}-{deps,mindeps},nightly,doc
 
 [testenv]
 deps =
-    py26-test: unittest2
+    py{26,27}-test: unittest2
     deps: cython>=0.19
     py{27,34,35}-deps: numpy>=1.7
     py26-deps: numpy>=1.7,<1.11


### PR DESCRIPTION
We currently assume that there is a numpy float type per size. If/when numpy gets true IEEE-128bit floats, there will be a conflict between the long double and IEEE-128bit floats on systems where longdouble is padded to 128 bits (e.g. x86-64), or where longdouble isn't a IEEE-128bit float.