### PR TITLE
FIX: Make libver default to 'earliest' as documented

### DIFF
--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -49,7 +49,10 @@ def make_fapl(driver, libver, **kwds):
             high = h5f.LIBVER_LATEST
         else:
             low, high = (libver_dict[x] for x in libver)
-        plist.set_libver_bounds(low, high)
+    else:
+        # we default to earliest
+        low, high = h5f.LIBVER_EARLIEST, h5f.LIBVER_LATEST
+    plist.set_libver_bounds(low, high)
 
     if driver is None or (driver == 'windows' and sys.platform == 'win32'):
         # Prevent swallowing unused key arguments

--- a/h5py/tests/old/test_file.py
+++ b/h5py/tests/old/test_file.py
@@ -278,6 +278,12 @@ class TestLibver(TestCase):
         opening a file.
     """
 
+    def test_default(self):
+        """ Opening with no libver arg """
+        f = File(self.mktemp(), 'w')
+        self.assertEqual(f.libver, ('earliest','latest'))
+        f.close()
+
     def test_single(self):
         """ Opening with single libver arg """
         f = File(self.mktemp(), 'w', libver='latest')


### PR DESCRIPTION
Fixes #933. I remain confused what was actually happening, as as far as I can see, we were using the default settings of HDF5 (see https://support.hdfgroup.org/HDF5/doc/RM/RM_H5P.html#Property-SetLibverBounds), which were what we said they were. In any case, we're consistent with our docs now, if HDF5 ever changes its default. 