### PR TITLE
MAINT: Add PEP-518 (a.k.a pyproject.toml) support

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,7 @@ include setup_build.py
 include setup_configure.py
 include tox.ini
 include pytest.ini
+include pyproject.toml
 
 recursive-include docs *
 prune docs/_build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,4 +2,11 @@
 # this should match SETUP_REQUIRES in setup.py, with the addition of setuptools
 # and wheel (in case some point in the future pip does not assume setuptools and
 # wheel)
-requires = ["setuptools", "wheel", "numpy>=1.7", "Cython>=0.23", "pkgconfig"]
+requires = [
+  "setuptools",
+  "wheel",
+  "numpy==1.12.0; python_version=='3.6'",
+  "numpy==1.14.3; python_version>='3.7'",
+  "Cython>=0.23",
+  "pkgconfig"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+# this should match SETUP_REQUIRES in setup.py, with the addition of setuptools
+# and wheel (in case some point in the future pip does not assume setuptools and
+# wheel)
+requires = ["setuptools", "wheel", "numpy>=1.7", "Cython>=0.23", "pkgconfig"]

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,12 @@ RUN_REQUIRES = [NUMPY_DEP,]
 # these are required to build h5py
 # RUN_REQUIRES is included as setup.py test needs RUN_REQUIRES for testing
 # RUN_REQUIRES can be removed when setup.py test is removed
+# apart from RUN_REQUIRES, this should match the deps in pyproject.toml
 SETUP_REQUIRES = RUN_REQUIRES + [NUMPY_DEP, 'Cython>=0.23', 'pkgconfig']
+
+# this specifies which versions of python we support, pip >= 9 knows to skip
+# versions of packages which are not compatible with the running python
+PYTHON_REQUIRES = '>=2.6, !=3.0.*, !=3.1.*, !=3.2.*'
 
 # Needed to avoid trying to install numpy/cython on pythons which the latest
 # versions don't support


### PR DESCRIPTION
This adds PEP-518 support, which is a much improved replacement for setup_requires. Whereas setup_requires is setuptools specific, and always calls easy_install (meaning no wheels, no recent improvements to packaging etc.), PEP-518 is build-system independent (so pip and other tools can automatically get the needed dependencies). One advantage of PEP-518 for use is that by having pip (or at least newer versions of pip) deal with all of the installation, `python_depends` will be checked on all our dependencies, which means we should have less problems with our dependencies dropping older versions of python. Numpy already has `python_depends` set, and I'm sending a patch to both cython and pkgconfig.

There's a good explanation of PEP-518 at https://snarky.ca/clarifying-pep-518/, but I don't think we (h5py) should change our current setup.