### PR TITLE
DOC/MAINT: Typo/spelling fixes

### DIFF
--- a/ANN.rst
+++ b/ANN.rst
@@ -44,8 +44,8 @@ Changes
 * Entire code base ported to "six"; 2to3 removed from setup.py
   
 
-Acknowlegements
----------------
+Acknowledgements
+----------------
 
 This release incorporates changes from, among others:
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -306,7 +306,7 @@ Adding a function only available in certain versions of HDF5
 At the moment, h5py must be backwards-compatible all the way back to
 HDF5 1.8.4.  Starting with h5py 2.2.0, it's possible to conditionally
 include functions which only appear in newer versions of HDF5.  It's also
-possible to mark functions which requre Parallel HDF5.  For example, the
+possible to mark functions which require Parallel HDF5.  For example, the
 function ``H5Fset_mpi_atomicity`` was introduced in HDF5 1.8.9 and requires
 Parallel HDF5.  Specifiers before the signature in ``api_functions.txt``
 communicate this::

--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -4,7 +4,7 @@
 Datasets
 ========
 
-Datasets are very similar to NumPy arrays.  They are homogenous collections of
+Datasets are very similar to NumPy arrays.  They are homogeneous collections of
 data elements, with an immutable datatype and (hyper)rectangular shape.
 Unlike NumPy arrays, they support a variety of transparent storage features
 such as compression, error-detection, and chunked I/O.

--- a/docs/high/file.rst
+++ b/docs/high/file.rst
@@ -142,7 +142,7 @@ Unix-like systems use locale settings to determine the correct encoding to use.
 These are set via a number of different environment variables, of which ``LANG``
 and ``LC_ALL`` are the ones of most interest. Of special interest is the ``C``
 locale, which Python will interpret as only allowing ASCII, meaning unicode
-paths should be preencoded. This will likely change in Python 3.7 with
+paths should be pre-encoded. This will likely change in Python 3.7 with
 https://www.python.org/dev/peps/pep-0538/, but this will likely be backported by
 distributions to earlier versions.
 

--- a/docs/high/group.rst
+++ b/docs/high/group.rst
@@ -70,7 +70,7 @@ Objects can be deleted from the file using the standard syntax::
 .. note::
     When using h5py from Python 3, the keys(), values() and items() methods
     will return view-like objects instead of lists.  These objects support
-    containership testing and iteration, but can't be sliced like lists.
+    membership testing and iteration, but can't be sliced like lists.
 
 
 .. _group_hardlinks:
@@ -173,7 +173,7 @@ Reference
 
     .. method:: __contains__(name)
 
-        Dict-like containership testing.  `name` may be a relative or absolute
+        Dict-like membership testing.  `name` may be a relative or absolute
         path.
 
     .. method:: __getitem__(name)

--- a/docs/quick.rst
+++ b/docs/quick.rst
@@ -41,7 +41,7 @@ methods which look interesting.  One of them is ``create_dataset``::
     >>> dset = f.create_dataset("mydataset", (100,), dtype='i')
 
 The object we created isn't an array, but :ref:`an HDF5 dataset <dataset>`.
-Like NumPy arrays, datasets have both a shape and a data type:
+Like NumPy arrays, datasets have both a shape and a data type::
 
     >>> dset.shape
     (100,)
@@ -49,7 +49,7 @@ Like NumPy arrays, datasets have both a shape and a data type:
     dtype('int32')
 
 They also support array-style slicing.  This is how you read and write data
-from a dataset in the file:
+from a dataset in the file::
 
     >>> dset[...] = np.arange(100)
     >>> dset[0]
@@ -108,14 +108,14 @@ Iterating over a group provides the names of its members::
     subgroup
     subgroup2
 
-Containership testing also uses names:
+Containership testing also uses names::
 
     >>> "mydataset" in f
     True
     >>> "somethingelse" in f
     False
 
-You can even use full path names:
+You can even use full path names::
 
     >>> "subgroup/another_dataset" in f
     True

--- a/docs/quick.rst
+++ b/docs/quick.rst
@@ -108,7 +108,7 @@ Iterating over a group provides the names of its members::
     subgroup
     subgroup2
 
-Containership testing also uses names::
+Membership testing also uses names::
 
     >>> "mydataset" in f
     True

--- a/docs/strings.rst
+++ b/docs/strings.rst
@@ -74,7 +74,7 @@ representation used by NumPy (and the only one which round-trips through HDF5).
 
 Technically, these strings are supposed to store `only` ASCII-encoded text,
 although in practice anything you can store in NumPy will round-trip.  But
-for compatibility with other progams using HDF5 (IDL, MATLAB, etc.), you
+for compatibility with other programs using HDF5 (IDL, MATLAB, etc.), you
 should use ASCII only.
 
 .. note::

--- a/docs/swmr.rst
+++ b/docs/swmr.rst
@@ -10,7 +10,7 @@ What is SWMR?
 
 The SWMR features allow simple concurrent reading of a HDF5 file while it is 
 being written from another process. Prior to this feature addition it was not
-possible to do this as the file data and meta-data would not be syncrhonised
+possible to do this as the file data and meta-data would not be synchronised
 and attempts to read a file which was open for writing would fail or result in
 garbage data.
 

--- a/docs/whatsnew/2.0.rst
+++ b/docs/whatsnew/2.0.rst
@@ -26,7 +26,7 @@ Enhancements unlikely to affect compatibility
 
 * Object and region references now work correctly in compound types.
 
-* Zero-length dimensions for extendible axes are now allowed.
+* Zero-length dimensions for extendable axes are now allowed.
 
 * H5py no longer attempts to auto-import ipython on startup.
 

--- a/docs/whatsnew/2.5.rst
+++ b/docs/whatsnew/2.5.rst
@@ -21,7 +21,7 @@ SWMR support was contributed by Ulrik Pedersen (`#551`_).
 Other changes
 -------------
 * Use system Cython as a fallback if `cythonize()` fails (`#541`_ by Ulrik Pedersen).
-* Use pkg-config for builing/linking against hdf5 (`#505`_ by James Tocknell).
+* Use pkg-config for building/linking against hdf5 (`#505`_ by James Tocknell).
 * Disable building Cython on Travis (`#513`_ by Andrew Collette).
 * Improvements to release tarball (`#555`_, `#560`_ by Ghislain Antony
   Vaillant).
@@ -62,6 +62,6 @@ Other changes
 .. _`#501` : https://github.com/h5py/h5py/pull/501
 .. _`#503` : https://github.com/h5py/h5py/pull/503
 
-Acknowlegements
----------------
+Acknowledgements
+----------------
 

--- a/docs/whatsnew/2.6.rst
+++ b/docs/whatsnew/2.6.rst
@@ -41,7 +41,7 @@ to type conversion was added in `#614`_ by Andrew Collette.
 Documentation improvements
 --------------------------
 * Updates to FAQ by Dan Guest (`#608`_) and Peter Hill (`#607`_).
-* Updates MPI-releated documentation by Jens Timmerman (`#604`_) and
+* Updates MPI-related documentation by Jens Timmerman (`#604`_) and
   Matthias König (`#572`_).
 * Fixes to documentation building by Ghislain Antony Vaillant (`#562`_,
   `#561`_).
@@ -87,5 +87,5 @@ Other changes
 .. _`#661` : https://github.com/h5py/h5py/pull/661
 .. _`#663` : https://github.com/h5py/h5py/pull/663
 
-Acknowlegements
----------------
+Acknowledgements
+----------------

--- a/docs/whatsnew/2.7.1.rst
+++ b/docs/whatsnew/2.7.1.rst
@@ -31,7 +31,7 @@ to Python 3.3 onwards).
 Avoid unaligned memory access in conversion functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Some architectures (e.g. SPRAC64) do not allow unaligned memory access, which
+Some architectures (e.g. SPARC64) do not allow unaligned memory access, which
 can come up when copying packed structs. :issue:`904` (by James Clarke) uses
 ``memcpy`` to avoid said unaligned memory access.
 

--- a/docs/whatsnew/2.7.rst
+++ b/docs/whatsnew/2.7.rst
@@ -90,6 +90,6 @@ Other changes
 .. _`HDF5 Direct Chunk Write` : https://support.hdfgroup.org/HDF5/doc/Advanced/DirectChunkWrite/
 .. _`HDF5 File Image Operations` : http://www.hdfgroup.org/HDF5/doc/Advanced/FileImageOperations/HDF5FileImageOperations.pdf
 
-Acknowlegements
----------------
+Acknowledgements
+----------------
 

--- a/docs_api/automod.py
+++ b/docs_api/automod.py
@@ -11,7 +11,7 @@ from functools import partial
 role_expr = re.compile(r"(:.+:(?:`.+`)?)")
 
 def safe_replace(istr, expr, rpl):
-    """ Perform a role-safe replacement of all occurances of "expr", using
+    """ Perform a role-safe replacement of all occurrences of "expr", using
         the callable "rpl".
     """
     outparts = []
@@ -88,7 +88,7 @@ const_exclude = "|".join(const_exclude)
 
 const_expr = re.compile(r"""
 (?P<pre>
-  (?:^|\s+)                   # Must be preceeded by whitespace or string start
+  (?:^|\s+)                   # Must be preceded by whitespace or string start
   \W?                         # May have punctuation ( (CONST) or "CONST" )
   (?!%s)                      # Exclude known list of non-constant objects
 )
@@ -130,7 +130,7 @@ def replace_constant(istr, current_module):
 
 mod_expr = re.compile(r"""
 (?P<pre>
-  (?:^|\s+)                 # Must be preceeded by whitespace
+  (?:^|\s+)                 # Must be preceded by whitespace
   \W?                       # Optional opening paren/quote/whatever
 )
 (?!h5py)                    # Don't match the package name

--- a/docs_api/h5s.rst
+++ b/docs_api/h5s.rst
@@ -22,7 +22,7 @@ Module constants
 
 .. data:: ALL
 
-    Accepted in place of an actual datapace; means "every point"
+    Accepted in place of an actual dataspace; means "every point"
 
 .. data:: UNLIMITED
     

--- a/examples/collective_io.py
+++ b/examples/collective_io.py
@@ -15,7 +15,7 @@ import time
 import sys
 
 #"run as "mpirun -np 64 python-mpi collective_io.py 1 file.h5" 
-#(1 is for collective write, ohter number for non-collective write)"
+#(1 is for collective write, other numbers for non-collective write)"
 
 colw=1 #default is collective write
 filename="parallel_test.hdf5"

--- a/h5py/_conv.pyx
+++ b/h5py/_conv.pyx
@@ -185,7 +185,7 @@ cdef int conv_vlen2str(void* ipt, void* opt, void* bkg, void* priv) except -1:
     # is our responsibility to free the memory used by the vlens.
     free(buf_cstring0)
 
-    # HDF5 will eventuallly overwrite this target location, so we
+    # HDF5 will eventually overwrite this target location, so we
     # make sure to decref the object there.
     Py_XDECREF(bkg_obj0)
 

--- a/h5py/_errors.pyx
+++ b/h5py/_errors.pyx
@@ -36,7 +36,7 @@ _minor_table = {
     H5E_BADATOM:        ValueError,  # Unable to find atom information (already closed?) 
     H5E_BADGROUP:       ValueError,  # Unable to find ID group information 
     H5E_BADSELECT:      ValueError,  # Invalid selection (hyperslabs)
-    H5E_UNINITIALIZED:  ValueError,  # Information is uinitialized 
+    H5E_UNINITIALIZED:  ValueError,  # Information is uninitialized
     H5E_UNSUPPORTED:    NotImplementedError,    # Feature is unsupported 
 
     H5E_NOTFOUND:       KeyError,    # Object not found 
@@ -57,7 +57,7 @@ _minor_table = {
     H5E_CANTMOVE:       ValueError,  # Can't move a link
   }
 
-# "Fudge" table to accomodate annoying inconsistencies in HDF5's use 
+# "Fudge" table to accommodate annoying inconsistencies in HDF5's use
 # of the minor error codes.  If a (major, minor) entry appears here,
 # it will override any entry in the minor error table.
 _exact_table = {

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -490,7 +490,7 @@ class Dataset(HLObject):
             # pad with ones
             mshape = (1,)*(len(self.shape)-len(mshape)) + mshape
 
-        # Perfom the actual read
+        # Perform the actual read
         mspace = h5s.create_simple(mshape)
         fspace = selection.id
         self.id.read(mspace, fspace, arr, mtype, dxpl=self._dxpl)
@@ -684,8 +684,8 @@ class Dataset(HLObject):
     @with_phil
     def __array__(self, dtype=None):
         """ Create a Numpy array containing the whole dataset.  DON'T THINK
-        THIS MEANS DATASETS ARE INTERCHANGABLE WITH ARRAYS.  For one thing,
-        you have to read the whole dataset everytime this method is called.
+        THIS MEANS DATASETS ARE INTERCHANGEABLE WITH ARRAYS.  For one thing,
+        you have to read the whole dataset every time this method is called.
         """
         arr = numpy.empty(self.shape, dtype=self.dtype if dtype is None else dtype)
 
@@ -719,7 +719,7 @@ class Dataset(HLObject):
             """ Refresh the dataset metadata by reloading from the file.
 
             This is part of the SWMR features and only exist when the HDF5
-            librarary version >=1.9.178
+            library version >=1.9.178
             """
             self._id.refresh()
 
@@ -730,6 +730,6 @@ class Dataset(HLObject):
             If the dataset is chunked, raw data chunks are written to the file.
 
             This is part of the SWMR features and only exist when the HDF5
-            librarary version >=1.9.178
+            library version >=1.9.178
             """
             self._id.flush()

--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -154,7 +154,7 @@ def generate_dcpl(shape, dtype, chunks, compression, compression_opts,
                             'and floating-point types')
         
         # Scale/offset following fletcher32 in the filter chain will (almost?)
-        # always triggera a read error, as most scale/offset settings are
+        # always triggers a read error, as most scale/offset settings are
         # lossy. Since fletcher32 must come first (see comment below) we
         # simply prohibit the combination of fletcher32 and scale/offset.
         if fletcher32:

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -422,7 +422,7 @@ class Group(HLObject, MutableMappingHDF5):
 
         Returning None continues iteration, returning anything else stops
         and immediately returns that value from the visit method.  No
-        particular order of iteration within groups is guranteed.
+        particular order of iteration within groups is guaranteed.
 
         Example:
 
@@ -448,7 +448,7 @@ class Group(HLObject, MutableMappingHDF5):
 
         Returning None continues iteration, returning anything else stops
         and immediately returns that value from the visit method.  No
-        particular order of iteration within groups is guranteed.
+        particular order of iteration within groups is guaranteed.
 
         Example:
 

--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -20,7 +20,7 @@
 # Header declarations are the basenames of the C header files (without the .h);
 # for example, functions from "hdf5.h" are under the "hdf5" declaration.
 #
-# Function lines are C function signatures, optionally preceeded by:
+# Function lines are C function signatures, optionally preceded by:
 #   MPI     If present, function requires an MPI-aware build of h5py
 #   ERROR   Explicit error checks are needed (HDF5 does not use error stack)
 #   X.Y.Z   Minimum version of HDF5 required for this function

--- a/h5py/h5ds.pyx
+++ b/h5py/h5ds.pyx
@@ -120,7 +120,7 @@ def iterate(DatasetID dset not None, unsigned int dim, object func,
     => Return value from func
 
     Iterate a callable (function, method or callable object) over the
-    members of a group.  Your callable shoutld have the signature::
+    members of a group.  Your callable should have the signature::
 
         func(STRING name) => Result
 

--- a/h5py/h5f.pyx
+++ b/h5py/h5f.pyx
@@ -372,7 +372,7 @@ cdef class FileID(GroupID):
 
             Retrieves a copy of the image of an existing, open file.
 
-            Feature requries: 1.8.9
+            Feature requires: 1.8.9
             """
 
             cdef ssize_t size

--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -1494,7 +1494,7 @@ cdef class PropDXID(PropInstanceID):
         def set_dxpl_mpio(self, int xfer_mode):
             """ Set the transfer mode for MPI I/O.
             Must be one of:
-            - h5fd.MPIO_INDEPDENDENT (default)
+            - h5fd.MPIO_INDEPENDENT (default)
             - h5fd.MPIO_COLLECTIVE
             """
             H5Pset_dxpl_mpio(self.id, <H5FD_mpio_xfer_t>xfer_mode)
@@ -1502,7 +1502,7 @@ cdef class PropDXID(PropInstanceID):
         def get_dxpl_mpio(self):
             """ Get the current transfer mode for MPI I/O.
             Will be one of:
-            - h5fd.MPIO_INDEPDENDENT (default)
+            - h5fd.MPIO_INDEPENDENT (default)
             - h5fd.MPIO_COLLECTIVE
             """
             cdef H5FD_mpio_xfer_t mode

--- a/h5py/tests/hl/test_file.py
+++ b/h5py/tests/hl/test_file.py
@@ -28,7 +28,7 @@ def ngroups():
 class TestDealloc(TestCase):
 
     """ 
-        Behavior on object dellocation.  Note most of this behavior is
+        Behavior on object deallocation.  Note most of this behavior is
         delegated to FileID.
     """
     

--- a/h5py/tests/hl/test_threads.py
+++ b/h5py/tests/hl/test_threads.py
@@ -26,7 +26,7 @@ class TestErrorPrinting(TestCase):
     """
     
     def test_printing(self):
-        """ No console messages should be shown from containership tests """
+        """ No console messages should be shown from membership tests """
         # Unfortunately we can't have this test assert anything, as
         # HDF5 writes directly to stderr.  But it will show up in the
         # console output.

--- a/h5py/tests/old/test_base.py
+++ b/h5py/tests/old/test_base.py
@@ -40,7 +40,7 @@ class TestName(BaseTest):
     """
 
     def test_anonymous(self):
-        """ Anomymous objects have name None """
+        """ Anonymous objects have name None """
         grp = self.f.create_group(None)
         self.assertIs(grp.name, None)
 

--- a/h5py/tests/old/test_dataset.py
+++ b/h5py/tests/old/test_dataset.py
@@ -176,7 +176,7 @@ class TestCreateRequire(BaseDataset):
         with self.assertRaises(TypeError):
             self.f.require_dataset('foo', (10, 4), 'f')
 
-    def test_type_confict(self):
+    def test_type_conflict(self):
         """ require_dataset with object type conflict yields TypeError """
         self.f.create_group('foo')
         with self.assertRaises(TypeError):
@@ -418,7 +418,7 @@ class TestCreateShuffle(BaseDataset):
 @ut.skipIf('fletcher32' not in h5py.filters.encode, "FLETCHER32 is not installed")
 class TestCreateFletcher32(BaseDataset):
     """
-        Feature: Datases can use the fletcher32 filter
+        Feature: Datasets can use the fletcher32 filter
     """
 
     def test_fletcher32(self):
@@ -532,7 +532,7 @@ class TestCreateScaleOffset(BaseDataset):
 class TestAutoCreate(BaseDataset):
 
     """
-        Feauture: Datasets auto-created from data produce the correct types
+        Feature: Datasets auto-created from data produce the correct types
     """
 
     def test_vlen_bytes(self):
@@ -554,7 +554,7 @@ class TestAutoCreate(BaseDataset):
         self.assertEqual(tid.get_cset(), h5py.h5t.CSET_UTF8)
 
     def test_string_fixed(self):
-        """ Assignement of fixed-length byte string produces a fixed-length
+        """ Assignment of fixed-length byte string produces a fixed-length
         ascii dataset """
         self.f['x'] = np.string_("Hello there")
         ds = self.f['x']

--- a/h5py/tests/old/test_file.py
+++ b/h5py/tests/old/test_file.py
@@ -547,7 +547,7 @@ class TestFilename(TestCase):
 class TestBackwardsCompat(TestCase):
 
     """
-        Feauture: Deprecated attributes are included to support 1.3 code
+        Feature: Deprecated attributes are included to support 1.3 code
     """
 
     def test_fid(self):

--- a/h5py/tests/old/test_group.py
+++ b/h5py/tests/old/test_group.py
@@ -304,11 +304,11 @@ class TestLen(BaseMapping):
 class TestContains(BaseGroup):
 
     """
-        Feature: The Python "in" builtin tests for containership
+        Feature: The Python "in" builtin tests for membership
     """
 
     def test_contains(self):
-        """ "in" builtin works for containership (byte and Unicode) """
+        """ "in" builtin works for membership (byte and Unicode) """
         self.f.create_group('a')
         self.assertIn(b'a', self.f)
         self.assertIn(u'a', self.f)

--- a/h5py/tests/old/test_slicing.py
+++ b/h5py/tests/old/test_slicing.py
@@ -80,7 +80,7 @@ class TestSingleElement(BaseSlicing):
 class TestObjectIndex(BaseSlicing):
 
     """
-        Feauture: numpy.object_ subtypes map to real Python objects
+        Feature: numpy.object_ subtypes map to real Python objects
     """
 
     def test_reference(self):

--- a/lzf/lzf/lzfP.h
+++ b/lzf/lzf/lzfP.h
@@ -99,7 +99,7 @@
 
 /*
  * Avoid assigning values to errno variable? for some embedding purposes
- * (linux kernel for example), this is neccessary. NOTE: this breaks
+ * (linux kernel for example), this is necessary. NOTE: this breaks
  * the documentation in lzf.h.
  */
 #ifndef AVOID_ERRNO
@@ -107,7 +107,7 @@
 #endif
 
 /*
- * Wether to pass the LZF_STATE variable as argument, or allocate it
+ * Whether to pass the LZF_STATE variable as argument, or allocate it
  * on the stack. For small-stack environments, define this to 1.
  * NOTE: this breaks the prototype in lzf.h.
  */
@@ -116,11 +116,11 @@
 #endif
 
 /*
- * Wether to add extra checks for input validity in lzf_decompress
+ * Whether to add extra checks for input validity in lzf_decompress
  * and return EINVAL if the input stream has been corrupted. This
  * only shields against overflowing the input buffer and will not
  * detect most corrupted streams.
- * This check is not normally noticable on modern hardware
+ * This check is not normally noticeable on modern hardware
  * (<1% slowdown), but might slow down older cpus considerably.
  */
 

--- a/lzf/lzf_filter.c
+++ b/lzf/lzf_filter.c
@@ -42,7 +42,7 @@
 
 #endif
 
-/*  Deal with the mutiple definitions for H5Z_class_t.
+/*  Deal with the multiple definitions for H5Z_class_t.
     Note: Only HDF5 1.6 and 1.8 are supported.
 
     (1) The old class should always be used for HDF5 1.6

--- a/other/garbage.py
+++ b/other/garbage.py
@@ -8,7 +8,7 @@
 #           and contributor agreement.
 
 """
-    Demonstrates garbage messages printed to stderr for containership
+    Demonstrates garbage messages printed to stderr for membership
     testing, when performed in new threads.
 """
 


### PR DESCRIPTION
Saw a typo in the documentation and took a look then; no guarantees I spotted everything.

Only one change is in code, and it is a test function name, and thus should not alter behavior; rest is comments/docstrs.