### PR TITLE
ENH: Allow ExternalLinks to use non-ASCII hdf5 paths

### DIFF
--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -532,7 +532,7 @@ class ExternalLink(object):
 
     def __init__(self, filename, path):
         self._filename = filename_decode(filename_encode(filename))
-        self._path = str(path)
+        self._path = path
 
     def __repr__(self):
         return '<ExternalLink to "%s" in file "%s"' % (self.path, self.filename)

--- a/h5py/tests/old/test_group.py
+++ b/h5py/tests/old/test_group.py
@@ -769,6 +769,18 @@ class TestExternalLinks(TestCase):
         self.f['ext'] = ExternalLink(ext_filename, '/external')
         self.assertEqual(self.f["ext"].attrs["ext_attr"], "test")
 
+    def test_unicode_hdf5_path(self):
+        """
+        Check that external links handle unicode hdf5 paths properly
+        Testing issue #333
+        """
+        ext_filename = os.path.join(mkdtemp(), "external.hdf5")
+        with File(ext_filename, "w") as ext_file:
+            ext_file.create_group(u'α')
+            ext_file[u"α"].attrs["ext_attr"] = "test"
+        self.f['ext'] = ExternalLink(ext_filename, u'/α')
+        self.assertEqual(self.f["ext"].attrs["ext_attr"], "test")
+
 class TestExtLinkBugs(TestCase):
 
     """


### PR DESCRIPTION
Fixes #333. Encoding/decoding is handled when assigning/reading, so don't duplicate this inside the actual class (as it lacks the correct context).