### PR TITLE
ENH: allow registration of new drivers

### DIFF
--- a/h5py/__init__.py
+++ b/h5py/__init__.py
@@ -46,7 +46,12 @@ from . import h5a, h5d, h5ds, h5f, h5fd, h5g, h5r, h5s, h5t, h5p, h5z
 
 from ._hl import filters
 from ._hl.base import is_hdf5, HLObject, Empty
-from ._hl.files import File
+from ._hl.files import (
+    File,
+    register_driver,
+    unregister_driver,
+    registered_drivers,
+)
 from ._hl.group import Group, SoftLink, ExternalLink, HardLink
 from ._hl.dataset import Dataset
 from ._hl.datatype import Datatype

--- a/h5py/tests/hl/test_file.py
+++ b/h5py/tests/hl/test_file.py
@@ -14,6 +14,7 @@
 from __future__ import absolute_import
 
 import h5py
+from h5py._hl.files import _drivers
 
 from ..common import ut, TestCase
 
@@ -67,3 +68,36 @@ class TestDealloc(TestCase):
         
         self.assertEqual(nfiles(), start_nfiles)
         self.assertEqual(ngroups(), start_ngroups)
+
+
+class TestDriverRegsitration(TestCase):
+    def test_register_driver(self):
+        called_with = [None]
+
+        def set_fapl(plist, *args, **kwargs):
+            called_with[0] = args, kwargs
+            return _drivers['sec2'](plist)
+
+        h5py.register_driver('new-driver', set_fapl)
+        self.assertIn('new-driver', h5py.registered_drivers())
+
+        fname = self.mktemp()
+        h5py.File(fname, driver='new-driver', driver_arg_0=0, driver_arg_1=1)
+
+        self.assertEqual(
+            called_with,
+            [((), {'driver_arg_0': 0, 'driver_arg_1': 1})],
+        )
+
+    def test_unregister_driver(self):
+        h5py.register_driver('new-driver', lambda plist: None)
+        self.assertIn('new-driver', h5py.registered_drivers())
+
+        h5py.unregister_driver('new-driver')
+        self.assertNotIn('new-driver', h5py.registered_drivers())
+
+        with self.assertRaises(ValueError) as e:
+            fname = self.mktemp()
+            h5py.File(fname, driver='new-driver')
+
+        self.assertEqual(str(e.exception), 'Unknown driver type "new-driver"')


### PR DESCRIPTION
I am currently developing a driver for hdf5 to transparently store and read files from Amazon S3 and would like to expose bindings in Python with h5py. I searched briefly, but did not see any way to add support for a new driver in h5py so I have tried to implement a simple registration API.

This would probably need some tests and may not be the desired API, but I wanted to open this PR early to gauge interest in this feature. I have manually tested this feature against my driver and this does work, though it might not be comprehensive.

For those interested, the driver implementation is available [here](https://github.com/h5s3/h5s3). With this patch applied we have been able to read and write files, though we still have a lot of work to do before I would advise using this.