### PR TITLE
FIX: Avoid crashing the ipython completer when missing key

### DIFF
--- a/h5py/ipy_completer.py
+++ b/h5py/ipy_completer.py
@@ -172,7 +172,7 @@ def h5py_completer(self, event):
     """ Completer function to be loaded into IPython """
     base = re_object_match.split(event.line)[1]
 
-    if not isinstance(self._ofind(base)['obj'], (AttributeManager, HLObject)):
+    if not isinstance(self._ofind(base).get('obj'), (AttributeManager, HLObject)):
         raise TryNext
 
     try:


### PR DESCRIPTION
Fixes #885. I'm not sure how to test this or the completer in general. There's apparently support for ipython<0.11, which doesn't even support Python 3. We should probably work out what versions of ipython we actually want to support, and clean up the code (e.g. there's a comment about not calling any functions, why is that a thing?)