### PR TITLE
ENH: Add missing py36 setting to tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist = {py26,py27,py33,py34,py35,py36,pypy}-{test}-{deps,mindeps},nightly,doc
 deps =
     py26-test: unittest2
     deps: cython>=0.19
-    py{27,34,35}-deps: numpy>=1.7
+    py{27,34,35,36}-deps: numpy>=1.7
     py26-deps: numpy>=1.7,<1.11
     py33-deps: numpy>=1.7,<1.12
     mindeps: cython==0.19


### PR DESCRIPTION
Minor update, missed 36 in numpy deps.