### PR TITLE
FIX: Don't pass non-boolean ndarrays to PointSelection

### DIFF
--- a/h5py/_hl/selections.py
+++ b/h5py/_hl/selections.py
@@ -67,7 +67,7 @@ def select(shape, args, dsid):
                 raise TypeError("Mismatched selection shape")
             return arg
 
-        elif isinstance(arg, np.ndarray):
+        elif isinstance(arg, np.ndarray) and arg.dtype.kind == 'b':
             sel = PointSelection(shape)
             sel[arg]
             return sel

--- a/h5py/tests/hl/test_dataset_getitem.py
+++ b/h5py/tests/hl/test_dataset_getitem.py
@@ -407,6 +407,9 @@ class Test1DFloat(TestCase):
     def test_indexlist_simple(self):
         self.assertNumpyBehavior(self.dset, self.data, np.s_[[1,2,5]])
 
+    def test_indexlist_numpyarray(self):
+        self.assertNumpyBehavior(self.dset, self.data, np.s_[np.array([1, 2, 5])])
+
     def test_indexlist_single_index_ellipsis(self):
         self.assertNumpyBehavior(self.dset, self.data, np.s_[[0], ...])
 


### PR DESCRIPTION
Fixes #586. I need to add tests, both for checking boolean and non-boolean arrays, so WIP.