### PR TITLE
Track object creation order under group

### DIFF
--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -39,15 +39,25 @@ class Group(HLObject, MutableMappingHDF5):
                 raise ValueError("%s is not a GroupID" % bind)
             HLObject.__init__(self, bind)
 
-    def create_group(self, name):
+
+    _gcpl_crt_order = h5p.create(h5p.GROUP_CREATE)
+    _gcpl_crt_order.set_link_creation_order(
+        h5p.CRT_ORDER_TRACKED | h5p.CRT_ORDER_INDEXED)
+
+
+    def create_group(self, name, track_order=False):
         """ Create and return a new subgroup.
 
         Name may be absolute or relative.  Fails if the target name already
         exists.
+
+        track_order
+            Track dataset/group creation order under this group if True.
         """
         with phil:
             name, lcpl = self._e(name, lcpl=True)
-            gid = h5g.create(self.id, name, lcpl=lcpl)
+            gcpl = Group._gcpl_crt_order if track_order else None
+            gid = h5g.create(self.id, name, lcpl=lcpl, gcpl=gcpl)
             return Group(gid)
 
     def create_dataset(self, name, shape=None, dtype=None, data=None, **kwds):

--- a/h5py/tests/old/test_group.py
+++ b/h5py/tests/old/test_group.py
@@ -395,6 +395,20 @@ class TestIter(BaseMapping):
         finally:
             hfile.close()
 
+class TestTrackOrder(BaseGroup):
+    def test_track_order(self):
+        g = self.f.create_group('order', track_order=True)
+        for i in xrange(100):
+            # Mix group and dataset creation.
+            if i % 10 == 0:
+                g.create_group(str(i))
+            else:
+                g[str(i)] = [i]
+
+        objs = [str(i) for i in xrange(100)]
+        objs2 = [o for o in g]
+        self.assertEqual(objs, objs2)
+
 @ut.skipIf(sys.version_info[0] != 2, "Py2")
 class TestPy2Dict(BaseMapping):
 

--- a/h5py/tests/old/test_group.py
+++ b/h5py/tests/old/test_group.py
@@ -398,14 +398,14 @@ class TestIter(BaseMapping):
 class TestTrackOrder(BaseGroup):
     def test_track_order(self):
         g = self.f.create_group('order', track_order=True)
-        for i in xrange(100):
+        for i in range(100):
             # Mix group and dataset creation.
             if i % 10 == 0:
                 g.create_group(str(i))
             else:
                 g[str(i)] = [i]
 
-        objs = [str(i) for i in xrange(100)]
+        objs = [str(i) for i in range(100)]
         objs2 = [o for o in g]
         self.assertEqual(objs, objs2)
 


### PR DESCRIPTION
Changes made in this pull request:

1. Add an option `track_order` in `Group.create()` to enable object creation order tracking. Because of HDF5 limitation, this only works for group, not for root level objects.
2. If group has creation order tracking property, iterate over objects with creation order.