### PR TITLE
FIX: Don't reorder compound types, breaks on numpy 1.14 

### DIFF
--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -1136,12 +1136,6 @@ cdef class TypeCompoundID(TypeCompositeID):
         else:
             if sys.version[0] == '3':
                 field_names = [x.decode('utf8') for x in field_names]
-            if len(field_names) > 0:
-                collated_fields = zip(field_names, field_types, field_offsets)
-                ordered_fields = sorted(
-                    collated_fields, key=operator.itemgetter(2))
-                field_names, field_types, field_offsets = \
-                    map(list, zip(*ordered_fields))
             typeobj = dtype({
                 'names': field_names,
                 'formats': field_types,
@@ -1458,8 +1452,7 @@ cdef TypeCompoundID _c_compound(dtype dt, int logical, int aligned):
     cdef dtype member_dt
     cdef size_t member_offset = 0
 
-    cdef dict offsets = {}
-    cdef list fields = []
+    cdef dict fields = {}
 
     # The challenge with correctly converting a numpy/h5py dtype to a HDF5 type
     # which is composed of subtypes has three aspects we must consider
@@ -1468,19 +1461,14 @@ cdef TypeCompoundID _c_compound(dtype dt, int logical, int aligned):
     # 2. For correct round-tripping of aligned dtypes, we need to consider how
     #   much padding we need by looking at the field offsets
     # 3. There is no requirement that the offsets be monotonically increasing
-    #  (so we start by sorting the names as a function of increasing offset)
     #
     # The code below tries to cover these aspects
 
-    # Get offsets for each compound member
-    for name, field in dt.fields.items():
-        offsets[name] = field[1]
-
     # Build list of names, offsets, and types, sorted by increasing offset
     # (i.e. the position of the member in the struct)
-    for name in sorted(dt.names, key=offsets.__getitem__):
+    for name in sorted(dt.names, key=(lambda n: dt.fields[n][1])):
         field = dt.fields[name]
-        name = name.encode('utf8') if isinstance(name, unicode) else name
+        h5_name = name.encode('utf8') if isinstance(name, unicode) else name
 
         # Get HDF5 data types and set the offset for each member
         member_dt = field[0]
@@ -1489,7 +1477,7 @@ cdef TypeCompoundID _c_compound(dtype dt, int logical, int aligned):
         if aligned and (member_offset > field[1]
                         or member_dt.itemsize != member_type.get_size()):
             raise TypeError("Enforced alignment not compatible with HDF5 type")
-        fields.append((name, member_offset, member_type))
+        fields[name] = (h5_name, member_offset, member_type)
 
         # Update member offset based on the HDF5 type size
         member_offset += member_type.get_size()
@@ -1500,8 +1488,9 @@ cdef TypeCompoundID _c_compound(dtype dt, int logical, int aligned):
 
     # Create compound with the necessary size, and insert its members
     tid = H5Tcreate(H5T_COMPOUND, member_offset)
-    for (name, member_offset, member_type) in fields:
-        H5Tinsert(tid, name, member_offset, member_type.id)
+    for name in dt.names:
+        h5_name, member_offset, member_type = fields[name]
+        H5Tinsert(tid, h5_name, member_offset, member_type.id)
 
     return TypeCompoundID(tid)
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ RUN_REQUIRES = [NUMPY_DEP, 'six']
 # these are required to build h5py
 # RUN_REQUIRES is included as setup.py test needs RUN_REQUIRES for testing
 # RUN_REQUIRES can be removed when setup.py test is removed
-SETUP_REQUIRES = RUN_REQUIRES + [NUMPY_DEP, 'Cython>=0.19', 'pkgconfig']
+SETUP_REQUIRES = RUN_REQUIRES + [NUMPY_DEP, 'Cython>=0.23', 'pkgconfig']
 
 # Needed to avoid trying to install numpy/cython on pythons which the latest
 # versions don't support

--- a/tox.ini
+++ b/tox.ini
@@ -7,11 +7,11 @@ envlist = {py26,py27,py33,py34,py35,py36,pypy}-{test}-{deps,mindeps},nightly,doc
 [testenv]
 deps =
     py26-test: unittest2
-    deps: cython>=0.19
+    deps: cython>=0.23
     py{27,34,35}-deps: numpy>=1.7
     py26-deps: numpy>=1.7,<1.11
     py33-deps: numpy>=1.7,<1.12
-    mindeps: cython==0.19
+    mindeps: cython==0.23
     py{26,27,33}-mindeps: numpy==1.7
     py34-mindeps: numpy==1.9
     py35-mindeps: numpy==1.10.0.post2

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist = {py26,py27,py33,py34,py35,py36,pypy}-{test}-{deps,mindeps},nightly,doc
 deps =
     py26-test: unittest2
     deps: cython>=0.23
-    py{27,34,35}-deps: numpy>=1.7
+    py{27,34,35,36}-deps: numpy>=1.7
     py26-deps: numpy>=1.7,<1.11
     py33-deps: numpy>=1.7,<1.12
     mindeps: cython==0.23


### PR DESCRIPTION
This removes the reordering of compound dtypes when written or read, needed on order for h5py to work on numpy 1.14 and later.

This includes #962, so that all the tests will pass on Travis. Appveyor may fail due to #954.