### PR TITLE
Set itemsize when constructing dtype.

### DIFF
--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -1203,7 +1203,8 @@ cdef class TypeCompoundID(TypeCompositeID):
             typeobj = dtype({
                 'names': field_names,
                 'formats': field_types,
-                'offsets': field_offsets
+                'offsets': field_offsets,
+                'itemsize': self.get_size()
             })
 
         return typeobj

--- a/h5py/tests/hl/test_datatype.py
+++ b/h5py/tests/hl/test_datatype.py
@@ -152,7 +152,7 @@ class TestOffsets(TestCase):
                         self.assertEqual(np_offsets, offsets)
 
     def test_aligned_offsets(self):
-        dt = np.dtype('i2,i8', align=True)
+        dt = np.dtype('i4,i8,i2', align=True)
         ht = h5py.h5t.py_create(dt)
         self.assertEqual(dt.itemsize, ht.get_size())
         self.assertEqual(
@@ -162,12 +162,14 @@ class TestOffsets(TestCase):
 
 
     def test_aligned_data(self):
-        dt = np.dtype('i2,f8', align=True)
+        dt = np.dtype('i4,f8,i2', align=True)
         data = np.empty(10, dtype=dt)
 
         data['f0'] = np.array(np.random.randint(-100, 100, size=data.size),
-                dtype='i2')
+                dtype='i4')
         data['f1'] = np.random.rand(data.size)
+        data['f2'] = np.array(np.random.randint(-100, 100, size=data.size),
+                dtype='i2')
 
         fname = self.mktemp()
 


### PR DESCRIPTION
This fix is for #967. I have built h5py with hdf5 1.10.1 and 1.8.20 under python 2.7.14 and python 3.6.4. All tests passed when running `h5py.run_tests()` in prompt. The `dtype` of the dataset reports the correct `itemsize`.

System: macOS 10.13.2
numpy: 1.13.3