### PR TITLE
FIX: Fix check

### DIFF
--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -224,7 +224,7 @@ cdef dict _sign_map  = { H5T_SGN_NONE: 'u', H5T_SGN_2: 'i' }
 # Available floating point types
 available_ftypes = dict()
 for ftype in np.typeDict.values():
-    if np.issubdtype(ftype, float):
+    if np.issubdtype(ftype, np.floating):
         available_ftypes[np.dtype(ftype).itemsize] = np.finfo(ftype)
 
 # === General datatype operations =============================================


### PR DESCRIPTION
On latest `NumPy` dev I get a lot of these warnings when using `h5py`:
```
h5py/__init__.py:36: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.
```
This gets rid of them, but I'm not sure if the check should be more or less specific than this, but I think this is the change suggested by the warning message.