### PR TITLE
Add cache-manipulation parameters to h5py.File

### DIFF
--- a/docs/high/file.rst
+++ b/docs/high/file.rst
@@ -164,6 +164,63 @@ unicode filenames as other operating systems.
 The best suggestion is to use unicode strings, but to keep to ASCII for
 filenames to avoid possible breakage.
 
+
+.. _file_cache:
+
+Chunk cache
+...........
+
+:ref:`dataset_chunks` allows datasets to be stored on disk in separate pieces.
+When a part of any one of these pieces is needed, the entire chunk is read into
+memory before the requested part is copied to the user's buffer.  To the extent
+possible those chunks are cached in memory, so that if the user requests a
+different part of a chunk that has already been read, the data can be copied
+directly from memory rather than reading the file again.  The details of a
+given dataset's chunks are controlled when creating the dataset, but it is
+possible to adjust the behavior of the chunk *cache* when opening the file.
+
+The parameters controlling this behavior are prefixed by ``rdcc`, for raw data
+chunk cache.  The first parameter is ``rdcc_nbytes``, which sets the total size
+(measured in bytes) of the raw data chunk cache for each dataset.  The default
+size is 1 MB.  This should be set to the size of each chunk times the number of
+chunks that are likely to be needed in cache.
+
+The next parameter is ``rdcc_w0``, which sets the policy for chunks to be
+removed from the cache when more space is needed.  If the value is set to 0,
+then the library will always evict the least recently used chunk in cache.  If
+the value is set to 1, the library will always evict the least recently used
+chunk which has been fully read or written, and if none have been fully read or
+written, it will evict the least recently used chunk.  If the value is between
+0 and 1, the behavior will be a blend of the two.  Therefore, if the
+application will access the same data more than once, the value should be set
+closer to 0, and if the application does not, the value should be set closer
+to 1.
+
+The final parameter is ``rdcc_nslots``, which is the number of chunk slots in
+the cache for this entire file.  In order to allow the chunks to be looked up
+quickly in cache, each chunk is assigned a unique hash value that is used to
+look up the chunk.  The cache contains a simple array of pointers to chunks,
+which is called a hash table.  A chunk's hash value is simply the index into
+the hash table of the pointer to that chunk.  While the pointer at this
+location might instead point to a different chunk or to nothing at all, no
+other locations in the hash table can contain a pointer to the chunk in
+question.  Therefore, the library only has to check this one location in the
+hash table to tell if a chunk is in cache or not.  This also means that if two
+or more chunks share the same hash value, then only one of those chunks can be
+in the cache at the same time.  When a chunk is brought into cache and another
+chunk with the same hash value is already in cache, the second chunk must be
+evicted first.  Therefore it is very important to make sure that the size of
+the hash table (which is determined by the ``rdcc_nslots`` parameter) is large
+enough to minimize the number of hash value collisions.  Due to the hashing
+strategy, this value should ideally be a prime number.  As a rule of thumb,
+this value should be at least 10 times the number of chunks that can fit in
+``rdcc_nbytes`` bytes. For maximum performance, this value should be set
+approximately 100 times that number of chunks. The default value is 521.
+
+Chunks and caching are described in greater detail in the `HDF5 documentation
+<https://portal.hdfgroup.org/display/HDF5/Chunking+in+HDF5>`_.
+
+
 Reference
 ---------
 
@@ -173,7 +230,8 @@ Reference
     HDF5 name of the root group, "``/``". To access the on-disk name, use
     :attr:`File.filename`.
 
-.. class:: File(name, mode=None, driver=None, libver=None, userblock_size=None, **kwds)
+.. class:: File(name, mode=None, driver=None, libver=None, userblock_size=None, swmr=False,
+                rdcc_nslots=None, rdcc_nbytes=None, rdcc_w0=None, **kwds)
 
     Open or create a new file.
 
@@ -190,6 +248,14 @@ Reference
     :param userblock_size:  Size (in bytes) of the user block.  If nonzero,
                     must be a power of 2 and at least 512.  See
                     :ref:`file_userblock`.
+    :param swmr:    If ``True`` open the file in single-writer-multiple-reader
+                    mode. Only used when mode="r".
+    :param rdcc_nbytes:  Total size of the raw data chunk cache in bytes. The
+                    default size is 1024**2 (1 MB) per dataset.
+    :param rdcc_w0: Chunk preemption policy for all datasets.  Default value is
+                    0.75.
+    :param rdcc_nslots:  Number of chunk slots in the raw data chunk cache for
+                    this file.  Default value is 521.
     :param kwds:    Driver-specific keywords; see :ref:`file_driver`.
 
     .. method:: close()

--- a/docs/high/file.rst
+++ b/docs/high/file.rst
@@ -179,7 +179,7 @@ directly from memory rather than reading the file again.  The details of a
 given dataset's chunks are controlled when creating the dataset, but it is
 possible to adjust the behavior of the chunk *cache* when opening the file.
 
-The parameters controlling this behavior are prefixed by ``rdcc`, for raw data
+The parameters controlling this behavior are prefixed by ``rdcc``, for raw data
 chunk cache.  The first parameter is ``rdcc_nbytes``, which sets the total size
 (measured in bytes) of the raw data chunk cache for each dataset.  The default
 size is 1 MB.  This should be set to the size of each chunk times the number of

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -324,13 +324,13 @@ class File(Group):
             default value is 0.75.
         rdcc_nslots
             The number of chunk slots in the raw data chunk cache for this
-            dataset. Increasing this value reduces the number of cache
-            collisions, but slightly increases the memory used. Due to the
-            hashing strategy, this value should ideally be a prime number. As
-            a rule of thumb, this value should be at least 10 times the number
-            of chunks that can fit in rdcc_nbytes bytes. For maximum
-            performance, this value should be set approximately 100 times that
-            number of chunks. The default value is 521.
+            file. Increasing this value reduces the number of cache collisions,
+            but slightly increases the memory used. Due to the hashing
+            strategy, this value should ideally be a prime number. As a rule of
+            thumb, this value should be at least 10 times the number of chunks
+            that can fit in rdcc_nbytes bytes. For maximum performance, this
+            value should be set approximately 100 times that number of
+            chunks. The default value is 521.
         Additional keywords
             Passed on to the selected file driver.
 

--- a/h5py/tests/hl/test_file.py
+++ b/h5py/tests/hl/test_file.py
@@ -70,7 +70,7 @@ class TestDealloc(TestCase):
         self.assertEqual(ngroups(), start_ngroups)
 
 
-class TestDriverRegsitration(TestCase):
+class TestDriverRegistration(TestCase):
     def test_register_driver(self):
         called_with = [None]
 
@@ -101,3 +101,29 @@ class TestDriverRegsitration(TestCase):
             h5py.File(fname, driver='new-driver')
 
         self.assertEqual(str(e.exception), 'Unknown driver type "new-driver"')
+
+
+class TestCache(TestCase):
+    def test_defaults(self):
+        fname = self.mktemp()
+        f = h5py.File(fname, 'w')
+        self.assertEqual(list(f.id.get_access_plist().get_cache()),
+                         [0, 521, 1048576, 0.75])
+
+    def test_nbytes(self):
+        fname = self.mktemp()
+        f = h5py.File(fname, 'w', rdcc_nbytes=1024)
+        self.assertEqual(list(f.id.get_access_plist().get_cache()),
+                         [0, 521, 1024, 0.75])
+
+    def test_nslots(self):
+        fname = self.mktemp()
+        f = h5py.File(fname, 'w', rdcc_nslots=125)
+        self.assertEqual(list(f.id.get_access_plist().get_cache()),
+                         [0, 125, 1048576, 0.75])
+
+    def test_w0(self):
+        fname = self.mktemp()
+        f = h5py.File(fname, 'w', rdcc_w0=0.25)
+        self.assertEqual(list(f.id.get_access_plist().get_cache()),
+                         [0, 521, 1048576, 0.25])


### PR DESCRIPTION
This PR adds three arguments to `h5py.File` that control the chunk caching behavior:

  * `rdcc_nslots`: The number of slots in the cache's hash table
  * `rdcc_nbytes`: The number of bytes to use for the chunk cache
  * `rdcc_w0`: The parameter controlling cache preemption

The same parameters are added to the `make_fapl` helper function, which does the relevant work.  This effectively uses [`H5Pset_cache`](https://support.hdfgroup.org/HDF5/doc/RM/RM_H5P.html#Property-SetCache) to control the default behavior for a file.  It does *not* allow manipulation of the caching behavior on a per-dataset basis, as [`H5Pset_chunk_cache `](https://support.hdfgroup.org/HDF5/doc/RM/RM_H5P.html#Property-SetChunkCache) would.

This change [was requested by @aragilar](https://github.com/moble/h5py_cache/issues/1) in my [`h5py_cache` repo](https://github.com/moble/h5py_cache), which is just a hacky way of doing exactly this.  I did not carry over some code that I used for setting `nslots` because it's pretty dumb and ugly, and was tailored to my needs.
