### PR TITLE
Remove unnecessary import

### DIFF
--- a/h5py/__init__.py
+++ b/h5py/__init__.py
@@ -64,8 +64,6 @@ from .h5t import special_dtype, check_dtype
 from . import version
 from .version import version as __version__
 
-from .tests import run_tests
-
 if version.hdf5_version_tuple != version.hdf5_built_version_tuple:
     _warn(("h5py is running against HDF5 {0} when it was built against {1}, "
         "this may cause problems").format(


### PR DESCRIPTION
Import of 'run_tests' seems unnecessary in __init__.py