### PR TITLE
FIX: Use system encoding for errors, not utf-8

### DIFF
--- a/h5py/_errors.pyx
+++ b/h5py/_errors.pyx
@@ -9,6 +9,9 @@
 
 # Python-style minor error classes.  If the minor error code matches an entry
 # in this dict, the generated exception will be used.
+
+from ._hl.compat import filename_encode, filename_decode
+
 _minor_table = {
     H5E_SEEKERROR:      IOError,    # Seek failed 
     H5E_READERROR:      IOError,    # Read failed  
@@ -120,7 +123,10 @@ cdef int set_exception() except -1:
     if desc_bottom is NULL:
         raise RuntimeError("Failed to extract bottom-level error description")
 
-    msg = ("%s (%s)" % (desc.decode('utf-8').capitalize(), desc_bottom.decode('utf-8'))).encode('utf-8')
+    msg = filename_encode(u"{0} ({1})".format(
+        filename_decode(desc).capitalize(),
+        filename_decode(desc_bottom)
+    ))
 
     # Finally, set the exception.  We do this with the Python C function
     # so that the traceback doesn't point here.

--- a/h5py/tests/old/test_file.py
+++ b/h5py/tests/old/test_file.py
@@ -431,6 +431,16 @@ class TestUnicode(TestCase):
         with File(fname, 'w') as f:
             self.assertTrue(os.path.exists(fname))
 
+    def test_nonexistent_file_unicode(self):
+        """
+        Modes 'r' and 'r+' do not create files even when given unicode names
+        """
+        fname = self.mktemp(prefix = six.unichr(0x201a))
+        with self.assertRaises(IOError):
+            File(fname, 'r')
+        with self.assertRaises(IOError):
+            File(fname, 'r+')
+
 
 class TestFileProperty(TestCase):
 


### PR DESCRIPTION
Fixes #1016. We assume that the error messages are going to be in the same encoding as the file system encoding (if they're not, mojibake has already happened at the HDF5 level, so there's not much we can do...).