### PR TITLE
Support lists of unicode strings as attributes

### DIFF
--- a/h5py/h5a.pyx
+++ b/h5py/h5a.pyx
@@ -435,7 +435,10 @@ cdef class AttrID(ObjectID):
         """
         return H5Aget_storage_size(self.id)
 
-
+    @with_phil
+    def get_cset(self):
+        tid = H5Aget_type(self.id)
+        return <int>H5Tget_cset(tid)
 
 
 

--- a/h5py/h5t.pxd
+++ b/h5py/h5t.pxd
@@ -67,7 +67,7 @@ cdef class TypeCompoundID(TypeCompositeID):
 
 cpdef TypeID typewrap(hid_t id_)
 cdef hid_t H5PY_OBJ
-cpdef TypeID py_create(object dtype, bint logical=*, bint aligned=*)
+cpdef TypeID py_create(object dtype, bint logical=*, bint aligned=*, bint s_cset_utf8=*)
 
 
 


### PR DESCRIPTION
Store attributes that are lists of unicode strings as numpy bytestring arrays with character set set to UTF8 to indicate the data is encoded text.

This is compatible with other programs reading the file, which will simply see an array of bytestrings and the character set flag (which they can ignore if they like)

This addresses #441 