### PR TITLE
Allow list of unicode strings to be saved as attrs

### DIFF
--- a/docs/strings.rst
+++ b/docs/strings.rst
@@ -148,6 +148,28 @@ this and "pretend" to support it, h5py will raise an error when attempting
 to create datasets or attributes of this type.
 
 
+Handling of iterables of strings as attributes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you set an attribute equal to a Python list or tuple of unicode strings,
+such as the following:
+
+    >>> f.attrs['x'] = (u'a', u'b') # PY2
+    >>> f.attrs['x'] = ('a', 'b') # PY3
+
+h5py will save these as arrays of variable-length strings with character set
+H5T_CSET_UTF8. When read back, the result will be numpy arrays of dtype
+``'object'``, as if the original data were written as:
+
+    # PY2
+    >>> f['x'] = np.array((u'a', u'b'), dtype=h5py.special_dtype(vlen=unicode))
+
+    # PY3
+    >>> f['x'] = np.array(('a', 'b'), dtype=h5py.special_dtype(vlen=str))
+    
+h5py will only perform this conversion if you set an attribute that is not a numpy array.
+
+
 Object names
 ------------
 

--- a/docs/strings.rst
+++ b/docs/strings.rst
@@ -154,15 +154,14 @@ Handling of iterables of strings as attributes
 If you set an attribute equal to a Python list or tuple of unicode strings,
 such as the following:
 
-    >>> f.attrs['x'] = (u'a', u'b') # PY2
-    >>> f.attrs['x'] = ('a', 'b') # PY3
+    >>> f.attrs['x'] = (u'a', u'b')
 
 h5py will save these as arrays of variable-length strings with character set
 H5T_CSET_UTF8. When read back, the result will be numpy arrays of dtype
 ``'object'``, as if the original data were written as:
 
-    >>> f['x'] = np.array((u'a', u'b'), dtype=h5py.special_dtype(vlen=unicode)) # PY2
     >>> f['x'] = np.array(('a', 'b'), dtype=h5py.special_dtype(vlen=str)) # PY3
+    >>> f['x'] = np.array((u'a', u'b'), dtype=h5py.special_dtype(vlen=unicode)) # PY2
     
 h5py will only perform this conversion if you set an attribute that is not a numpy array.
 

--- a/docs/strings.rst
+++ b/docs/strings.rst
@@ -148,8 +148,8 @@ this and "pretend" to support it, h5py will raise an error when attempting
 to create datasets or attributes of this type.
 
 
-Handling of iterables of strings as attributes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Handling of lists/tuples of strings as attributes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you set an attribute equal to a Python list or tuple of unicode strings,
 such as the following:
@@ -157,14 +157,11 @@ such as the following:
     >>> f.attrs['x'] = (u'a', u'b')
 
 h5py will save these as arrays of variable-length strings with character set
-H5T_CSET_UTF8. When read back, the result will be numpy arrays of dtype
+H5T_CSET_UTF8. When read back, the results will be numpy arrays of dtype
 ``'object'``, as if the original data were written as:
 
     >>> f['x'] = np.array(('a', 'b'), dtype=h5py.special_dtype(vlen=str)) # PY3
     >>> f['x'] = np.array((u'a', u'b'), dtype=h5py.special_dtype(vlen=unicode)) # PY2
-
-h5py will only perform this conversion if you set an attribute that is not a numpy
-array.
 
 
 Object names

--- a/docs/strings.rst
+++ b/docs/strings.rst
@@ -162,8 +162,9 @@ H5T_CSET_UTF8. When read back, the result will be numpy arrays of dtype
 
     >>> f['x'] = np.array(('a', 'b'), dtype=h5py.special_dtype(vlen=str)) # PY3
     >>> f['x'] = np.array((u'a', u'b'), dtype=h5py.special_dtype(vlen=unicode)) # PY2
-    
-h5py will only perform this conversion if you set an attribute that is not a numpy array.
+
+h5py will only perform this conversion if you set an attribute that is not a numpy
+array.
 
 
 Object names

--- a/docs/strings.rst
+++ b/docs/strings.rst
@@ -149,7 +149,7 @@ to create datasets or attributes of this type.
 
 
 Handling of iterables of strings as attributes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you set an attribute equal to a Python list or tuple of unicode strings,
 such as the following:
@@ -161,11 +161,8 @@ h5py will save these as arrays of variable-length strings with character set
 H5T_CSET_UTF8. When read back, the result will be numpy arrays of dtype
 ``'object'``, as if the original data were written as:
 
-    # PY2
-    >>> f['x'] = np.array((u'a', u'b'), dtype=h5py.special_dtype(vlen=unicode))
-
-    # PY3
-    >>> f['x'] = np.array(('a', 'b'), dtype=h5py.special_dtype(vlen=str))
+    >>> f['x'] = np.array((u'a', u'b'), dtype=h5py.special_dtype(vlen=unicode)) # PY2
+    >>> f['x'] = np.array(('a', 'b'), dtype=h5py.special_dtype(vlen=str)) # PY3
     
 h5py will only perform this conversion if you set an attribute that is not a numpy array.
 

--- a/h5py/_hl/attrs.py
+++ b/h5py/_hl/attrs.py
@@ -119,14 +119,12 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
             # First, make sure we have a NumPy array.  We leave the data type
             # conversion for HDF5 to perform (other than the below exception).
             if not isinstance(data, Empty):
-                # Whether we were already given a numpy array or whether we are
-                # converting to a numpy array ourselves:
-                auto_convert_to_array = not isinstance(data, numpy.ndarray)
+                is_list_or_tuple = isinstance(data, (list, tuple))
                 data = numpy.asarray(data, order='C')
-                # If we converted to a numpy array ourselves, then we do not
-                # need to respect the datatype of the numpy array. If it is U
-                # type, convert to vlen unicode strings:
-                if auto_convert_to_array and data.dtype.type == numpy.unicode_:
+                # If we were passed a list or tuple, then we do not need to respect the
+                # datatype of the numpy array. If it is U type, convert to vlen unicode
+                # strings:
+                if is_list_or_tuple and data.dtype.type == numpy.unicode_:
                     data = numpy.array(data, dtype=h5t.special_dtype(vlen=six.text_type))
 
             if shape is None:

--- a/h5py/_hl/attrs.py
+++ b/h5py/_hl/attrs.py
@@ -116,16 +116,16 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
 
         with phil:
 
-            # First, make sure we have a NumPy array.  We leave the data
-            # type conversion for HDF5 to perform (other than the below exception).
+            # First, make sure we have a NumPy array.  We leave the data type
+            # conversion for HDF5 to perform (other than the below exception).
             if not isinstance(data, Empty):
                 # Whether we were already given a numpy array or whether we are
                 # converting to a numpy array ourselves:
                 auto_convert_to_array = not isinstance(data, numpy.ndarray)
                 data = numpy.asarray(data, order='C')
-                # If we converted to a numpy array ourselves, then we do not need
-                # to respect the datatype of the numpy array. If it is U type, 
-                # convert to vlen unicode strings:
+                # If we converted to a numpy array ourselves, then we do not
+                # need to respect the datatype of the numpy array. If it is U
+                # type, convert to vlen unicode strings:
                 if auto_convert_to_array and data.dtype.type == numpy.unicode_:
                     data = numpy.array(data, dtype=h5t.special_dtype(vlen=six.text_type))
 

--- a/h5py/_hl/attrs.py
+++ b/h5py/_hl/attrs.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 
 import numpy
 import uuid
-
+import six
 
 from .. import h5s, h5t, h5a
 from . import base
@@ -117,9 +117,17 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
         with phil:
 
             # First, make sure we have a NumPy array.  We leave the data
-            # type conversion for HDF5 to perform.
+            # type conversion for HDF5 to perform (other than the below exception).
             if not isinstance(data, Empty):
+                # Whether we were already given a numpy array or whether we are
+                # converting to a numpy array ourselves:
+                auto_convert_to_array = not isinstance(data, numpy.ndarray)
                 data = numpy.asarray(data, order='C')
+                # If we converted to a numpy array ourselves, then we do not need
+                # to respect the datatype of the numpy array. If it is U type, 
+                # convert to vlen unicode strings:
+                if auto_convert_to_array and data.dtype.type == numpy.unicode_:
+                    data = numpy.array(data, dtype=h5t.special_dtype(vlen=six.text_type))
 
             if shape is None:
                 shape = data.shape

--- a/h5py/tests/hl/test_attribute_create.py
+++ b/h5py/tests/hl/test_attribute_create.py
@@ -45,3 +45,21 @@ class TestArray(TestCase):
         # See issue 498 discussion
         
         self.f.attrs.create('x', data=42, dtype='i8')
+
+    def test_tuple_of_unicode(self):
+        # Test that a tuple of unicode strings can be set as an attribute. It will
+        # be converted to a numpy array of vlen unicode type:
+        data = (u'a', u'b')
+        self.f.attrs.create('x', data=data)
+        result = self.f.attrs['x']
+        self.assertTrue(all(result == data))
+        self.assertEqual(result.dtype, np.dtype('O'))
+
+        # However, a numpy array of type U being passed in will not be
+        # automatically converted, and should raise an error as it does
+        # not map to a h5py dtype
+        data_as_U_array = np.array(data)
+        self.assertEqual(data_as_U_array.dtype, np.dtype('U1'))
+        with self.assertRaises(TypeError):
+            self.f.attrs.create('y', data=data_as_U_array)
+

--- a/h5py/tests/hl/test_attribute_create.py
+++ b/h5py/tests/hl/test_attribute_create.py
@@ -62,4 +62,3 @@ class TestArray(TestCase):
         self.assertEqual(data_as_U_array.dtype, np.dtype('U1'))
         with self.assertRaises(TypeError):
             self.f.attrs.create('y', data=data_as_U_array)
-


### PR DESCRIPTION
This addresses issue #441

Store attributes that are lists of unicode strings as arrays of vlen unicode type

This is only done if the array was auto converted from a tuple or similar.
If the user passes in a numpy array, then its type will be respected and not auto converted.

With this change the following works without error:

```python
with h5py.File('test', driver='core', backing_store=False) as f:
    f.attrs['x'] = ['ü', 'y']
    print(repr(f.attrs[u'x']))
```
printing:

```python
array(['ü', 'y'], dtype=object)
```
