### PR TITLE
ENH: Add deprecation warnings where needed.

### DIFF
--- a/h5py/__init__.py
+++ b/h5py/__init__.py
@@ -113,3 +113,6 @@ from .h5t import py_new_vlen as new_vlen
 from .h5t import py_get_vlen as get_vlen
 from .h5t import py_new_enum as new_enum
 from .h5t import py_get_enum as get_enum
+
+from .h5py_warnings import ModuleWrapper as _ModuleWrapper
+highlevel = _ModuleWrapper("h5py.highlevel")

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 
 import posixpath as pp
 import sys
+from warnings import warn
 
 from threading import local
 
@@ -31,6 +32,7 @@ from . import selections2 as sel2
 from .datatype import Datatype
 from .compat import filename_decode
 from .vds import VDSmap, vds_support
+from ..h5py_warnings import H5pyDeprecationWarning
 
 _LEGACY_GZIP_COMPRESSION_VALS = frozenset(range(10))
 MPI = h5.get_config().mpi
@@ -285,8 +287,8 @@ class Dataset(HLObject):
     @with_phil
     def value(self):
         """  Alias for dataset[()] """
-        DeprecationWarning("dataset.value has been deprecated. "
-            "Use dataset[()] instead.")
+        warn("dataset.value has been deprecated. "
+            "Use dataset[()] instead.", H5pyDeprecationWarning)
         return self[()]
 
     @property

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 
 import sys
 import os
+from warnings import warn
 
 from .compat import filename_decode, filename_encode
 
@@ -24,6 +25,7 @@ from .base import phil, with_phil
 from .group import Group
 from .. import h5, h5f, h5p, h5i, h5fd, _objects
 from .. import version
+from ..h5py_warnings import H5pyDeprecationWarning
 
 mpi = h5.get_config().mpi
 hdf5_version = version.hdf5_version_tuple[0:3]
@@ -213,7 +215,7 @@ class File(Group):
     @with_phil
     def filename(self):
         """File name on disk"""
-        return filename_decode(h5f.get_name(self.fid))
+        return filename_decode(h5f.get_name(self.id))
 
     @property
     @with_phil
@@ -227,19 +229,21 @@ class File(Group):
                    h5fd.MPIO: 'mpio',
                    h5fd.MPIPOSIX: 'mpiposix',
                    h5fd.fileobj_driver: 'fileobj'}
-        return drivers.get(self.fid.get_access_plist().get_driver(), 'unknown')
+        return drivers.get(self.id.get_access_plist().get_driver(), 'unknown')
 
     @property
     @with_phil
     def mode(self):
         """ Python mode used to open file """
         return {h5f.ACC_RDONLY: 'r',
-                h5f.ACC_RDWR: 'r+'}.get(self.fid.get_intent())
+                h5f.ACC_RDWR: 'r+'}.get(self.id.get_intent())
 
     @property
     @with_phil
     def fid(self):
         """File ID (backwards compatibility) """
+        warn("File.fid has been deprecated. "
+            "Use File.id instead.", H5pyDeprecationWarning)
         return self.id
 
     @property
@@ -253,7 +257,7 @@ class File(Group):
     @with_phil
     def userblock_size(self):
         """ User block size (in bytes) """
-        fcpl = self.fid.get_create_plist()
+        fcpl = self.id.get_create_plist()
         return fcpl.get_userblock()
 
 
@@ -405,7 +409,7 @@ class File(Group):
         """ Tell the HDF5 library to flush its buffers.
         """
         with phil:
-            h5f.flush(self.fid)
+            h5f.flush(self.id)
 
     @with_phil
     def __enter__(self):

--- a/h5py/h5py_warnings.py
+++ b/h5py/h5py_warnings.py
@@ -11,9 +11,28 @@
     This module contains the warning classes for h5py. These classes are part of
     the public API of h5py, and should be imported from this module.
 """
+try:
+    from importlib import import_module
+except ImportError:
+    import_module = __import__
 
 class H5pyWarning(UserWarning):
     pass
 
+
 class H5pyDeprecationWarning(H5pyWarning):
     pass
+
+
+class ModuleWrapper(object):
+    def __init__(self, mod):
+        self._imported = False
+        self._mod = mod
+
+    def __getattr__(self, attr):
+        if not self._imported:
+            self._mod = self._import()
+        return getattr(self._mod, attr)
+
+    def _import(self):
+        return import_module(self._mod)

--- a/h5py/highlevel.py
+++ b/h5py/highlevel.py
@@ -18,6 +18,15 @@
 
 from __future__ import absolute_import
 
+import warnings
+from .h5py_warnings import H5pyDeprecationWarning
+warnings.warn(
+    "The h5py.highlevel module is deprecated, code should import directly "
+    "from h5py, e.g. 'from h5py import File'.",
+    H5pyDeprecationWarning,
+    stacklevel=2
+)
+
 from ._hl import filters
 from ._hl.base import is_hdf5, HLObject
 from ._hl.files import File

--- a/h5py/tests/hl/test_deprecation.py
+++ b/h5py/tests/hl/test_deprecation.py
@@ -1,0 +1,27 @@
+# This file is part of h5py, a Python interface to the HDF5 library.
+#
+# http://www.h5py.org
+#
+# Copyright 2008-2018 Andrew Collette and contributors
+#
+# License:  Standard 3-clause BSD; see "license.txt" for full license terms
+#           and contributor agreement.
+
+"""
+Tests that deprecations work correctly
+"""
+from __future__ import absolute_import
+
+import h5py
+
+from ..common import ut, TestCase
+
+
+class TestDeprecations(TestCase):
+    def test_highlevel_access(self):
+        warning_message = (
+            "The h5py.highlevel module is deprecated, code should import "
+            "directly from h5py, e.g. 'from h5py import File'."
+        )
+        with self.assertWarnsRegex(H5pyDeprecationWarning, warning_message) as warning:
+            hl = h5py.highlevel

--- a/h5py/tests/old/test_attrs.py
+++ b/h5py/tests/old/test_attrs.py
@@ -24,9 +24,9 @@ import collections
 
 from ..common import TestCase, ut
 
-from h5py.highlevel import File
+from h5py import File
 from h5py import h5a,  h5t
-from h5py.highlevel import AttributeManager
+from h5py import AttributeManager
 
 
 class BaseAttrs(TestCase):

--- a/h5py/tests/old/test_attrs_data.py
+++ b/h5py/tests/old/test_attrs_data.py
@@ -23,7 +23,7 @@ from ..common import TestCase, ut
 
 import h5py
 from h5py import h5a, h5s, h5t
-from h5py.highlevel import File
+from h5py import File
 from h5py._hl.base import is_empty_dataspace
 
 class BaseAttrs(TestCase):

--- a/h5py/tests/old/test_dataset.py
+++ b/h5py/tests/old/test_dataset.py
@@ -25,7 +25,7 @@ import six
 import numpy as np
 
 from ..common import ut, TestCase
-from h5py.highlevel import File, Group, Dataset
+from h5py import File, Group, Dataset
 from h5py._hl.base import is_empty_dataspace
 from h5py import h5f, h5t
 import h5py

--- a/h5py/tests/old/test_dimension_scales.py
+++ b/h5py/tests/old/test_dimension_scales.py
@@ -14,7 +14,7 @@ import sys
 import numpy as np
 
 from ..common import ut, TestCase
-from h5py.highlevel import File, Group, Dataset
+from h5py import File, Group, Dataset
 import h5py
 
 

--- a/h5py/tests/old/test_file.py
+++ b/h5py/tests/old/test_file.py
@@ -22,7 +22,7 @@ import tempfile
 import six
 
 from ..common import ut, TestCase, UNICODE_FILENAMES, closed_tempfile
-from h5py.highlevel import File
+from h5py import File
 import h5py
 
 try:

--- a/h5py/tests/old/test_group.py
+++ b/h5py/tests/old/test_group.py
@@ -30,8 +30,8 @@ import six
 
 from ..common import ut, TestCase
 import h5py
-from h5py.highlevel import File, Group, SoftLink, HardLink, ExternalLink
-from h5py.highlevel import Dataset, Datatype
+from h5py import File, Group, SoftLink, HardLink, ExternalLink
+from h5py import Dataset, Datatype
 from h5py import h5t
 from h5py._hl.compat import filename_encode
 

--- a/h5py/tests/old/test_slicing.py
+++ b/h5py/tests/old/test_slicing.py
@@ -26,7 +26,7 @@ from ..common import ut, TestCase
 
 import h5py
 from h5py import h5s, h5t, h5d
-from h5py.highlevel import File
+from h5py import File
 
 class BaseSlicing(TestCase):
 


### PR DESCRIPTION
There's a few places where we've deprecated something, but not warned about it (based on grepping the h5py folder, so there may be other places where we should be warning). This adds those warnings.