### PR TITLE
Small change to improve REPL usability: HDF5KeysView

### DIFF
--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -301,6 +301,12 @@ class HLObject(CommonStateObject):
 # AttributeManager can only test for key names.
 
 
+class KeysViewHDF5(KeysView):
+    def __str__(self):
+        k = ", ".join(repr(x) for x in self)
+        return "hdf_keys([{}])".format(k)
+    __repr__ = __str__
+
 class ValuesViewHDF5(ValuesView):
 
     """
@@ -380,7 +386,7 @@ class MappingHDF5(Mapping):
     else:
         def keys(self):
             """ Get a view object on member names """
-            return KeysView(self)
+            return KeysViewHDF5(self)
 
         def values(self):
             """ Get a view object on member objects """


### PR DESCRIPTION
This change adds an HDF5KeysView class to be the return type of Group.keys()

When exploring files interactively it can be handy to quickly see what the keys of a group are.
This change follows the behaviour of `dict.keys` by returning an object whose representation shows
its elements.

For example, before, when `f` is an `h5py.File` instance :
```
    > f.keys()
    KeysView(<HDF5 file "filename.hdf" (mode r+)>)
```
after:
```
    > f.keys()
    hdf_keys(['group1', 'group2'])
```

This exactly matches the `dict.keys` behaviour but with `dict_keys -> hdf_keys`