### PR TITLE
Fix DeprecationWarning on Python 3.7

### DIFF
--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -16,8 +16,13 @@ from __future__ import absolute_import
 import posixpath
 import os
 import six
-from collections import (Mapping, MutableMapping, KeysView,
-                         ValuesView, ItemsView)
+
+try:
+    from collections.abc import (Mapping, MutableMapping, KeysView,
+                                 ValuesView, ItemsView)
+except ImportError:
+    from collections import (Mapping, MutableMapping, KeysView,
+                             ValuesView, ItemsView)
 
 from .compat import fspath, filename_encode
 


### PR DESCRIPTION
Fixes the following warning on Python 3.7:

```
> py -3.7 -Wd -c"import h5py"
X:\Python37\lib\site-packages\h5py\_hl\base.py:19: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  from collections import (Mapping, MutableMapping, KeysView,
```