### PR TITLE
Add open_file_image for opening a file from an image

### DIFF
--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -150,6 +150,7 @@ hdf5:
 
   # File Image Operations
   1.8.9     ssize_t H5Fget_file_image(hid_t file_id, void *buf_ptr, size_t buf_len)
+  1.8.9     hid_t H5LTopen_file_image(void *buf_ptr, size_t buf_len, unsigned int flags)
 
   # MPI functions
   MPI 1.8.9 herr_t H5Fset_mpi_atomicity(hid_t file_id, hbool_t flag)

--- a/h5py/api_types_hdf5.pxd
+++ b/h5py/api_types_hdf5.pxd
@@ -99,6 +99,11 @@ cdef extern from "hdf5.h":
     H5F_ACC_SWMR_WRITE
     H5F_ACC_SWMR_READ
 
+  cdef enum:
+    H5LT_FILE_IMAGE_OPEN_RW
+    H5LT_FILE_IMAGE_DONT_COPY
+    H5LT_FILE_IMAGE_DONT_RELEASE
+
   # The difference between a single file and a set of mounted files
   cdef enum H5F_scope_t:
     H5F_SCOPE_LOCAL     = 0,    # specified file handle only

--- a/h5py/h5f.pyx
+++ b/h5py/h5f.pyx
@@ -35,9 +35,6 @@ ACC_TRUNC   = H5F_ACC_TRUNC
 ACC_EXCL    = H5F_ACC_EXCL
 ACC_RDWR    = H5F_ACC_RDWR
 ACC_RDONLY  = H5F_ACC_RDONLY
-if HDF5_VERSION >= (1, 8, 9):
-    ACC_FILE_IMAGE_DONT_COPY = H5LT_FILE_IMAGE_DONT_COPY
-    ACC_FILE_IMAGE_OPEN_RW = H5LT_FILE_IMAGE_OPEN_RW
 IF HDF5_VERSION >= SWMR_MIN_HDF5_VERSION:
     ACC_SWMR_WRITE = H5F_ACC_SWMR_WRITE
     ACC_SWMR_READ  = H5F_ACC_SWMR_READ
@@ -62,6 +59,11 @@ UNLIMITED   = H5F_UNLIMITED
 
 LIBVER_EARLIEST = H5F_LIBVER_EARLIEST
 LIBVER_LATEST = H5F_LIBVER_LATEST
+
+if HDF5_VERSION >= (1, 8, 9):
+    FILE_IMAGE_OPEN_RW = H5LT_FILE_IMAGE_OPEN_RW
+    FILE_IMAGE_DONT_COPY = H5LT_FILE_IMAGE_DONT_COPY
+    FILE_IMAGE_DONT_RELEASE = H5LT_FILE_IMAGE_DONT_RELEASE
 
 # === File operations =========================================================
 
@@ -103,16 +105,23 @@ def create(char* name, int flags=H5F_ACC_TRUNC, PropFCID fcpl=None,
 
 IF HDF5_VERSION >= (1, 8, 9):
     @with_phil
-    def open_file_image(char* image, int flags=H5FLT_FILE_IMAGE_DONT_COPY):
-        """(STRING image, INT flags=ACC_FILE_IMAGE_DONT_COPY) => FileID
+    def open_file_image(char* image, int flags=0):
+        """(STRING image, INT flags=0) => FileID
 
         Load a new HDF5 file into memory.  Keyword "flags" may be:
 
-        ACC_FILE_IMAGE_DONT_COPY
-            Open an existing image, read only.
+        FILE_IMAGE_OPEN_RW
+            Specifies opening the file image in read/write mode.
 
-        ACC_FILE_IMAGE_OPEN_RW
-            Copy the given buffer, open read/write.
+        FILE_IMAGE_DONT_COPY
+            Specifies to not copy the provided file image buffer;
+            the buffer will be used directly. HDF5 will release the
+            file image when finished.
+
+        FILE_IMAGE_DONT_RELEASE
+        Specifies that HDF5 is not to release the buffer when the file is closed;
+        releasing the buffer will be left to the application. This flag is valid
+        only when used with FILE_IMAGE_DONT_COPY.
         """
         return FileID(H5LTopen_file_image(image, len(image), flags))
 

--- a/h5py/h5f.pyx
+++ b/h5py/h5f.pyx
@@ -35,8 +35,9 @@ ACC_TRUNC   = H5F_ACC_TRUNC
 ACC_EXCL    = H5F_ACC_EXCL
 ACC_RDWR    = H5F_ACC_RDWR
 ACC_RDONLY  = H5F_ACC_RDONLY
-ACC_FILE_IMAGE_DONT_COPY = H5LT_FILE_IMAGE_DONT_COPY
-ACC_FILE_IMAGE_OPEN_RW = H5LT_FILE_IMAGE_OPEN_RW
+if HDF5_VERSION >= (1, 8, 9):
+    ACC_FILE_IMAGE_DONT_COPY = H5LT_FILE_IMAGE_DONT_COPY
+    ACC_FILE_IMAGE_OPEN_RW = H5LT_FILE_IMAGE_OPEN_RW
 IF HDF5_VERSION >= SWMR_MIN_HDF5_VERSION:
     ACC_SWMR_WRITE = H5F_ACC_SWMR_WRITE
     ACC_SWMR_READ  = H5F_ACC_SWMR_READ
@@ -100,20 +101,20 @@ def create(char* name, int flags=H5F_ACC_TRUNC, PropFCID fcpl=None,
     """
     return FileID(H5Fcreate(name, flags, pdefault(fcpl), pdefault(fapl)))
 
+IF HDF5_VERSION >= (1, 8, 9):
+    @with_phil
+    def open_file_image(char* image, int flags=H5FLT_FILE_IMAGE_DONT_COPY):
+        """(STRING image, INT flags=ACC_FILE_IMAGE_DONT_COPY) => FileID
 
-@with_phil
-def open_file_image(char* image, int flags=H5FLT_FILE_IMAGE_DONT_COPY):
-    """(STRING image, INT flags=ACC_FILE_IMAGE_DONT_COPY) => FileID
+        Load a new HDF5 file into memory.  Keyword "flags" may be:
 
-    Load a new HDF5 file into memory.  Keyword "flags" may be:
+        ACC_FILE_IMAGE_DONT_COPY
+            Open an existing image, read only.
 
-    ACC_FILE_IMAGE_DONT_COPY
-        Open an existing image, read only.
-
-    ACC_FILE_IMAGE_OPEN_RW
-        Copy the given buffer, open read/write.
-    """
-    return FileID(H5LTopen_file_image(image, len(image), flags))
+        ACC_FILE_IMAGE_OPEN_RW
+            Copy the given buffer, open read/write.
+        """
+        return FileID(H5LTopen_file_image(image, len(image), flags))
 
 
 @with_phil

--- a/h5py/h5f.pyx
+++ b/h5py/h5f.pyx
@@ -35,6 +35,8 @@ ACC_TRUNC   = H5F_ACC_TRUNC
 ACC_EXCL    = H5F_ACC_EXCL
 ACC_RDWR    = H5F_ACC_RDWR
 ACC_RDONLY  = H5F_ACC_RDONLY
+ACC_FILE_IMAGE_DONT_COPY = H5LT_FILE_IMAGE_DONT_COPY
+ACC_FILE_IMAGE_OPEN_RW = H5LT_FILE_IMAGE_OPEN_RW
 IF HDF5_VERSION >= SWMR_MIN_HDF5_VERSION:
     ACC_SWMR_WRITE = H5F_ACC_SWMR_WRITE
     ACC_SWMR_READ  = H5F_ACC_SWMR_READ
@@ -97,6 +99,21 @@ def create(char* name, int flags=H5F_ACC_TRUNC, PropFCID fcpl=None,
     the default is ACC_TRUNC.  Be careful!
     """
     return FileID(H5Fcreate(name, flags, pdefault(fcpl), pdefault(fapl)))
+
+
+@with_phil
+def open_file_image(char* image, int flags=H5FLT_FILE_IMAGE_DONT_COPY):
+    """(STRING image, INT flags=ACC_FILE_IMAGE_DONT_COPY) => FileID
+
+    Load a new HDF5 file into memory.  Keyword "flags" may be:
+
+    ACC_FILE_IMAGE_DONT_COPY
+        Open an existing image, read only.
+
+    ACC_FILE_IMAGE_OPEN_RW
+        Copy the given buffer, open read/write.
+    """
+    return FileID(H5LTopen_file_image(image, len(image), flags))
 
 
 @with_phil

--- a/h5py/tests/old/test_file_image.py
+++ b/h5py/tests/old/test_file_image.py
@@ -23,3 +23,16 @@ class TestFileImage(TestCase):
         f = h5py.File(fid)
 
         self.assertTrue('test' in f)
+
+    def test_open_from_image(self):
+        from binascii import a2b_base64
+        from zlib import decompress
+
+        compressed_image = 'eJzr9HBx4+WS4mIAAQ4OBhYGAQZk8B8KKjhQ+TD5BCjNCKU7oPQKJpg4I1hOAiouCDUfXV1IkKsrSPV/NACzx4AFQnMwjIKRCDxcHQNAdASUD0ulJ5hQ1ZWkFpeAaFh69KDQXkYGNohZjDA+JCUzMkIEmKHqELQAWKkAByytOoBJViAPJM7ExATWyAE0B8RgZkyAJmlYDoEAIahukJoNU6+HMTA0UOgT6oBgP38XUI6G5UMFZrzKR8EoGAUjGMDKYVgxDSsuAHcfMK8='
+
+        image = decompress(a2b_base64(compressed_image))
+
+        fid = h5f.open_file_image(image)
+        f = h5py.File(fid)
+
+        self.assertTrue('test' in f)


### PR DESCRIPTION
Adds access to H5LTopen_file_image from the low level interface. This will allow opening files from byte arrays without creating an empty file, as opening a new file and then calling set_file_image would.