### PR TITLE
New method create_dataset_like

### DIFF
--- a/docs/high/group.rst
+++ b/docs/high/group.rst
@@ -363,6 +363,23 @@ Reference
 
         :keyword exact:     Require shape and type to match exactly (T/**F**)
 
+
+    .. method:: create_dataset_like(name, other, **kwds)
+
+        Create a dataset similar to `other`, much like numpy's `_like` functions.
+
+        :param name:
+            Name of the dataset (absolute or relative).  Provide None to make
+            an anonymous dataset.
+        :param other:
+            The dataset whom the new dataset should mimic. All properties, such
+            as shape, dtype, chunking, ... will be taken from it, but no data
+            or attributes are being copied.
+
+        Any dataset keywords (see create_dataset) may be provided, including
+        shape and dtype, in which case the provided values take precedence over
+        those from `other`.
+
     .. attribute:: attrs
 
         :ref:`attributes` for this group.

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -158,12 +158,12 @@ class Group(HLObject, MutableMappingHDF5):
         shape and dtype, in which case the provided values take precedence over
         those from `other`.
         """
-        kw = {k: kwupdate.get(k, getattr(other, k)) for k in [
-            'shape', 'dtype', 'chunks', 'maxshape', 'compression',
-            'compression_opts', 'scaleoffset', 'shuffle', 'fletcher32', 'fillvalue'
-        ]}
+        for k in ('shape', 'dtype', 'chunks', 'maxshape', 'compression',
+                  'compression_opts', 'scaleoffset', 'shuffle', 'fletcher32',
+                  'fillvalue'):
+            kwupdate.setdefault(k, getattr(other, k))
 
-        return self.create_dataset(name, **kw)
+        return self.create_dataset(name, **kwupdate)
 
     def require_group(self, name):
         """ Return a group, creating it if it doesn't exist.

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -150,7 +150,7 @@ class Group(HLObject, MutableMappingHDF5):
             Name of the dataset (absolute or relative).  Provide None to make
             an anonymous dataset.
         other
-            The dataset whom the new dataset should mimic. All properties, such
+            The dataset which the new dataset should mimic. All properties, such
             as shape, dtype, chunking, ... will be taken from it, but no data
             or attributes are being copied.
 
@@ -158,10 +158,16 @@ class Group(HLObject, MutableMappingHDF5):
         shape and dtype, in which case the provided values take precedence over
         those from `other`.
         """
-        for k in ('shape', 'dtype', 'chunks', 'maxshape', 'compression',
+        for k in ('shape', 'dtype', 'chunks', 'compression',
                   'compression_opts', 'scaleoffset', 'shuffle', 'fletcher32',
                   'fillvalue'):
             kwupdate.setdefault(k, getattr(other, k))
+
+        # Special case: the maxshape property always exists, but if we pass it
+        # to create_dataset, the new dataset will automatically get chunked
+        # layout. So we copy it only if it is different from shape.
+        if other.maxshape != other.shape:
+            kwupdate.setdefault('maxshape', other.maxshape)
 
         return self.create_dataset(name, **kwupdate)
 

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -143,6 +143,28 @@ class Group(HLObject, MutableMappingHDF5):
 
             return dset
 
+    def create_dataset_like(self, name, other, **kwupdate):
+        """ Create a dataset similar to `other`.
+
+        name
+            Name of the dataset (absolute or relative).  Provide None to make
+            an anonymous dataset.
+        other
+            The dataset whom the new dataset should mimic. All properties, such
+            as shape, dtype, chunking, ... will be taken from it, but no data
+            or attributes are being copied.
+
+        Any dataset keywords (see create_dataset) may be provided, including
+        shape and dtype, in which case the provided values take precedence over
+        those from `other`.
+        """
+        kw = {k: kwupdate.get(k, getattr(other, k)) for k in [
+            'shape', 'dtype', 'chunks', 'maxshape', 'compression',
+            'compression_opts', 'scaleoffset', 'shuffle', 'fletcher32', 'fillvalue'
+        ]}
+
+        return self.create_dataset(name, **kw)
+
     def require_group(self, name):
         """ Return a group, creating it if it doesn't exist.
 

--- a/h5py/tests/old/test_dataset.py
+++ b/h5py/tests/old/test_dataset.py
@@ -564,6 +564,15 @@ class TestAutoCreate(BaseDataset):
         self.assertEqual(tid.get_cset(), h5py.h5t.CSET_ASCII)
 
 
+class TestCreateLike(BaseDataset):
+    def test_no_chunks(self):
+        self.f['lol'] = np.arange(25).reshape(5, 5)
+        self.f.create_dataset_like('like_lol', self.f['lol'])
+        dslike = self.f['like_lol']
+        self.assertEqual(dslike.shape, (5, 5))
+        self.assertIs(dslike.chunks, None)
+
+
 class TestResize(BaseDataset):
 
     """


### PR DESCRIPTION
Continuation of #848.

I added the test under the `old` subdirectory because that's where all the other tests of creating datasets seemed to be. I can move it if preferred, but it wasn't clear to me what qualifies a test as not 'old'.