### PR TITLE
File-like objects support for h5py.File

### DIFF
--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -360,7 +360,7 @@ class File(Group):
                     raise ValueError("Invalid value of 'fileobj' argument; "
                                      "must equal to file-like object if specified.")
                 kwds.update(fileobj=name)
-                name = repr(name).encode('ASCII')
+                name = repr(name).encode('ASCII', 'replace')
             else:
                 name = filename_encode(name)
 

--- a/h5py/h5fd.pyx
+++ b/h5py/h5fd.pyx
@@ -107,7 +107,6 @@ ctypedef struct H5FD_fileobj_t:
 # parameters (dxpl, type) are ignored.
 
 from cpython cimport Py_INCREF, Py_DECREF
-import numpy as np
 from libc.stdlib cimport malloc as stdlib_malloc
 from libc.stdlib cimport free as stdlib_free
 cimport libc.stdio
@@ -156,7 +155,7 @@ cdef herr_t H5FD_fileobj_read(H5FD_fileobj_t *f, H5FD_mem_t type, hid_t dxpl, ha
     (<object>f.fileobj).seek(addr)
     if hasattr(<object>f.fileobj, 'readinto'):
         mview = <unsigned char[:size]>(buf)
-        (<object>f.fileobj).readinto(np.asarray(mview))
+        (<object>f.fileobj).readinto(mview)
     else:
         b = (<object>f.fileobj).read(size)
         if len(b) == size:
@@ -169,7 +168,7 @@ cdef herr_t H5FD_fileobj_write(H5FD_fileobj_t *f, H5FD_mem_t type, hid_t dxpl, h
     cdef unsigned char[:] mview
     (<object>f.fileobj).seek(addr)
     mview = <unsigned char[:size]>buf
-    (<object>f.fileobj).write(np.asarray(mview))
+    (<object>f.fileobj).write(mview)
     return 0
 
 cdef herr_t H5FD_fileobj_truncate(H5FD_fileobj_t *f, hid_t dxpl, hbool_t closing) except 1:


### PR DESCRIPTION
A small follow-up for https://github.com/h5py/h5py/issues/1006, actually enabling a work-around for https://github.com/h5py/h5py/issues/839.
Only https://github.com/h5py/h5py/commit/875e3729fe1b321702977cfda351aff5c740eee6 is of interest, sorry for unclean history :shy:
