### PR TITLE
MAINT Numpy 1.16 deprecates asscalar

### DIFF
--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -552,7 +552,7 @@ class Dataset(HLObject):
         if len(names) == 1:
             arr = arr[names[0]]     # Single-field recarray convention
         if arr.shape == ():
-            arr = numpy.asscalar(arr)
+            arr = arr.item()
         if single_element:
             arr = arr[0]
         return arr


### PR DESCRIPTION
Just a quick refactor to avoid using deprecated function that is deprecated in numpy/numpy#12123