### PR TITLE
FIX: hide mpi imports until as late as possible

### DIFF
--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -34,14 +34,13 @@ swmr_support = False
 if hdf5_version >= h5.get_config().swmr_min_hdf5_version:
     swmr_support = True
 
-if mpi:
-    import mpi4py
 
 libver_dict = {'earliest': h5f.LIBVER_EARLIEST, 'latest': h5f.LIBVER_LATEST}
 libver_dict_r = dict((y, x) for x, y in six.iteritems(libver_dict))
 
 
 def _set_fapl_mpio(plist, **kwargs):
+    import mpi4py
     kwargs.setdefault('info', mpi4py.MPI.Info())
     plist.set_fapl_mpio(**kwargs)
 

--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -29,14 +29,6 @@ from h5py import _objects
 
 from ._objects import phil, with_phil
 
-if MPI:
-    if MPI4PY_V2:
-        from mpi4py.libmpi cimport MPI_Comm, MPI_Info, MPI_Comm_dup, MPI_Info_dup, \
-                               MPI_Comm_free, MPI_Info_free
-    else:
-        from mpi4py.mpi_c cimport MPI_Comm, MPI_Info, MPI_Comm_dup, MPI_Info_dup, \
-                               MPI_Comm_free, MPI_Info_free
-
 # Initialization
 import_array()
 
@@ -1174,6 +1166,15 @@ cdef class PropFAID(PropInstanceID):
             0. The mpi4py.MPI.Comm Communicator
             1. The mpi4py.MPI.Comm Info
             """
+            if MPI4PY_V2:
+                from mpi4py.libmpi cimport (
+                    MPI_Comm, MPI_Info, MPI_Comm_dup, MPI_Info_dup,
+                    MPI_Comm_free, MPI_Info_free)
+            else:
+                from mpi4py.mpi_c cimport (
+                    MPI_Comm, MPI_Info, MPI_Comm_dup, MPI_Info_dup,
+                    MPI_Comm_free, MPI_Info_free)
+
             cdef MPI_Comm comm
             cdef MPI_Info info
 

--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -29,6 +29,17 @@ from h5py import _objects
 
 from ._objects import phil, with_phil
 
+if MPI:
+    if MPI4PY_V2:
+        from mpi4py.libmpi cimport (
+            MPI_Comm, MPI_Info, MPI_Comm_dup, MPI_Info_dup,
+            MPI_Comm_free, MPI_Info_free)
+    else:
+        from mpi4py.mpi_c cimport (
+            MPI_Comm, MPI_Info, MPI_Comm_dup, MPI_Info_dup,
+            MPI_Comm_free, MPI_Info_free)
+
+
 # Initialization
 import_array()
 
@@ -1166,15 +1177,6 @@ cdef class PropFAID(PropInstanceID):
             0. The mpi4py.MPI.Comm Communicator
             1. The mpi4py.MPI.Comm Info
             """
-            if MPI4PY_V2:
-                from mpi4py.libmpi cimport (
-                    MPI_Comm, MPI_Info, MPI_Comm_dup, MPI_Info_dup,
-                    MPI_Comm_free, MPI_Info_free)
-            else:
-                from mpi4py.mpi_c cimport (
-                    MPI_Comm, MPI_Info, MPI_Comm_dup, MPI_Info_dup,
-                    MPI_Comm_free, MPI_Info_free)
-
             cdef MPI_Comm comm
             cdef MPI_Info info
 


### PR DESCRIPTION
This may help all of the mpi order-related issues.

closes #1081 