### PR TITLE
Clearer broadcasting errors with singleton dimensions

### DIFF
--- a/h5py/_hl/selections.py
+++ b/h5py/_hl/selections.py
@@ -296,7 +296,13 @@ class SimpleSelection(Selection):
                 if t == 1 or count[-idx] == t:
                     tshape.append(t)
                 else:
-                    raise TypeError("Can't broadcast %s -> %s" % (target_shape, count))
+                    raise TypeError("Can't broadcast %s -> %s" % (target_shape, self.mshape))
+
+        if any([n > 1 for n in target]):
+            # All dimensions from target_shape should either have been popped
+            # to match the selection shape, or be 1.
+            raise TypeError("Can't broadcast %s -> %s" % (target_shape, self.mshape))
+
         tshape.reverse()
         tshape = tuple(tshape)
 

--- a/h5py/tests/old/test_slicing.py
+++ b/h5py/tests/old/test_slicing.py
@@ -141,6 +141,16 @@ class TestSimpleSlicing(TestCase):
         """ Negative stop indexes work as they do in NumPy """
         self.assertArrayEqual(self.dset[2:-2], self.arr[2:-2])
 
+    def test_write(self):
+        """Assigning to a 1D slice of a 2D dataset
+        """
+        dset = self.f.create_dataset('x2', (10, 2))
+
+        x = np.zeros((10, 1))
+        dset[:, 0] = x[:, 0]
+        with self.assertRaises(TypeError):
+            dset[:, 1] = x
+
 class TestArraySlicing(BaseSlicing):
 
     """


### PR DESCRIPTION
From discussion on #910.

```python
import numpy as np
import h5py

with h5py.File('foo.h5', 'w') as f:
    ds = f.create_dataset("foo", (2, 10, 10, 4))

    ds[:, :, :, 2] = np.zeros((2, 10, 10, 1))  # Error A

with h5py.File('bar.h5', 'w') as f:
    ds = f.create_dataset("bar", (10, 4))

    ds[:, 2] = np.zeros((10, 1))  # Error B
```

Error A:

```
Before: TypeError: Can't broadcast (2, 10, 10, 1) -> (2, 10, 10, 1)
After:  TypeError: Can't broadcast (2, 10, 10, 1) -> (2, 10, 10)
```

Error B:

```
Before: OSError: Can't prepare for writing data (src and dest data spaces have different sizes)
After:  TypeError: Can't broadcast (10, 1) -> (10,)
```