### PR TITLE
Expose the full H5Sselect_hyperslab API to _hl.selections

### DIFF
--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -313,6 +313,31 @@ Obviously shouldn't be used with lossy compression filters.
 
 Enable by setting :meth:`Group.create_dataset` keyword ``fletcher32`` to True.
 
+.. _dataset_multi_block:
+
+Multi-Block Selection
+---------------------
+
+The full H5Sselect_hyperslab API is exposed via the MultiBlockSlice object.
+This takes four elements to define the selection (start, count, stride and
+block) in constrast to the built-in slice object, which takes three elements.
+A MultiBlockSlice can be used in place of a slice to select a number of (count)
+blocks of multiple elements separated by a stride, rather than a set of single
+elements separated by a step.
+
+For an explanation of how this slicing works, see the `HDF5 documentation <https://support.hdfgroup.org/HDF5/Tutor/selectsimple.html>`_.
+
+For example::
+
+    >>> dset[...]
+    array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10])
+    >>> dset[MultiBlockSlice(start=1, count=3, stride=4, block=2)]
+    array([ 1,  2,  5,  6,  9, 10])
+
+They can be used in multi-dimensional slices alongside any slicing object,
+including other MultiBlockSlices. For a more complete example of this,
+see the multiblockslice_interleave.py example script.
+
 .. _dataset_fancy:
 
 Fancy indexing

--- a/examples/multiblockslice_interleave.py
+++ b/examples/multiblockslice_interleave.py
@@ -1,0 +1,36 @@
+"""
+An example of using MultiBlockSlice to interleave frames in a virtual dataset.
+"""
+import h5py
+
+
+# These files were written round-robin in blocks of 1000 frames from a single source
+# 1.h5 has 0-999, 4000-4999, ...; 2.h4 has 1000-1999, 5000-5999, ...; etc
+# The frames from each block are contiguous within each file
+# e.g. 1.h5 = [..., 998, 999, 4000, 4001, ... ]
+files = ["1.h5", "2.h5", "3.h5", "4.h5"]
+dataset_name = "data"
+dtype = "float"
+source_shape = (25000, 256, 512)
+target_shape = (100000, 256, 512)
+block_size = 1000
+
+v_layout = h5py.VirtualLayout(shape=target_shape, dtype=dtype)
+
+for file_idx, file_path in enumerate(files):
+    v_source = h5py.VirtualSource(
+        file_path, name=dataset_name, shape=source_shape, dtype=dtype
+    )
+    dataset_frames = v_source.shape[0]
+
+    # A single raw file maps to every len(files)th block of frames in the VDS
+    start = file_idx * block_size  # 0, 1000, 2000, 3000
+    count = dataset_frames // block_size  # 25
+    stride = len(files) * block_size  # 4000
+    block = block_size  # 1000
+
+    # MultiBlockSlice for frame dimension and full extent for height and width
+    v_layout[h5py.MultiBlockSlice(start, count, stride, block), :, :] = v_source
+
+with h5py.File("interleave_vds.h5", "w", libver="latest") as f:
+    f.create_virtual_dataset(dataset_name, v_layout, fillvalue=0)

--- a/h5py/__init__.py
+++ b/h5py/__init__.py
@@ -65,6 +65,7 @@ from ._hl.files import (
 )
 from ._hl.group import Group, SoftLink, ExternalLink, HardLink
 from ._hl.dataset import Dataset
+from ._hl.selections import MultiBlockSlice
 from ._hl.datatype import Datatype
 from ._hl.attrs import AttributeManager
 

--- a/h5py/tests/test_dataset_getitem.py
+++ b/h5py/tests/test_dataset_getitem.py
@@ -34,6 +34,7 @@
         Ellipsis
         Empty tuple
         Regular slice
+        MultiBlockSlice
         Indexing
         Index list
         Boolean mask
@@ -83,6 +84,11 @@ class TestEmpty(TestCase):
         """ slice -> ValueError """
         with self.assertRaises(ValueError):
             self.dset[0:4]
+
+    def test_multi_block_slice(self):
+        """ MultiBlockSlice -> ValueError """
+        with self.assertRaises(ValueError):
+            self.dset[h5py.MultiBlockSlice()]
 
     def test_index(self):
         """ index -> ValueError """
@@ -135,6 +141,11 @@ class TestScalarFloat(TestCase):
         """ slice -> ValueError """
         with self.assertRaises(ValueError):
             self.dset[0:4]
+
+    def test_multi_block_slice(self):
+        """ MultiBlockSlice -> ValueError """
+        with self.assertRaises(ValueError):
+            self.dset[h5py.MultiBlockSlice()]
 
     def test_index(self):
         """ index -> ValueError """
@@ -193,6 +204,11 @@ class TestScalarCompound(TestCase):
         """ slice -> ValueError """
         with self.assertRaises(ValueError):
             self.dset[0:4]
+
+    def test_multi_block_slice(self):
+        """ MultiBlockSlice -> ValueError """
+        with self.assertRaises(ValueError):
+            self.dset[h5py.MultiBlockSlice()]
 
     def test_index(self):
         """ index -> ValueError """
@@ -253,6 +269,11 @@ class TestScalarArray(TestCase):
         """ slice -> ValueError """
         with self.assertRaises(ValueError):
             self.dset[0:4]
+
+    def test_multi_block_slice(self):
+        """ MultiBlockSlice -> ValueError """
+        with self.assertRaises(ValueError):
+            self.dset[h5py.MultiBlockSlice()]
 
     def test_index(self):
         """ index -> ValueError """

--- a/h5py/tests/test_slicing.py
+++ b/h5py/tests/test_slicing.py
@@ -22,7 +22,7 @@ from .common import ut, TestCase
 
 import h5py
 from h5py import h5s, h5t, h5d
-from h5py import File
+from h5py import File, MultiBlockSlice
 
 class BaseSlicing(TestCase):
 
@@ -316,3 +316,101 @@ class TestFieldNames(BaseSlicing):
         data2['b'] = 1.0
         self.dset['b'] = 1.0
         self.assertTrue(np.all(self.dset[...] == data2))
+
+
+class TestMultiBlockSlice(BaseSlicing):
+
+    def setUp(self):
+        super(TestMultiBlockSlice, self).setUp()
+        self.arr = np.arange(10)
+        self.dset = self.f.create_dataset('x', data=self.arr)
+
+    def test_default(self):
+        # Default selects entire dataset as one block
+        mbslice = MultiBlockSlice()
+
+        self.assertEqual(mbslice.indices(10), (0, 10, 1, 1))
+        np.testing.assert_array_equal(self.dset[mbslice], self.arr)
+
+    def test_default_explicit(self):
+        mbslice = MultiBlockSlice(start=0, count=10, stride=1, block=1)
+
+        self.assertEqual(mbslice.indices(10), (0, 10, 1, 1))
+        np.testing.assert_array_equal(self.dset[mbslice], self.arr)
+
+    def test_start(self):
+        mbslice = MultiBlockSlice(start=4)
+
+        self.assertEqual(mbslice.indices(10), (4, 6, 1, 1))
+        np.testing.assert_array_equal(self.dset[mbslice], np.array([4, 5, 6, 7, 8, 9]))
+
+    def test_count(self):
+        mbslice = MultiBlockSlice(count=7)
+
+        self.assertEqual(mbslice.indices(10), (0, 7, 1, 1))
+        np.testing.assert_array_equal(
+            self.dset[mbslice], np.array([0, 1, 2, 3, 4, 5, 6])
+        )
+
+    def test_count_more_than_length_error(self):
+        mbslice = MultiBlockSlice(count=11)
+        with self.assertRaises(ValueError):
+            mbslice.indices(10)
+
+    def test_stride(self):
+        mbslice = MultiBlockSlice(stride=2)
+
+        self.assertEqual(mbslice.indices(10), (0, 5, 2, 1))
+        np.testing.assert_array_equal(self.dset[mbslice], np.array([0, 2, 4, 6, 8]))
+
+    def test_stride_zero_error(self):
+        with self.assertRaises(ValueError):
+            # This would cause a ZeroDivisionError if not caught
+            MultiBlockSlice(stride=0, block=0).indices(10)
+
+    def test_stride_block_equal(self):
+        mbslice = MultiBlockSlice(stride=2, block=2)
+
+        self.assertEqual(mbslice.indices(10), (0, 5, 2, 2))
+        np.testing.assert_array_equal(self.dset[mbslice], self.arr)
+
+    def test_block_more_than_stride_error(self):
+        with self.assertRaises(ValueError):
+            MultiBlockSlice(block=3)
+
+        with self.assertRaises(ValueError):
+            MultiBlockSlice(stride=2, block=3)
+
+    def test_stride_more_than_block(self):
+        mbslice = MultiBlockSlice(stride=3, block=2)
+
+        self.assertEqual(mbslice.indices(10), (0, 3, 3, 2))
+        np.testing.assert_array_equal(self.dset[mbslice], np.array([0, 1, 3, 4, 6, 7]))
+
+    def test_block_overruns_extent_error(self):
+        # If fully described then must fit within extent
+        mbslice = MultiBlockSlice(start=2, count=2, stride=5, block=4)
+        with self.assertRaises(ValueError):
+            mbslice.indices(10)
+
+    def test_fully_described(self):
+        mbslice = MultiBlockSlice(start=1, count=2, stride=5, block=4)
+
+        self.assertEqual(mbslice.indices(10), (1, 2, 5, 4))
+        np.testing.assert_array_equal(
+            self.dset[mbslice], np.array([1, 2, 3, 4, 6, 7, 8, 9])
+        )
+
+    def test_count_calculated(self):
+        # If not given, count should be calculated to select as many full blocks as possible
+        mbslice = MultiBlockSlice(start=1, stride=3, block=2)
+
+        self.assertEqual(mbslice.indices(10), (1, 3, 3, 2))
+        np.testing.assert_array_equal(self.dset[mbslice], np.array([1, 2, 4, 5, 7, 8]))
+
+    def test_zero_count_calculated_error(self):
+        # In this case, there is no possible count to select even one block, so error
+        mbslice = MultiBlockSlice(start=8, stride=4, block=3)
+
+        with self.assertRaises(ValueError):
+            mbslice.indices(10)


### PR DESCRIPTION
This is an idea of how to implement 4-tuple (start, count, stride, block) selections in the high-level VDS API, as defined in the [HDF5 docs](https://support.hdfgroup.org/HDF5/Tutor/selectsimple.html).

I have a use case of interleaving frames written to multiple files into a single VDS. I initially did this with a per frame mapping, but by making use of the block selection I have now implemented it with a per file mapping, which is much quicker (4 maps in <1ms vs 1,000,000 maps in ~35 seconds, with 250,000 frames in each file) and produces much smaller files. This is implemented [here](https://github.com/dls-controls/vds-gen/commit/804352b429456850c690b6233c511d21268d3630#diff-b16ac9c817c68af1282779934f0ef4e3) by subclassing the VirtualLayout class and overriding `__set_item__`.

Here is an excerpt of its usage in my code with 3D (axis, height, width) datasets:

```
...
v_layout = AdvancedVirtualLayout(target_shape, source_meta.dtype)
...
for file_idx, file_path in enumerate(self.files):
    ...
    v_source = h5.VirtualSource(
        file_path,
        name="data", shape=source_shape, dtype=source_meta.dtype
    )
    v_layout[(start, count, stride, block), :, :] = v_source
...
```

I thought this might be more generally useful, so I have created this addition in h5py, which can achieve the same results using the existing VirtualLayout class.

Some things for discussion:

- I didn't know exactly where to implement this, I went with this as a balance of duplicating as little code as possible and not making invasive changes. There are other options:

   1. It could be made more vds specific moving it up into VirtualLayout, as I have in [my version](https://github.com/dls-controls/vds-gen/commit/804352b429456850c690b6233c511d21268d3630#diff-b16ac9c817c68af1282779934f0ef4e3) (i.e. by avoiding using SimpleSelection at all if a tuple element is given and directly creating a dataspace and calling select_hyperslab instead).

   2. It could be made more generic by moving it into the the SimpleSelection class directly (depending on the definition of _simple_). This would mean it could be used outside of the vds context; I don't know if this would be useful or not. This itself could be done in two ways:

      - Checking for tuple elements in `__set_item__` and calling `_handle_simple` or `_handle_advanced`
      - Replacing `_handle_simple`, as `_handle_advanced` should do the same thing in the case that only slices and ints are given.

- I am also not sure of the implication of defining a selection with block of more than 1 on `self._sel` and `self._mshape`. Currently, I have defined them as before, ignoring the block size.

- Most importantly: Is this a worthwhile addition?