### PR TITLE
Allow h5t.TypeID as dtype arg to create_dataset()

### DIFF
--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -37,6 +37,14 @@ optionally the data type (defaults to ``'f'``)::
     >>> dset = f.create_dataset("default", (100,))
     >>> dset = f.create_dataset("ints", (100,), dtype='i8')
 
+If you need a complex datatype, or if you perfer low-level HDF5 API, you can
+pass an instance of `h5py.h5t.TypeID` directly to :meth:`Group.create_dataset`
+as the `dtype`:
+
+    >>> my_h5t_id = h5t.create(h5t.COMPOUND, 100)
+    >>> my_h5t_id = h5t.insert(b'my_field', 40, h5t.NATIVE_DOUBLE)
+    >>> dset = f.create_dataset("default", (100,), my_h5t_id)
+
 You may initialize the dataset to an existing NumPy array::
 
     >>> arr = np.arange(100)

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -103,7 +103,10 @@ def make_new_dset(parent, shape=None, dtype=None, data=None,
                  "{} is not compatible with {}".format(chunks, shape)
         raise ValueError(errmsg)
 
-    if isinstance(dtype, Datatype):
+    if isinstance(dtype, h5t.TypeID):
+        tid = dtype
+        dtype = tid.dtype  # Following code needs this
+    elif isinstance(dtype, Datatype):
         # Named types are used as-is
         tid = dtype.id
         dtype = tid.dtype  # Following code needs this


### PR DESCRIPTION
- This allows a user who needs low level control of a dataset's datatype to
  create the dataset with the high level `create_dataset()` interface but
  passing an instance of a low-level h5t.TypeID as the dtype argument instead
  of a numpy.dtype