### PR TITLE
Breakout special dtypes

### DIFF
--- a/docs/refs.rst
+++ b/docs/refs.rst
@@ -77,20 +77,21 @@ are represented with the "object" dtype (kind 'O').  A small amount of
 metadata attached to the dtype tells h5py to interpret the data as containing
 reference objects.
 
-H5py contains a convenience function to create these "hinted dtypes" for you:
+These dtypes are available from h5py for references and region references:
 
-    >>> ref_dtype = h5py.special_dtype(ref=h5py.Reference)
-    >>> type(ref_dtype)
+    >>> type(h5py.ref_dtype)
     <type 'numpy.dtype'>
     >>> ref_dtype.kind
     'O'
+    >>> type(h5py.regionref_dtype)
+    <type 'numpy.dtype'>
 
 The types accepted by this "ref=" keyword argument are h5py.Reference (for
 object references) and h5py.RegionReference (for region references).
 
 To create an array of references, use this dtype as you normally would:
 
-    >>> ref_dataset = myfile.create_dataset("MyRefs", (100,), dtype=ref_dtype)
+    >>> ref_dataset = myfile.create_dataset("MyRefs", (100,), dtype=h5py.ref_dtype)
 
 You can read from and write to the array as normal:
 

--- a/docs/special.rst
+++ b/docs/special.rst
@@ -16,6 +16,10 @@ store these types.  Each type is represented by a native NumPy dtype, with a
 small amount of metadata attached.  NumPy routines ignore the metadata, but
 h5py can use it to determine how to store the data.
 
+The metadata h5py attaches to dtypes is not part of the public API,
+so it may change between versions.
+Use the functions described below to create and check for these types.
+
 Variable-length strings
 -----------------------
 

--- a/docs/special.rst
+++ b/docs/special.rst
@@ -47,22 +47,39 @@ Here's an example showing how to create a VL array of strings::
     >>> ds = f.create_dataset('VLDS', (100,100), dtype=dt)
     >>> ds.dtype.kind
     'O'
-    >>> h5py.check_vlen_dtype(ds.dtype)
-    <type 'str'>
+    >>> h5py.check_string_dtype(ds.dtype)
+    string_info(encoding='utf-8', length=None)
 
-.. function:: string_dtype(encoding='utf-8')
+.. function:: string_dtype(encoding='utf-8', length=None)
 
-   Make a numpy dtype for HDF5 variable-length strings
+   Make a numpy dtype for HDF5 strings
 
    :param encoding: ``'utf-8'`` or ``'ascii'``.
-                    If it is ``'utf-8'``, the data should be passed as Python
-                    ``str`` objects (``unicode`` in Python 2).
-                    For ``'ascii'``, data should be passed as bytes.
+   :param length: ``None`` for variable-length, or an integer for fixed-length
+                  string data, giving the length in bytes.
+
+If ``encoding`` is ``'utf-8'``, the variable length strings should be passed as
+Python ``str`` objects (``unicode`` in Python 2).
+For ``'ascii'``, they should be passed as bytes.
 
 .. function:: check_string_dtype(dt)
 
-   Check if ``dt`` is a variable-length string dtype.
-   Returns the encoding if it is, or ``None`` if not.
+   Check if ``dt`` is a string dtype.
+   Returns a *string_info* object if it is, or ``None`` if not.
+
+.. class:: string_info
+
+   A named tuple type holding string encoding and length.
+
+   .. attribute:: encoding
+
+      The character encoding associated with the string dtype,
+      which can be ``'utf-8'`` or ``'ascii'``.
+
+   .. attribute:: length
+
+      For fixed-length string dtypes, the length in bytes.
+      ``None`` for variable-length strings.
 
 .. _vlen:
 

--- a/docs/special.rst
+++ b/docs/special.rst
@@ -16,7 +16,131 @@ store these types.  Each type is represented by a native NumPy dtype, with a
 small amount of metadata attached.  NumPy routines ignore the metadata, but
 h5py can use it to determine how to store the data.
 
-There are two functions for creating these "hinted" dtypes:
+Variable-length strings
+-----------------------
+
+.. seealso:: :ref:`strings`
+
+In HDF5, data in VL format is stored as arbitrary-length vectors of a base
+type.  In particular, strings are stored C-style in null-terminated buffers.
+NumPy has no native mechanism to support this.  Unfortunately, this is the
+de facto standard for representing strings in the HDF5 C API, and in many
+HDF5 applications.
+
+Thankfully, NumPy has a generic pointer type in the form of the "object" ("O")
+dtype.  In h5py, variable-length strings are mapped to object arrays.  A
+small amount of metadata attached to an "O" dtype tells h5py that its contents
+should be converted to VL strings when stored in the file.
+
+Existing VL strings can be read and written to with no additional effort;
+Python strings and fixed-length NumPy strings can be auto-converted to VL
+data and stored.
+
+Here's an example showing how to create a VL array of strings::
+
+    >>> f = h5py.File('foo.hdf5')
+    >>> dt = h5py.string_dtype(encoding='utf-8')
+    >>> ds = f.create_dataset('VLDS', (100,100), dtype=dt)
+    >>> ds.dtype.kind
+    'O'
+    >>> h5py.check_vlen_dtype(ds.dtype)
+    <type 'str'>
+
+.. function:: string_dtype(encoding='utf-8')
+
+   Make a numpy dtype for HDF5 variable-length strings
+
+   :param encoding: ``'utf-8'`` or ``'ascii'``.
+                    If it is ``'utf-8'``, the data should be passed as Python
+                    ``str`` objects (``unicode`` in Python 2).
+                    For ``'ascii'``, data should be passed as bytes.
+
+.. function:: check_string_dtype(dt)
+
+   Check if ``dt`` is a variable-length string dtype.
+   Returns the encoding if it is, or ``None`` if not.
+
+.. _vlen:
+
+Arbitrary vlen data
+-------------------
+
+Starting with h5py 2.3, variable-length types are not restricted to strings.
+For example, you can create a "ragged" array of integers::
+
+    >>> dt = h5py.vlen_dtype(np.dtype('int32'))
+    >>> dset = f.create_dataset('vlen_int', (100,), dtype=dt)
+    >>> dset[0] = [1,2,3]
+    >>> dset[1] = [1,2,3,4,5]
+
+Single elements are read as NumPy arrays::
+
+    >>> dset[0]
+    array([1, 2, 3], dtype=int32)
+
+Multidimensional selections produce an object array whose members are integer
+arrays::
+
+    >>> dset[0:2]
+    array([array([1, 2, 3], dtype=int32), array([1, 2, 3, 4, 5], dtype=int32)], dtype=object)
+
+.. function:: vlen_dtype(basetype)
+
+   Make a numpy dtype for an HDF5 variable-length datatype.
+
+   :param basetype: The dtype of each element in the array.
+
+.. function:: check_vlen_dtype(dt)
+
+   Check if ``dt`` is a variable-length dtype.
+   Returns the base type if it is, or ``None`` if not.
+
+Enumerated types
+----------------
+
+HDF5 has the concept of an *enumerated type*, which is an integer datatype
+with a restriction to certain named values.  Since NumPy has no such datatype,
+HDF5 ENUM types are read and written as integers.
+
+Here's an example of creating an enumerated type::
+
+    >>> dt = h5py.enum_dtype({"RED": 0, "GREEN": 1, "BLUE": 42}, basetype='i')
+    >>> h5py.check_enum_dtype(dt)
+    {'BLUE': 42, 'GREEN': 1, 'RED': 0}
+    >>> f = h5py.File('foo.hdf5','w')
+    >>> ds = f.create_dataset("EnumDS", (100,100), dtype=dt)
+    >>> ds.dtype.kind
+    'i'
+    >>> ds[0,:] = 42
+    >>> ds[0,0]
+    42
+    >>> ds[1,0]
+    0
+
+.. function:: enum_dtype(values_dict, basetype=np.uint8)
+
+   Create a NumPy representation of an HDF5 enumerated type
+
+   :param values_dict: Mapping of string names to integer values.
+   :param basetype: An appropriate integer base dtype large enough to hold the
+                    possible options.
+
+.. function:: check_enum_dtype(dt)
+
+   Check if ``dt`` represents an enumerated type.
+   Returns the values dict if it is, or ``None`` if not.
+
+Object and region references
+----------------------------
+
+References have their :ref:`own section <refs>`.
+
+Older API
+---------
+
+Before h5py 2.9, a single pair of functions was used to create and check for
+all of these special dtypes. These are still available for backwards
+compatibility, but are deprecated in favour of the functions listed above.
 
 .. function:: special_dtype(**kwds)
 
@@ -46,85 +170,3 @@ There are two functions for creating these "hinted" dtypes:
     :param enum:    Check for an enumerated type; returns 2-tuple ``(basetype, values_dict)``.
     :param ref:     Check for an HDF5 object or region reference; returns
                     either ``h5py.Reference`` or ``h5py.RegionReference``.
-
-
-Variable-length strings
------------------------
-
-In HDF5, data in VL format is stored as arbitrary-length vectors of a base
-type.  In particular, strings are stored C-style in null-terminated buffers.
-NumPy has no native mechanism to support this.  Unfortunately, this is the
-de facto standard for representing strings in the HDF5 C API, and in many
-HDF5 applications.
-
-Thankfully, NumPy has a generic pointer type in the form of the "object" ("O")
-dtype.  In h5py, variable-length strings are mapped to object arrays.  A
-small amount of metadata attached to an "O" dtype tells h5py that its contents
-should be converted to VL strings when stored in the file.
-
-Existing VL strings can be read and written to with no additional effort;
-Python strings and fixed-length NumPy strings can be auto-converted to VL
-data and stored.
-
-Here's an example showing how to create a VL array of strings::
-
-    >>> f = h5py.File('foo.hdf5')
-    >>> dt = h5py.special_dtype(vlen=str)
-    >>> ds = f.create_dataset('VLDS', (100,100), dtype=dt)
-    >>> ds.dtype.kind
-    'O'
-    >>> h5py.check_dtype(vlen=ds.dtype)
-    <type 'str'>
-
-
-.. _vlen:
-
-Arbitrary vlen data
--------------------
-
-Starting with h5py 2.3, variable-length types are not restricted to strings.
-For example, you can create a "ragged" array of integers::
-
-    >>> dt = h5py.special_dtype(vlen=np.dtype('int32'))
-    >>> dset = f.create_dataset('vlen_int', (100,), dtype=dt)
-    >>> dset[0] = [1,2,3]
-    >>> dset[1] = [1,2,3,4,5]
-
-Single elements are read as NumPy arrays::
-
-    >>> dset[0]
-    array([1, 2, 3], dtype=int32)
-
-Multidimensional selections produce an object array whose members are integer
-arrays::
-
-    >>> dset[0:2]
-    array([array([1, 2, 3], dtype=int32), array([1, 2, 3, 4, 5], dtype=int32)], dtype=object)
-
-
-Enumerated types
-----------------
-
-HDF5 has the concept of an *enumerated type*, which is an integer datatype
-with a restriction to certain named values.  Since NumPy has no such datatype,
-HDF5 ENUM types are read and written as integers.
-
-Here's an example of creating an enumerated type::
-
-    >>> dt = h5py.special_dtype(enum=('i', {"RED": 0, "GREEN": 1, "BLUE": 42}))
-    >>> h5py.check_dtype(enum=dt)
-    {'BLUE': 42, 'GREEN': 1, 'RED': 0}
-    >>> f = h5py.File('foo.hdf5','w')
-    >>> ds = f.create_dataset("EnumDS", (100,100), dtype=dt)
-    >>> ds.dtype.kind
-    'i'
-    >>> ds[0,:] = 42
-    >>> ds[0,0]
-    42
-    >>> ds[1,0]
-    0
-
-Object and region references
-----------------------------
-
-References have their :ref:`own section <refs>`.

--- a/docs/strings.rst
+++ b/docs/strings.rst
@@ -91,9 +91,9 @@ These are created when you assign a byte string to an attribute::
 
     >>> dset.attrs["attr"] = b"Hello"
 
-or when you create a dataset with an explicit "bytes" vlen type::
+or when you create a dataset with an explicit ascii string dtype::
 
-    >>> dt = h5py.special_dtype(vlen=bytes)
+    >>> dt = h5py.string_dtype(encoding='ascii')
     >>> dset = f.create_dataset("name", (100,), dtype=dt)
 
 Note that they're `not` fully identical to Python byte strings.  You can
@@ -113,10 +113,9 @@ These are created when you assign a unicode string to an attribute::
 
     >>> dset.attrs["name"] = u"Hello"
 
-or if you create a dataset with an explicit unicode vlen type:
+or if you create a dataset with an explicit string dtype:
 
-    >>> dt = h5py.special_dtype(vlen=unicode) # PY2
-    >>> dt = h5py.special_dtype(vlen=str)     # PY3
+    >>> dt = h5py.string_dtype()
     >>> dset = f.create_dataset("name", (100,), dtype=dt)
 
 They can store any character a Python unicode string can store, with the
@@ -160,8 +159,7 @@ h5py will save these as arrays of variable-length strings with character set
 H5T_CSET_UTF8. When read back, the results will be numpy arrays of dtype
 ``'object'``, as if the original data were written as:
 
-    >>> f['x'] = np.array(('a', 'b'), dtype=h5py.special_dtype(vlen=str)) # PY3
-    >>> f['x'] = np.array((u'a', u'b'), dtype=h5py.special_dtype(vlen=unicode)) # PY2
+    >>> f['x'] = np.array((u'a', u'b'), dtype=h5py.string_dtype(encoding='utf-8'))
 
 
 Object names

--- a/docs_api/h5t.rst
+++ b/docs_api/h5t.rst
@@ -7,6 +7,12 @@ Functions specific to h5py
 --------------------------
 
 .. autofunction:: py_create
+.. autofunction:: string_dtype
+.. autofunction:: check_string_dtype
+.. autofunction:: vlen_dtype
+.. autofunction:: check_vlen_dtype
+.. autofunction:: enum_dtype
+.. autofunction:: check_enum_dtype
 .. autofunction:: special_dtype
 .. autofunction:: check_dtype
 

--- a/h5py/__init__.py
+++ b/h5py/__init__.py
@@ -59,7 +59,10 @@ from ._hl.attrs import AttributeManager
 
 from .h5 import get_config
 from .h5r import Reference, RegionReference
-from .h5t import special_dtype, check_dtype
+from .h5t import (special_dtype, check_dtype,
+    vlen_dtype, string_dtype, enum_dtype, ref_dtype, regionref_dtype,
+    check_vlen_dtype, check_enum_dtype, check_ref_dtype,
+)
 
 from . import version
 from .version import version as __version__

--- a/h5py/__init__.py
+++ b/h5py/__init__.py
@@ -61,7 +61,7 @@ from .h5 import get_config
 from .h5r import Reference, RegionReference
 from .h5t import (special_dtype, check_dtype,
     vlen_dtype, string_dtype, enum_dtype, ref_dtype, regionref_dtype,
-    check_vlen_dtype, check_enum_dtype, check_ref_dtype,
+    check_vlen_dtype, check_string_dtype, check_enum_dtype, check_ref_dtype,
 )
 
 from . import version

--- a/h5py/_hl/attrs.py
+++ b/h5py/_hl/attrs.py
@@ -125,7 +125,7 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
                 # datatype of the numpy array. If it is U type, convert to vlen unicode
                 # strings:
                 if is_list_or_tuple and data.dtype.type == numpy.unicode_:
-                    data = numpy.array(data, dtype=h5t.special_dtype(vlen=six.text_type))
+                    data = numpy.array(data, dtype=h5t.string_dtype())
 
             if shape is None:
                 shape = data.shape

--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -52,13 +52,13 @@ def guess_dtype(data):
     """
     with phil:
         if isinstance(data, h5r.RegionReference):
-            return h5t.special_dtype(ref=h5r.RegionReference)
+            return h5t.regionref_dtype
         if isinstance(data, h5r.Reference):
-            return h5t.special_dtype(ref=h5r.Reference)
+            return h5t.ref_dtype
         if type(data) == bytes:
-            return h5t.special_dtype(vlen=bytes)
+            return h5t.string_dtype(encoding='ascii')
         if type(data) == six.text_type:
-            return h5t.special_dtype(vlen=six.text_type)
+            return h5t.string_dtype()
 
         return None
 

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -590,7 +590,7 @@ class Dataset(HLObject):
 
         # Generally we try to avoid converting the arrays on the Python
         # side.  However, for compound literals this is unavoidable.
-        vlen = h5t.check_dtype(vlen=self.dtype)
+        vlen = h5t.check_vlen_dtype(self.dtype)
         if vlen is not None and vlen not in (bytes, six.text_type):
             try:
                 val = numpy.asarray(val, dtype=vlen)

--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -1741,7 +1741,7 @@ def enum_dtype(values_dict, basetype=np.uint8):
     appropriate integer base dtype large enough to hold the possible options.
     """
     dt = dtype(basetype)
-    if dt.kind not in "iu":
+    if not np.issubdtype(dt, np.integer):
         raise TypeError("Only integer types can be used as enums")
 
     return dtype(dt, metadata={'enum': values_dict})

--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -1798,6 +1798,44 @@ def special_dtype(**kwds):
     raise TypeError('Unknown special type "%s"' % name)
 
 
+def check_vlen_dtype(dt):
+    """If the dtype represents an HDF5 vlen, returns the Python base class.
+
+    Returns None if the dtype does not represent an HDF5 vlen.
+    """
+    return dt.metadata.get('vlen', None)
+
+def check_string_dtype(dt):
+    """If the dtype represents an HDF5 vlen string, returns the encoding.
+
+    Encodings can only be 'utf-8' or 'ascii'.
+
+    Returns None if the dtype does not represent an HDF5 vlen string.
+    """
+    vlen_kind = check_vlen_dtype(dt)
+    if vlen_kind is unicode:
+        return 'utf-8'
+    elif vlen_kind is bytes:
+        return 'ascii'
+    else:
+        return None
+
+def check_enum_dtype(dt):
+    """If the dtype represents an HDF5 enumerated type, returns the dictionary
+    mapping string names to integer values.
+
+    Returns None if the dtype does not represent an HDF5 enumerated type.
+    """
+    return dt.metadata.get('enum', None)
+
+def check_ref_dtype(dt):
+    """If the dtype represents an HDF5 reference type, returns the reference
+    class (either Reference or RegionReference).
+
+    Returns None if the dtype does not represent an HDF5 reference type.
+    """
+    return dt.metadata.get('ref', None)
+
 @with_phil
 def check_dtype(**kwds):
     """ Check a dtype for h5py special type "hint" information.  Only one
@@ -1897,9 +1935,9 @@ cpdef dict py_get_enum(object dt):
 
     Deprecated; use check_dtype() instead.
     """
-    warn("Deprecated; use check_dtype(enum=dtype) instead",
+    warn("Deprecated; use check_enum_dtype(dtype) instead",
         H5pyDeprecationWarning)
-    return check_dtype(enum=dt)
+    return check_enum_dtype(dt)
 
 cpdef dtype py_new_vlen(object kind):
     """ (OBJECT kind) => DTYPE
@@ -1913,8 +1951,8 @@ cpdef dtype py_new_vlen(object kind):
 cpdef object py_get_vlen(object dt_in):
     """ (OBJECT dt_in) => TYPE
 
-    Deprecated; use check_dtype() instead.
+    Deprecated; use check_vlen_dtype() instead.
     """
-    warn("Deprecated; use check_dtype(vlen=dtype) instead",
+    warn("Deprecated; use check_vlen_dtype(dtype) instead",
         H5pyDeprecationWarning)
-    return check_dtype(vlen=dt_in)
+    return check_vlen_dtype(dt_in)

--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -1509,7 +1509,7 @@ cdef TypeStringID _c_string(dtype dt):
     tid = H5Tcopy(H5T_C_S1)
     H5Tset_size(tid, dt.itemsize)
     H5Tset_strpad(tid, H5T_STR_NULLPAD)
-    if dt.metadata.get('h5py_encoding') == 'utf-8':
+    if dt.metadata and dt.metadata.get('h5py_encoding') == 'utf-8':
         H5Tset_cset(tid, H5T_CSET_UTF8)
     return TypeStringID(tid)
 

--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -1803,7 +1803,10 @@ def check_vlen_dtype(dt):
 
     Returns None if the dtype does not represent an HDF5 vlen.
     """
-    return dt.metadata.get('vlen', None)
+    try:
+        return dt.metadata.get('vlen', None)
+    except AttributeError:
+        return None
 
 def check_string_dtype(dt):
     """If the dtype represents an HDF5 vlen string, returns the encoding.
@@ -1826,7 +1829,10 @@ def check_enum_dtype(dt):
 
     Returns None if the dtype does not represent an HDF5 enumerated type.
     """
-    return dt.metadata.get('enum', None)
+    try:
+        return dt.metadata.get('enum', None)
+    except AttributeError:
+        return None
 
 def check_ref_dtype(dt):
     """If the dtype represents an HDF5 reference type, returns the reference
@@ -1834,7 +1840,10 @@ def check_ref_dtype(dt):
 
     Returns None if the dtype does not represent an HDF5 reference type.
     """
-    return dt.metadata.get('ref', None)
+    try:
+        return dt.metadata.get('ref', None)
+    except AttributeError:
+        return None
 
 @with_phil
 def check_dtype(**kwds):

--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -26,7 +26,7 @@ from utils cimport  emalloc, efree, \
 
 # Runtime imports
 import codecs
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 import sys
 import operator
 from warnings import warn
@@ -1834,18 +1834,25 @@ def check_vlen_dtype(dt):
     except AttributeError:
         return None
 
+string_info = namedtuple('string_info', ['encoding', 'length'])
+
 def check_string_dtype(dt):
-    """If the dtype represents an HDF5 vlen string, returns the encoding.
+    """If the dtype represents an HDF5 string, returns a string_info object.
 
-    Encodings can only be 'utf-8' or 'ascii'.
+    The returned string_info object holds the encoding and the length.
+    The encoding can only be 'utf-8' or 'ascii'. The length may be None
+    for a variable-length string, or a fixed length in bytes.
 
-    Returns None if the dtype does not represent an HDF5 vlen string.
+    Returns None if the dtype does not represent an HDF5 string.
     """
     vlen_kind = check_vlen_dtype(dt)
     if vlen_kind is unicode:
-        return 'utf-8'
+        return string_info('utf-8', None)
     elif vlen_kind is bytes:
-        return 'ascii'
+        return string_info('ascii', None)
+    elif dt.kind == 'S':
+        enc = (dt.metadata or {}).get('h5py_encoding', 'ascii')
+        return string_info(enc, dt.itemsize)
     else:
         return None
 

--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -1749,7 +1749,7 @@ def string_dtype(encoding='utf-8', length=None):
         return dtype("|S" + str(length), metadata={'h5py_encoding': encoding})
     elif length is None:
         vlen = unicode if (encoding == 'utf-8') else bytes
-        return dtype('O', metadata={'vlen': unicode})
+        return dtype('O', metadata={'vlen': vlen})
     else:
         raise TypeError("length must be integer or None (got %r)" % length)
 

--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -25,6 +25,7 @@ from utils cimport  emalloc, efree, \
                     require_tuple, convert_dims, convert_tuple
 
 # Runtime imports
+import codecs
 from collections import defaultdict
 import sys
 import operator
@@ -1740,6 +1741,12 @@ def string_dtype(encoding='utf-8', length=None):
     arrays, regardless of the encoding. Fixed length unicode data is not
     supported.
     """
+    # Normalise encoding name:
+    try:
+        encoding = codecs.lookup(encoding).name
+    except LookupError:
+        pass  # Use our error below
+
     if encoding not in {'ascii', 'utf-8'}:
         raise ValueError("Invalid encoding (%r); 'utf-8' or 'ascii' allowed"
                          % encoding)

--- a/h5py/tests/hl/test_datatype.py
+++ b/h5py/tests/hl/test_datatype.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 
 from itertools import count
 import numpy as np
+import six
 import h5py
 
 from ..common import ut, TestCase
@@ -238,3 +239,37 @@ class TestOffsets(TestCase):
             for n, d in dtype_dset_map.items():
                 ldata = f[n][:]
                 self.assertEqual(ldata.dtype, d)
+
+
+class TestStrings(TestCase):
+    def test_vlen_utf8(self):
+        dt = h5py.string_dtype()
+
+        string_info = h5py.check_string_dtype(dt)
+        assert string_info.encoding == 'utf-8'
+        assert string_info.length is None
+        assert h5py.check_vlen_dtype(dt) is six.text_type
+
+    def test_vlen_ascii(self):
+        dt = h5py.string_dtype(encoding='ascii')
+
+        string_info = h5py.check_string_dtype(dt)
+        assert string_info.encoding == 'ascii'
+        assert string_info.length is None
+        assert h5py.check_vlen_dtype(dt) is bytes
+
+    def test_fixed_utf8(self):
+        dt = h5py.string_dtype(length=10)
+
+        string_info = h5py.check_string_dtype(dt)
+        assert string_info.encoding == 'utf-8'
+        assert string_info.length == 10
+        assert h5py.check_vlen_dtype(dt) is None
+
+    def test_fixed_ascii(self):
+        dt = h5py.string_dtype(encoding='ascii', length=10)
+
+        string_info = h5py.check_string_dtype(dt)
+        assert string_info.encoding == 'ascii'
+        assert string_info.length == 10
+        assert h5py.check_vlen_dtype(dt) is None

--- a/h5py/tests/hl/test_datatype.py
+++ b/h5py/tests/hl/test_datatype.py
@@ -31,7 +31,8 @@ class TestVlen(TestCase):
         dt = np.dtype(fields)
         self.f['mytype'] = np.dtype(dt)
         dt_out = self.f['mytype'].dtype.fields['field_1'][0]
-        self.assertEqual(h5py.check_string_dtype(dt_out), 'utf-8')
+        string_inf = h5py.check_string_dtype(dt_out)
+        self.assertEqual(string_inf.encoding, 'utf-8')
 
     def test_compound_vlen_bool(self):
         vidt = h5py.vlen_dtype(np.uint8)

--- a/h5py/tests/hl/test_datatype.py
+++ b/h5py/tests/hl/test_datatype.py
@@ -31,7 +31,7 @@ class TestVlen(TestCase):
         dt = np.dtype(fields)
         self.f['mytype'] = np.dtype(dt)
         dt_out = self.f['mytype'].dtype.fields['field_1'][0]
-        self.assertEqual(h5py.check_vlen_dtype(dt_out), str)
+        self.assertEqual(h5py.check_string_dtype(dt_out), 'utf-8')
 
     def test_compound_vlen_bool(self):
         vidt = h5py.vlen_dtype(np.uint8)

--- a/h5py/tests/old/test_attrs.py
+++ b/h5py/tests/old/test_attrs.py
@@ -162,6 +162,6 @@ class TestMutableMapping(BaseAttrs):
 class TestVlen(BaseAttrs):
     def test_vlen(self):
         a = np.array([np.arange(3), np.arange(4)],
-            dtype=h5t.special_dtype(vlen=int))
+            dtype=h5t.vlen_dtype(int))
         self.f.attrs['a'] = a
         self.assertArrayEqual(self.f.attrs['a'][0], a[0])

--- a/h5py/tests/old/test_attrs_data.py
+++ b/h5py/tests/old/test_attrs_data.py
@@ -149,7 +149,7 @@ class TestTypes(BaseAttrs):
 
     def test_vlen_string_array(self):
         """ Storage of vlen byte string arrays"""
-        dt = h5py.special_dtype(vlen=bytes)
+        dt = h5py.string_dtype(encoding='ascii')
 
         data = np.ndarray((2,), dtype=dt)
         data[...] = b"Hello", b"Hi there!  This is HDF5!"

--- a/h5py/tests/old/test_dataset.py
+++ b/h5py/tests/old/test_dataset.py
@@ -746,7 +746,7 @@ class TestStrings(BaseDataset):
 
     def test_vlen_bytes(self):
         """ Vlen bytes dataset maps to vlen ascii in the file """
-        dt = h5py.special_dtype(vlen=bytes)
+        dt = h5py.string_dtype(encoding='ascii')
         ds = self.f.create_dataset('x', (100,), dtype=dt)
         tid = ds.id.get_type()
         self.assertEqual(type(tid), h5py.h5t.TypeStringID)
@@ -754,7 +754,7 @@ class TestStrings(BaseDataset):
 
     def test_vlen_unicode(self):
         """ Vlen unicode dataset maps to vlen utf-8 in the file """
-        dt = h5py.special_dtype(vlen=six.text_type)
+        dt = h5py.string_dtype()
         ds = self.f.create_dataset('x', (100,), dtype=dt)
         tid = ds.id.get_type()
         self.assertEqual(type(tid), h5py.h5t.TypeStringID)
@@ -780,7 +780,7 @@ class TestStrings(BaseDataset):
     def test_roundtrip_vlen_bytes(self):
         """ writing and reading to vlen bytes dataset preserves type and content
         """
-        dt = h5py.special_dtype(vlen=bytes)
+        dt = h5py.string_dtype(encoding='ascii')
         ds = self.f.create_dataset('x', (100,), dtype=dt)
         data = b"Hello\xef"
         ds[0] = data
@@ -791,7 +791,7 @@ class TestStrings(BaseDataset):
     def test_roundtrip_vlen_unicode(self):
         """ Writing and reading to unicode dataset preserves type and content
         """
-        dt = h5py.special_dtype(vlen=six.text_type)
+        dt = h5py.string_dtype()
         ds = self.f.create_dataset('x', (100,), dtype=dt)
         data = u"Hello" + six.unichr(0x2034)
         ds[0] = data
@@ -814,7 +814,7 @@ class TestStrings(BaseDataset):
     def test_unicode_write_error(self):
         """ Writing a non-utf8 byte string to a unicode vlen dataset raises
         ValueError """
-        dt = h5py.special_dtype(vlen=six.text_type)
+        dt = h5py.string_dtype()
         ds = self.f.create_dataset('x', (100,), dtype=dt)
         data = "Hello\xef"
         with self.assertRaises(ValueError):
@@ -823,7 +823,7 @@ class TestStrings(BaseDataset):
     def test_unicode_write_bytes(self):
         """ Writing valid utf-8 byte strings to a unicode vlen dataset is OK
         """
-        dt = h5py.special_dtype(vlen=six.text_type)
+        dt = h5py.string_dtype()
         ds = self.f.create_dataset('x', (100,), dtype=dt)
         data = u"Hello there" + six.unichr(0x2034)
         ds[0] = data.encode('utf8')
@@ -885,15 +885,15 @@ class TestEnum(BaseDataset):
 
     def test_create(self):
         """ Enum datasets can be created and type correctly round-trips """
-        dt = h5py.special_dtype(enum=('i', self.EDICT))
+        dt = h5py.enum_dtype(self.EDICT, basetype='i')
         ds = self.f.create_dataset('x', (100, 100), dtype=dt)
         dt2 = ds.dtype
-        dict2 = h5py.check_dtype(enum=dt2)
+        dict2 = h5py.check_enum_dtype(dt2)
         self.assertEqual(dict2, self.EDICT)
 
     def test_readwrite(self):
         """ Enum datasets can be read/written as integers """
-        dt = h5py.special_dtype(enum=('i4', self.EDICT))
+        dt = h5py.enum_dtype(self.EDICT, basetype='i4')
         ds = self.f.create_dataset('x', (100, 100), dtype=dt)
         ds[35, 37] = 42
         ds[1, :] = 1
@@ -1024,7 +1024,7 @@ class TestScalarCompound(BaseDataset):
 
 class TestVlen(BaseDataset):
     def test_int(self):
-        dt = h5py.special_dtype(vlen=int)
+        dt = h5py.vlen_dtype(int)
         ds = self.f.create_dataset('vlen', (4,), dtype=dt)
         ds[0] = np.arange(3)
         ds[1] = np.arange(0)
@@ -1042,12 +1042,12 @@ class TestVlen(BaseDataset):
         self.assertArrayEqual(ds[1], np.arange(3))
 
     def test_reuse_from_other(self):
-        dt = h5py.special_dtype(vlen=int)
+        dt = h5py.vlen_dtype(int)
         ds = self.f.create_dataset('vlen', (1,), dtype=dt)
         self.f.create_dataset('vlen2', (1,), ds[()].dtype)
 
     def test_reuse_struct_from_other(self):
-        dt = [('a', int), ('b', h5py.special_dtype(vlen=int))]
+        dt = [('a', int), ('b', h5py.vlen_dtype(int))]
         ds = self.f.create_dataset('vlen', (1,), dtype=dt)
         fname = self.f.filename
         self.f.close()
@@ -1055,7 +1055,7 @@ class TestVlen(BaseDataset):
         self.f.create_dataset('vlen2', (1,), self.f['vlen']['b'][()].dtype)
 
     def test_convert(self):
-        dt = h5py.special_dtype(vlen=int)
+        dt = h5py.vlen_dtype(int)
         ds = self.f.create_dataset('vlen', (3,), dtype=dt)
         ds[0] = np.array([1.4, 1.2])
         ds[1] = np.array([1.2])
@@ -1072,7 +1072,7 @@ class TestVlen(BaseDataset):
         self.assertArrayEqual(ds[1], np.arange(3))
 
     def test_multidim(self):
-        dt = h5py.special_dtype(vlen=int)
+        dt = h5py.vlen_dtype(int)
         ds = self.f.create_dataset('vlen', (2, 2), dtype=dt)
         ds[0, 0] = np.arange(1)
         ds[:, :] = np.array([[np.arange(3), np.arange(2)],
@@ -1086,7 +1086,7 @@ class TestVlen(BaseDataset):
         :param np_dt: Numpy datatype to test
         :param dataset_name: String name of the dataset to create for testing.
         """
-        dt = h5py.special_dtype(vlen=np_dt)
+        dt = h5py.vlen_dtype(np_dt)
         ds = self.f.create_dataset(dataset_name, (5,), dtype=dt)
 
         # Create some arrays, and assign them to the dataset

--- a/h5py/tests/old/test_dataset.py
+++ b/h5py/tests/old/test_dataset.py
@@ -774,6 +774,9 @@ class TestStrings(BaseDataset):
         self.assertFalse(tid.is_variable_str())
         self.assertEqual(tid.get_size(), 10)
         self.assertEqual(tid.get_cset(), h5py.h5t.CSET_ASCII)
+        string_info = h5py.check_string_dtype(ds.dtype)
+        self.assertEqual(string_info.encoding, 'ascii')
+        self.assertEqual(string_info.length, 10)
 
     def test_fixed_unicode(self):
         """ Fixed-length unicode datasets are unsupported (raise TypeError) """

--- a/h5py/tests/old/test_dataset.py
+++ b/h5py/tests/old/test_dataset.py
@@ -751,6 +751,8 @@ class TestStrings(BaseDataset):
         tid = ds.id.get_type()
         self.assertEqual(type(tid), h5py.h5t.TypeStringID)
         self.assertEqual(tid.get_cset(), h5py.h5t.CSET_ASCII)
+        string_info = h5py.check_string_dtype(ds.dtype)
+        self.assertEqual(string_info.encoding, 'ascii')
 
     def test_vlen_unicode(self):
         """ Vlen unicode dataset maps to vlen utf-8 in the file """
@@ -759,6 +761,8 @@ class TestStrings(BaseDataset):
         tid = ds.id.get_type()
         self.assertEqual(type(tid), h5py.h5t.TypeStringID)
         self.assertEqual(tid.get_cset(), h5py.h5t.CSET_UTF8)
+        string_info = h5py.check_string_dtype(ds.dtype)
+        self.assertEqual(string_info.encoding, 'utf-8')
 
     def test_fixed_bytes(self):
         """ Fixed-length bytes dataset maps to fixed-length ascii in the file

--- a/h5py/tests/old/test_group.py
+++ b/h5py/tests/old/test_group.py
@@ -228,8 +228,7 @@ class TestOpen(BaseGroup):
         """
         g = self.f.create_group('test')
 
-        rtype = h5py.special_dtype(ref=h5py.Reference)
-        dt = np.dtype([('a', 'i'),('b',rtype)])
+        dt = np.dtype([('a', 'i'),('b', h5py.ref_dtype)])
         dset = self.f.create_dataset('test_dset', (1,), dt)
 
         dset[0] =(42,g.ref)

--- a/h5py/tests/old/test_h5t.py
+++ b/h5py/tests/old/test_h5t.py
@@ -30,8 +30,7 @@ class TestCompound(ut.TestCase):
     def test_ref(self):
         """ Reference types are correctly stored in compound types (issue 144)
         """
-        ref = h5py.special_dtype(ref=h5py.Reference)
-        dt = np.dtype([('a', ref), ('b', '<f4')])
+        dt = np.dtype([('a', h5py.ref_dtype), ('b', '<f4')])
         tid = h5t.py_create(dt, logical=True)
         t1, t2 = tid.get_member_type(0), tid.get_member_type(1)
         self.assertEqual(t1, h5t.STD_REF_OBJ)

--- a/h5py/tests/old/test_slicing.py
+++ b/h5py/tests/old/test_slicing.py
@@ -85,7 +85,7 @@ class TestObjectIndex(BaseSlicing):
 
     def test_reference(self):
         """ Indexing a reference dataset returns a h5py.Reference instance """
-        dset = self.f.create_dataset('x', (1,), dtype=h5py.special_dtype(ref=h5py.Reference))
+        dset = self.f.create_dataset('x', (1,), dtype=h5py.ref_dtype)
         dset[0] = self.f.ref
         self.assertEqual(type(dset[0]), h5py.Reference)
 
@@ -94,14 +94,13 @@ class TestObjectIndex(BaseSlicing):
         """
         dset1 = self.f.create_dataset('x', (10,10))
         regref = dset1.regionref[...]
-        dset2 = self.f.create_dataset('y', (1,), dtype=h5py.special_dtype(ref=h5py.RegionReference))
+        dset2 = self.f.create_dataset('y', (1,), dtype=h5py.regionref_dtype)
         dset2[0] = regref
         self.assertEqual(type(dset2[0]), h5py.RegionReference)
 
     def test_reference_field(self):
         """ Compound types of which a reference is an element work right """
-        reftype = h5py.special_dtype(ref=h5py.Reference)
-        dt = np.dtype([('a', 'i'),('b',reftype)])
+        dt = np.dtype([('a', 'i'),('b', h5py.ref_dtype)])
 
         dset = self.f.create_dataset('x', (1,), dtype=dt)
         dset[0] = (42, self.f['/'].ref)
@@ -111,14 +110,14 @@ class TestObjectIndex(BaseSlicing):
 
     def test_scalar(self):
         """ Indexing returns a real Python object on scalar datasets """
-        dset = self.f.create_dataset('x', (), dtype=h5py.special_dtype(ref=h5py.Reference))
+        dset = self.f.create_dataset('x', (), dtype=h5py.ref_dtype)
         dset[()] = self.f.ref
         self.assertEqual(type(dset[()]), h5py.Reference)
 
     def test_bytestr(self):
         """ Indexing a byte string dataset returns a real python byte string
         """
-        dset = self.f.create_dataset('x', (1,), dtype=h5py.special_dtype(vlen=bytes))
+        dset = self.f.create_dataset('x', (1,), dtype=h5py.string_dtype(encoding='ascii'))
         dset[0] = b"Hello there!"
         self.assertEqual(type(dset[0]), bytes)
 

--- a/other/vlen_leak.py
+++ b/other/vlen_leak.py
@@ -46,7 +46,7 @@ def make_data(kind):
     else:
         s = b"xx".decode('utf8')
 
-    dt = h5py.special_dtype(vlen=kind)
+    dt = h5py.vlen_dtype(kind)
     data = np.array([s*100 for idx in xrange(1000)])
 
 


### PR DESCRIPTION
Closes #1118.

This adds three new pairs of functions for handling special dtypes:

* `string_dtype` and `check_string_dtype`
* `vlen_dtype` and `check_vlen_dtype`
* `enum_dtype` and `check_enum_dtype`

And two constants: `ref_dtype` and `regionref_dtype`, along with the function `check_ref_dtype`.

@aragilar I haven't yet changed the representation of string dtypes, as I think you were suggesting in #1118. I think it may make sense, especially if the changes requested in #379 go ahead, but there's more risk of breaking working code with that, so maybe it would be better to leave it for 3.0.