### PR TITLE
More standard repr for KeysViewHDF5

### DIFF
--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -308,8 +308,8 @@ class HLObject(CommonStateObject):
 
 class KeysViewHDF5(KeysView):
     def __str__(self):
-        k = ", ".join(repr(x) for x in self)
-        return "hdf_keys([{}])".format(k)
+        return "<KeysViewHDF5 {}>".format(list(self))
+
     __repr__ = __str__
 
 class ValuesViewHDF5(ValuesView):


### PR DESCRIPTION
By convention:

* reprs show their class name, but there's no object called `hdf_keys`.
* reprs which look like Python syntax can be evaluated to produce a similar object (e.g. `repr(set()) == 'set()'`), but you can't create a keys view from only the keys. When a repr is insufficient to create a similar object, a common pattern is to make a repr like `<Classname detail>` instead. That's what I've done here.

Marking this for 2.9 because it's a small change affecting something that was only introduced for 2.9 (see PR #1049).