### PR TITLE
DOC: do not specify upper bound on python support in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
 
 HDF5 for Python
 ===============
-`h5py` is a thin, pythonic wrapper around the `HDF5 <https://support.hdfgroup.org/HDF5/>`_, which runs on Python 2.7, and Python 3 (3.4-3.6).
+`h5py` is a thin, pythonic wrapper around the `HDF5 <https://support.hdfgroup.org/HDF5/>`_, which runs on Python 2.7, and Python 3 (3.4+).
 
 Websites
 --------


### PR DESCRIPTION
To avoid having to edit this when a new python comes out.