### PR TITLE
Deprecate special default default behaviour when opening file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ include README.rst
 include setup_build.py
 include setup_configure.py
 include tox.ini
+include pytest.ini
 
 recursive-include docs *
 prune docs/_build

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -183,6 +183,11 @@ def make_fid(name, mode, userblock_size, fapl, fcpl=None, swmr=False):
         except IOError:
             fid = h5f.create(name, h5f.ACC_EXCL, fapl=fapl, fcpl=fcpl)
     elif mode is None:
+        warn("The default file mode will change to 'r' (read-only) in h5py 3.0. "
+             "To suppress this warning, pass the mode you need to h5py.File(), "
+             "or set the global default h5.get_config().default_file_mode. "
+             "Available modes are: 'r', 'r+', 'w', 'w-'/'x', 'a'. "
+             "See the docs for details.", H5pyDeprecationWarning, stacklevel=3)
         # Try to open in append mode (read/write).
         # If that fails, try readonly, and finally create a new file only
         # if it won't clobber an existing file (ACC_EXCL).
@@ -386,6 +391,8 @@ class File(Group):
 
             if track_order is None:
                 track_order = h5.get_config().track_order
+            if mode is None:
+                mode = h5.get_config().default_file_mode
 
             with phil:
                 fapl = make_fapl(driver, libver, rdcc_nslots, rdcc_nbytes, rdcc_w0, **kwds)

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -185,7 +185,8 @@ def make_fid(name, mode, userblock_size, fapl, fcpl=None, swmr=False):
     elif mode is None:
         warn("The default file mode will change to 'r' (read-only) in h5py 3.0. "
              "To suppress this warning, pass the mode you need to h5py.File(), "
-             "or set the global default h5.get_config().default_file_mode. "
+             "or set the global default h5.get_config().default_file_mode, "
+             "or set the environment variable H5PY_DEFAULT_READONLY=1. "
              "Available modes are: 'r', 'r+', 'w', 'w-'/'x', 'a'. "
              "See the docs for details.", H5pyDeprecationWarning, stacklevel=3)
         # Try to open in append mode (read/write).
@@ -393,6 +394,8 @@ class File(Group):
                 track_order = h5.get_config().track_order
             if mode is None:
                 mode = h5.get_config().default_file_mode
+                if mode is None and os.environ.get('H5PY_DEFAULT_READONLY', ''):
+                    mode = 'r'
 
             with phil:
                 fapl = make_fapl(driver, libver, rdcc_nslots, rdcc_nbytes, rdcc_w0, **kwds)

--- a/h5py/h5.pxd
+++ b/h5py/h5.pxd
@@ -19,5 +19,6 @@ cdef class H5PYConfig:
     cdef readonly object API_18
     cdef readonly object _bytestrings
     cdef readonly object _track_order
+    cdef readonly object default_file_mode
 
 cpdef H5PYConfig get_config()

--- a/h5py/h5.pxd
+++ b/h5py/h5.pxd
@@ -19,6 +19,6 @@ cdef class H5PYConfig:
     cdef readonly object API_18
     cdef readonly object _bytestrings
     cdef readonly object _track_order
-    cdef readonly object default_file_mode
+    cdef readonly object _default_file_mode
 
 cpdef H5PYConfig get_config()

--- a/h5py/h5.pyx
+++ b/h5py/h5.pyx
@@ -60,6 +60,7 @@ cdef class H5PYConfig:
         self._t_name = b'TRUE'
         self._bytestrings = ByteStringContext()
         self._track_order = False
+        self.default_file_mode = None
 
     property complex_names:
         """ Settable 2-tuple controlling how complex numbers are saved.

--- a/h5py/h5.pyx
+++ b/h5py/h5.pyx
@@ -60,7 +60,7 @@ cdef class H5PYConfig:
         self._t_name = b'TRUE'
         self._bytestrings = ByteStringContext()
         self._track_order = False
-        self.default_file_mode = None
+        self._default_file_mode = None
 
     property complex_names:
         """ Settable 2-tuple controlling how complex numbers are saved.
@@ -148,6 +148,17 @@ cdef class H5PYConfig:
             return self._track_order
         def __set__(self, val):
             self._track_order = val
+
+    property default_file_mode:
+        """Default mode for h5py.File()"""
+        def __get__(self):
+            return self._default_file_mode
+
+        def __set__(self, val):
+            if val is None or val in {'r', 'r+', 'x', 'w-', 'w', 'a'}:
+                self._default_file_mode = val
+            else:
+                raise ValueError("Invalid mode; must be one of r, r+, w, w-, x, a or None")
 
 cdef H5PYConfig cfg = H5PYConfig()
 

--- a/h5py/h5py_warnings.py
+++ b/h5py/h5py_warnings.py
@@ -16,6 +16,7 @@ try:
 except ImportError:
     import_module = __import__
 
+
 class H5pyWarning(UserWarning):
     pass
 

--- a/h5py/tests/hl/test_vds/test_highlevel_vds.py
+++ b/h5py/tests/hl/test_vds/test_highlevel_vds.py
@@ -39,7 +39,7 @@ class TestEigerHighLevel(ut.TestCase):
         # Create the virtual dataset file
         with h5.File(outfile, 'w', libver='latest') as f:
             for foo in self.fname:
-                in_data = h5.File(foo)['data']
+                in_data = h5.File(foo, 'r')['data']
                 src_shape = in_data.shape
                 in_data.file.close()
                 M = M_minus_1 + src_shape[0]

--- a/h5py/tests/hl/test_vds/test_lowlevel_vds.py
+++ b/h5py/tests/hl/test_vds/test_lowlevel_vds.py
@@ -41,7 +41,7 @@ class TestEigerLowLevel(ut.TestCase):
             # Create the source dataset dataspace
             k = 0
             for foo in self.fname:
-                in_data = h5.File(foo)['data']
+                in_data = h5.File(foo, 'r')['data']
                 src_shape = in_data.shape
                 max_src_shape = src_shape
                 in_data.file.close()
@@ -239,7 +239,7 @@ class TestPercivalLowLevel(ut.TestCase):
             # Create the source dataset dataspace
             k = 0
             for foo in self.fname:
-                in_data = h5.File(foo)['data']
+                in_data = h5.File(foo, 'r')['data']
                 src_shape = in_data.shape
                 max_src_shape = (num,)+src_shape[1:]
                 in_data.file.close()

--- a/h5py/tests/hl/test_vds/test_virtual_source.py
+++ b/h5py/tests/hl/test_vds/test_virtual_source.py
@@ -135,7 +135,8 @@ class TestVirtualSource(ut.TestCase):
         self.assertEqual((1,)+dataset.shape[1:-1]+(1,),sliced.shape)
 
     def test_extra_args(self):
-        with h5.File(name='f1', driver='core', backing_store=False) as ftest:
+        with h5.File(name='f1', driver='core',
+                     backing_store=False, mode='w') as ftest:
             ftest['a'] = [1, 2, 3]
             a = ftest['a']
 

--- a/h5py/tests/old/test_dataset.py
+++ b/h5py/tests/old/test_dataset.py
@@ -1071,7 +1071,7 @@ class TestVlen(BaseDataset):
         ds = self.f.create_dataset('vlen', (1,), dtype=dt)
         fname = self.f.filename
         self.f.close()
-        self.f = h5py.File(fname)
+        self.f = h5py.File(fname, 'a')
         self.f.create_dataset('vlen2', (1,), self.f['vlen']['b'][()].dtype)
 
     def test_convert(self):

--- a/h5py/tests/old/test_file.py
+++ b/h5py/tests/old/test_file.py
@@ -572,8 +572,9 @@ class TestBackwardsCompat(TestCase):
 
     def test_fid(self):
         """ File objects provide a .fid attribute aliased to the file ID """
-        with File(self.mktemp(), 'w') as hfile:
-            self.assertIs(hfile.fid, hfile.id)
+        with pytest.warns(H5pyDeprecationWarning):
+            with File(self.mktemp(), 'w') as hfile:
+                self.assertIs(hfile.fid, hfile.id)
 
 
 class TestCloseInvalidatesOpenObjectIDs(TestCase):

--- a/h5py/tests/old/test_file.py
+++ b/h5py/tests/old/test_file.py
@@ -488,7 +488,7 @@ class TestClose(TestCase):
 
     def test_close(self):
         """ Close file via .close method """
-        fid = File(self.mktemp())
+        fid = File(self.mktemp(), 'w')
         self.assertTrue(fid)
         fid.close()
         self.assertFalse(fid)
@@ -539,7 +539,7 @@ class TestRepr(TestCase):
 
     def test_repr(self):
         """ __repr__ behaves itself when files are open and closed """
-        fid = File(self.mktemp())
+        fid = File(self.mktemp(), 'w')
         self.assertIsInstance(repr(fid), six.string_types)
         fid.close()
         self.assertIsInstance(repr(fid), six.string_types)
@@ -604,15 +604,15 @@ class TestPathlibSupport(TestCase):
         """ Check that pathlib is accepted by h5py.File """
         with closed_tempfile() as f:
             path = pathlib.Path(f)
-            with File(path) as f2:
+            with File(path, 'w') as f2:
                 self.assertTrue(True)
 
     def test_pathlib_name_match(self):
         """ Check that using pathlib does not affect naming """
         with closed_tempfile() as f:
             path = pathlib.Path(f)
-            with File(path) as h5f1:
+            with File(path, 'w') as h5f1:
                 pathlib_name = h5f1.filename
-            with File(f) as h5f2:
+            with File(f, 'w') as h5f2:
                 normal_name = h5f2.filename
             self.assertEqual(pathlib_name, normal_name)

--- a/h5py/tests/old/test_h5f.py
+++ b/h5py/tests/old/test_h5f.py
@@ -19,7 +19,8 @@ from ..common import TestCase
 
 class TestFileID(TestCase):
     def test_descriptor_core(self):
-        with File('TestFileID.test_descriptor_core', driver='core', backing_store=False) as f:
+        with File('TestFileID.test_descriptor_core', driver='core',
+                  backing_store=False, mode='x') as f:
             with self.assertRaises(NotImplementedError):
                 f.id.get_vfd_handle()
 
@@ -27,7 +28,7 @@ class TestFileID(TestCase):
         dn_tmp = tempfile.mkdtemp('h5py.lowtest.test_h5f.TestFileID.test_descriptor_sec2')
         fn_h5 = os.path.join(dn_tmp, 'test.h5')
         try:
-            with File(fn_h5, driver='sec2') as f:
+            with File(fn_h5, driver='sec2', mode='x') as f:
                 descriptor = f.id.get_vfd_handle()
                 self.assertNotEqual(descriptor, 0)
                 os.fsync(descriptor)
@@ -40,7 +41,7 @@ class TestCacheConfig(TestCase):
         dn_tmp = tempfile.mkdtemp('h5py.lowtest.test_h5f.TestFileID.TestCacheConfig.test_simple_gets')
         fn_h5 = os.path.join(dn_tmp, 'test.h5')
         try:
-            with File(fn_h5) as f:
+            with File(fn_h5, mode='x') as f:
                 hit_rate = f._id.get_mdc_hit_rate()
                 mdc_size = f._id.get_mdc_size()
 
@@ -51,7 +52,7 @@ class TestCacheConfig(TestCase):
         dn_tmp = tempfile.mkdtemp('h5py.lowtest.test_h5f.TestFileID.TestCacheConfig.test_hitrate_reset')
         fn_h5 = os.path.join(dn_tmp, 'test.h5')
         try:
-            with File(fn_h5) as f:
+            with File(fn_h5, mode='x') as f:
                 hit_rate = f._id.get_mdc_hit_rate()
                 f._id.reset_mdc_hit_rate_stats()
                 hit_rate = f._id.get_mdc_hit_rate()
@@ -64,7 +65,7 @@ class TestCacheConfig(TestCase):
         dn_tmp = tempfile.mkdtemp('h5py.lowtest.test_h5f.TestFileID.TestCacheConfig.test_mdc_config_get')
         fn_h5 = os.path.join(dn_tmp, 'test.h5')
         try:
-            with File(fn_h5) as f:
+            with File(fn_h5, mode='x') as f:
                 conf = f._id.get_mdc_config()
                 f._id.set_mdc_config(conf)
         finally:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    error::h5py.h5py_warnings.H5pyDeprecationWarning


### PR DESCRIPTION
From discussion in #397: introduce a global config option for the default mode when opening files, and a deprecation warning if you haven't explicitly specified a mode.

The idea is that this change would happen in a 2.x release, and then 3.0 would switch the global default to `'r'` and get rid of the special try readwrite, try readonly, try create sequence. At a later point, we could then get rid of the global config option; I think it's always clearer to pass the mode directly when you open a file.

This implementation doesn't allow any way to get *exactly* the old behaviour back without the warning. You can get close by setting mode `'a'` (try readwrite, try exclusive create). I don't think a fallback to read-only really makes sense: if you need to write data, it's best to fail fast, and if you don't need to write data, it's best to open the file read-only. If there's a corner case where the pattern is useful, someone can still write their own try/excepts to achieve it.