### PR TITLE
Set stacklevel for warnings

### DIFF
--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -310,7 +310,7 @@ class Dataset(HLObject):
     def value(self):
         """  Alias for dataset[()] """
         warn("dataset.value has been deprecated. "
-            "Use dataset[()] instead.", H5pyDeprecationWarning)
+            "Use dataset[()] instead.", H5pyDeprecationWarning, stacklevel=2)
         return self[()]
 
     @property

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -255,7 +255,7 @@ class File(Group):
     def fid(self):
         """File ID (backwards compatibility) """
         warn("File.fid has been deprecated. "
-            "Use File.id instead.", H5pyDeprecationWarning)
+            "Use File.id instead.", H5pyDeprecationWarning, stacklevel=2)
         return self.id
 
     @property


### PR DESCRIPTION
Without these, the code shown with the warning is the final line of the `warn()` call itself, which isn't very informative. This tells it to show the next level up the stack, which is the code that will likely need to be changed. 