### PR TITLE
Travis CI: 'sudo' tag is now deprecated in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 
+dist: xenial
+
 notifications:
   email: false
 
@@ -7,9 +9,6 @@ addons:
   apt:
     packages:
       - libhdf5-serial-dev
-
-sudo: false
-dist: xenial
 
 cache:
   directories:
@@ -113,14 +112,12 @@ matrix:
 
     # Python 3.7
     - python: 3.7
-      sudo: true
       env:
       - TOXENV=py37-test-deps
         HDF5_VERSION=1.10.3
         HDF5_DIR=$HDF5_CACHE_DIR/$HDF5_VERSION
 
     - python: 3.7
-      sudo: true
       env:
       - TOXENV=py37-test-deps
         HDF5_VERSION=1.10.4


### PR DESCRIPTION
[Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)