### PR TITLE
Fix Python 3 compatibility issues

### DIFF
--- a/examples/collective_io.py
+++ b/examples/collective_io.py
@@ -7,6 +7,7 @@ Prerequisites: python 2.5.0, mpi4py and numpy
 Source Codes: Already submit this 'collective io' branch to h5py master, meanwhile, can download this branch at https://github.com/valiantljk/h5py.git
 Note: Must build the h5py with parallel hdf5
 """
+from __future__ import print_function
 
 from mpi4py import MPI
 import numpy as np
@@ -50,10 +51,10 @@ comm.Barrier()
 timeend=MPI.Wtime()
 if rank==0:
     if colw==1:
-        print "collective write time %f" %(timeend-timestart)
+        print("collective write time %f" %(timeend-timestart))
     else:
-        print "independent write time %f" %(timeend-timestart)
-    print "data size x: %d y: %d" %(length_x, length_y)
-    print "file size ~%d GB" % (length_x*length_y/1024.0/1024.0/1024.0*8.0)
-    print "number of processes %d" %nproc
+        print("independent write time %f" %(timeend-timestart))
+    print("data size x: %d y: %d" %(length_x, length_y))
+    print("file size ~%d GB" % (length_x*length_y/1024.0/1024.0/1024.0*8.0))
+    print("number of processes %d" %nproc)
 f.close()

--- a/examples/multiprocessing_example.py
+++ b/examples/multiprocessing_example.py
@@ -30,6 +30,7 @@ from __future__ import print_function
 
 import numpy as np
 import multiprocessing as mp
+from six.moves import xrange  # pylint: disable=redefined-builtin
 import h5py
 
 # === Parameters for Mandelbrot calculation ===================================

--- a/examples/threading_example.py
+++ b/examples/threading_example.py
@@ -29,12 +29,14 @@
     stores them in an HDF5 file.  The visualization/control thread reads
     datasets from the same file and displays them using matplotlib.
 """
+from __future__ import print_function
 
 import Tkinter as tk
 import threading
 
 import numpy as np
 import pylab as p
+from six.moves import xrange  # pylint: disable=redefined-builtin
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 from matplotlib.figure import Figure
 
@@ -89,7 +91,7 @@ class ComputeThread(threading.Thread):
             return i
 
         for x in xrange(nx):
-            if x%25 == 0: print "Computing row %d" % x
+            if x%25 == 0: print("Computing row %d" % x)
             for y in xrange(ny):
                 pos = self.startcoords + complex(x*xincr, y*yincr)
                 arr[x,y] = compute_escape(pos, self.escape)
@@ -103,7 +105,7 @@ class ComputeThread(threading.Thread):
             dset.attrs['escape'] = self.escape
             dset[...] = arr
 
-        print "Calculation for %s done" % dsname
+        print("Calculation for %s done" % dsname)
 
         self.eventcall()
 
@@ -183,8 +185,8 @@ class ComputeWidget(object):
                 raise ValueError("NX, NY and ESCAPE must be positive")
             if abs(extent)==0:
                 raise ValueError("Extent must be finite")
-        except (ValueError, TypeError), e:
-            print e
+        except (ValueError, TypeError) as e:
+            print(e)
             return
 
         if t is not None:
@@ -263,7 +265,7 @@ class ViewWidget(object):
     def back(self):
         """ Go to the previous dataset (in ASCII order) """
         if self.index == 0:
-            print "Can't go back"
+            print("Can't go back")
             return
         self.index -= 1
         self.draw_fractal()
@@ -271,7 +273,7 @@ class ViewWidget(object):
     def forward(self):
         """ Go to the next dataset (in ASCII order) """
         if self.index == (len(self.f)-1):
-            print "Can't go forward"
+            print("Can't go forward")
             return
         self.index += 1
         self.draw_fractal()
@@ -280,7 +282,7 @@ class ViewWidget(object):
         """ Jump to the last (ASCII order) dataset and display it """
         with file_lock:
             if len(self.f) == 0:
-                print "can't jump to last (no datasets)"
+                print("can't jump to last (no datasets)")
                 return
             index = len(self.f)-1
         self.index = index

--- a/windows/pavement.py
+++ b/windows/pavement.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import shutil, zipfile, tempfile, glob, urllib
 import os
 import os.path as op
@@ -10,7 +11,7 @@ ROOTPATH = op.dirname(op.abspath(__file__))
 
 def archive(fname):
     """ Currently just copies a single file to the current directory """
-    print "Archiving %s" % str(fname)
+    print("Archiving %s" % str(fname))
     if op.exists(op.join(ROOTPATH, fname)):
         os.remove(op.join(ROOTPATH, fname))
     shutil.copy(fname, ROOTPATH)
@@ -57,7 +58,7 @@ def build(vs_version):
 
 def check_zip():
     if not op.exists(ZIPFILE_NAME):
-        print "Downloading HDF5 source code..."
+        print("Downloading HDF5 source code...")
         urllib.urlretrieve(ZIPFILE_URL, ZIPFILE_NAME)
     try:
         sh('cmake --version')


### PR DESCRIPTION
* __print()__ function
* __xrange()__ --> __six.moves.xrange()__
* Old style exceptions --> new style

[flake8](http://flake8.pycqa.org) testing of https://github.com/h5py/h5py on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./examples/multiprocessing_example.py:55:14: F821 undefined name 'xrange'
    for i in xrange(ESCAPE):
             ^
./examples/multiprocessing_example.py:65:14: F821 undefined name 'xrange'
    for y in xrange(NY):
             ^
./examples/multiprocessing_example.py:89:55: F821 undefined name 'xrange'
    result = pool.imap(compute_row, (x*xincr for x in xrange(NX)))
                                                      ^
./examples/threading_example.py:92:50: E999 SyntaxError: invalid syntax
            if x%25 == 0: print "Computing row %d" % x
                                                 ^
./examples/collective_io.py:53:40: E999 SyntaxError: invalid syntax
        print "collective write time %f" %(timeend-timestart)
                                       ^
./windows/pavement.py:13:24: E999 SyntaxError: invalid syntax
    print "Archiving %s" % str(fname)
                       ^
3     E999 SyntaxError: invalid syntax
3     F821 undefined name 'xrange'
6
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree