### PR TITLE
TST,CI: Specify coverage location as default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ MANIFEST
 *.so
 *~
 .pytest_cache
+.coverage

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,9 @@ changedir =
 passenv =
     HDF5_DIR
     TOXPYTHON
+setenv =
+    COVERAGE_FILE={toxinidir}/.coverage
+# needed otherwise coverage cannot find the file when reporting
 basepython =
     pypy: {env:TOXPYTHON:pypy}
     py27: {env:TOXPYTHON:python2.7}


### PR DESCRIPTION
Coverage looks by default at .coverage, but due to cd'ing to .tox, the
output file is written to a different location than the default.
Specifying the base dir in the associated envvar when testing fixes
this.

This is why even though codecov appears to be set up, no data is being sent.