### PR TITLE
Replace deprecated assertion methods

### DIFF
--- a/h5py/tests/common.py
+++ b/h5py/tests/common.py
@@ -105,39 +105,27 @@ class TestCase(ut.TestCase):
             message = ' (%s)' % message
 
         if np.isscalar(dset) or np.isscalar(arr):
-            self.assert_(
-                np.isscalar(dset) and np.isscalar(arr),
+            assert np.isscalar(dset) and np.isscalar(arr), \
                 'Scalar/array mismatch ("%r" vs "%r")%s' % (dset, arr, message)
-                )
-            self.assert_(
-                dset - arr < precision,
+            assert dset - arr < precision, \
                 "Scalars differ by more than %.3f%s" % (precision, message)
-                )
             return
 
-        self.assert_(
-            dset.shape == arr.shape,
+        assert dset.shape == arr.shape, \
             "Shape mismatch (%s vs %s)%s" % (dset.shape, arr.shape, message)
-            )
-        self.assert_(
-            dset.dtype == arr.dtype,
+        assert dset.dtype == arr.dtype, \
             "Dtype mismatch (%s vs %s)%s" % (dset.dtype, arr.dtype, message)
-            )
 
         if arr.dtype.names is not None:
             for n in arr.dtype.names:
                 message = '[FIELD %s] %s' % (n, message)
                 self.assertArrayEqual(dset[n], arr[n], message=message, precision=precision)
         elif arr.dtype.kind in ('i', 'f'):
-            self.assert_(
-                np.all(np.abs(dset[...] - arr[...]) < precision),
+            assert np.all(np.abs(dset[...] - arr[...]) < precision), \
                 "Arrays differ by more than %.3f%s" % (precision, message)
-                )
         else:
-            self.assert_(
-                np.all(dset[...] == arr[...]),
+            assert np.all(dset[...] == arr[...]), \
                 "Arrays are not equal (dtype %s) %s" % (arr.dtype.str, message)
-                )
 
     def assertNumpyBehavior(self, dset, arr, s):
         """ Apply slicing arguments "s" to both dset and arr.

--- a/h5py/tests/hl/test_dataset_getitem.py
+++ b/h5py/tests/hl/test_dataset_getitem.py
@@ -62,23 +62,23 @@ class TestEmpty(TestCase):
 
     def test_ndim(self):
         """ Verify number of dimensions """
-        self.assertEquals(self.dset.ndim, 0)
+        self.assertEqual(self.dset.ndim, 0)
 
     def test_shape(self):
         """ Verify shape """
-        self.assertEquals(self.dset.shape, None)
+        self.assertEqual(self.dset.shape, None)
 
     def test_size(self):
         """ Verify shape """
-        self.assertEquals(self.dset.size, None)
+        self.assertEqual(self.dset.size, None)
 
     def test_ellipsis(self):
         """ Ellipsis -> ValueError """
-        self.assertEquals(self.dset[...], self.empty_obj)
+        self.assertEqual(self.dset[...], self.empty_obj)
 
     def test_tuple(self):
         """ () -> IOError """
-        self.assertEquals(self.dset[()], self.empty_obj)
+        self.assertEqual(self.dset[()], self.empty_obj)
 
     def test_slice(self):
         """ slice -> ValueError """
@@ -116,11 +116,11 @@ class TestScalarFloat(TestCase):
 
     def test_ndim(self):
         """ Verify number of dimensions """
-        self.assertEquals(self.dset.ndim, 0)
+        self.assertEqual(self.dset.ndim, 0)
 
     def test_shape(self):
         """ Verify shape """
-        self.assertEquals(self.dset.shape, tuple())
+        self.assertEqual(self.dset.shape, tuple())
 
     def test_ellipsis(self):
         """ Ellipsis -> scalar ndarray """
@@ -170,11 +170,11 @@ class TestScalarCompound(TestCase):
 
     def test_ndim(self):
         """ Verify number of dimensions """
-        self.assertEquals(self.dset.ndim, 0)
+        self.assertEqual(self.dset.ndim, 0)
 
     def test_shape(self):
         """ Verify shape """
-        self.assertEquals(self.dset.shape, tuple())
+        self.assertEqual(self.dset.shape, tuple())
 
     def test_ellipsis(self):
         """ Ellipsis -> scalar ndarray """
@@ -232,13 +232,13 @@ class TestScalarArray(TestCase):
 
     def test_ndim(self):
         """ Verify number of dimensions """
-        self.assertEquals(self.data.ndim, 2)
-        self.assertEquals(self.dset.ndim, 0)
+        self.assertEqual(self.data.ndim, 2)
+        self.assertEqual(self.dset.ndim, 0)
 
     def test_shape(self):
         """ Verify shape """
-        self.assertEquals(self.data.shape, (3, 2))
-        self.assertEquals(self.dset.shape, tuple())
+        self.assertEqual(self.data.shape, (3, 2))
+        self.assertEqual(self.dset.shape, tuple())
 
     def test_ellipsis(self):
         """ Ellipsis -> ndarray promoted to underlying shape """
@@ -287,11 +287,11 @@ class Test1DZeroFloat(TestCase):
 
     def test_ndim(self):
         """ Verify number of dimensions """
-        self.assertEquals(self.dset.ndim, 1)
+        self.assertEqual(self.dset.ndim, 1)
 
     def test_shape(self):
         """ Verify shape """
-        self.assertEquals(self.dset.shape, (0,))
+        self.assertEqual(self.dset.shape, (0,))
 
     def test_ellipsis(self):
         """ Ellipsis -> ndarray of matching shape """
@@ -342,11 +342,11 @@ class Test1DFloat(TestCase):
 
     def test_ndim(self):
         """ Verify number of dimensions """
-        self.assertEquals(self.dset.ndim, 1)
+        self.assertEqual(self.dset.ndim, 1)
 
     def test_shape(self):
         """ Verify shape """
-        self.assertEquals(self.dset.shape, (13,))
+        self.assertEqual(self.dset.shape, (13,))
 
     def test_ellipsis(self):
         self.assertNumpyBehavior(self.dset, self.data, np.s_[...])
@@ -466,11 +466,11 @@ class Test2DZeroFloat(TestCase):
 
     def test_ndim(self):
         """ Verify number of dimensions """
-        self.assertEquals(self.dset.ndim, 2)
+        self.assertEqual(self.dset.ndim, 2)
 
     def test_shape(self):
         """ Verify shape """
-        self.assertEquals(self.dset.shape, (0, 3))
+        self.assertEqual(self.dset.shape, (0, 3))
 
     @ut.expectedFailure
     def test_indexlist(self):

--- a/h5py/tests/hl/test_datatype.py
+++ b/h5py/tests/hl/test_datatype.py
@@ -16,10 +16,8 @@ class TestVlen(TestCase):
         Check that storage of vlen strings is carried out correctly.
     """
     def assertVlenArrayEqual(self, dset, arr, message=None, precision=None):
-        self.assert_(
-            dset.shape == arr.shape,
+        assert dset.shape == arr.shape, \
             "Shape mismatch (%s vs %s)%s" % (dset.shape, arr.shape, message)
-            )
         for (i, d, a) in zip(count(), dset, arr):
             self.assertArrayEqual(d, a, message, precision)
 

--- a/h5py/tests/hl/test_file.py
+++ b/h5py/tests/hl/test_file.py
@@ -137,8 +137,8 @@ class TestFileObj(TestCase):
 
     def check_write(self, fileobj):
         f = h5py.File(fileobj)
-        self.assertEquals(f.driver, 'fileobj')
-        self.assertEquals(f.filename, repr(fileobj))
+        self.assertEqual(f.driver, 'fileobj')
+        self.assertEqual(f.filename, repr(fileobj))
         f.create_dataset('test', data=list(range(12)))
         self.assertEqual(list(f), ['test'])
         self.assertEqual(list(f['test'][:]), list(range(12)))
@@ -154,7 +154,7 @@ class TestFileObj(TestCase):
 
     def test_BytesIO(self):
         with io.BytesIO() as fileobj:
-            self.assertEquals(len(fileobj.getvalue()), 0)
+            self.assertEqual(len(fileobj.getvalue()), 0)
             self.check_write(fileobj)
             self.assertGreater(len(fileobj.getvalue()), 0)
             self.check_read(fileobj)
@@ -164,7 +164,7 @@ class TestFileObj(TestCase):
         fname = self.mktemp()
         try:
             with open(fname, 'wb+') as fileobj:
-                self.assertEquals(os.path.getsize(fname), 0)
+                self.assertEqual(os.path.getsize(fname), 0)
                 self.check_write(fileobj)
                 self.assertGreater(os.path.getsize(fname), 0)
                 self.check_read(fileobj)

--- a/h5py/tests/old/test_file.py
+++ b/h5py/tests/old/test_file.py
@@ -82,7 +82,7 @@ class TestFileOpen(TestCase):
         """ Mode 'w-' opens file in exclusive mode """
         fname = self.mktemp()
         fid = File(fname, 'w-')
-        self.assert_(fid)
+        self.assertTrue(fid)
         fid.close()
         with self.assertRaises(IOError):
             File(fname, 'w-')
@@ -92,16 +92,16 @@ class TestFileOpen(TestCase):
         fname = self.mktemp()
         fid = File(fname, 'a')
         try:
-            self.assert_(fid)
+            self.assertTrue(fid)
             fid.create_group('foo')
-            self.assert_('foo' in fid)
+            assert 'foo' in fid
         finally:
             fid.close()
         fid = File(fname, 'a')
         try:
-            self.assert_('foo' in fid)
+            assert 'foo' in fid
             fid.create_group('bar')
-            self.assert_('bar' in fid)
+            assert 'bar' in fid
         finally:
             fid.close()
 
@@ -110,9 +110,9 @@ class TestFileOpen(TestCase):
         fname = self.mktemp()
         fid = File(fname, 'w')
         fid.close()
-        self.assert_(not fid)
+        self.assertFalse(fid)
         fid = File(fname, 'r')
-        self.assert_(fid)
+        self.assertTrue(fid)
         with self.assertRaises(ValueError):
             fid.create_group('foo')
         fid.close()
@@ -124,9 +124,9 @@ class TestFileOpen(TestCase):
         fid.create_group('foo')
         fid.close()
         fid = File(fname, 'r+')
-        self.assert_('foo' in fid)
+        assert 'foo' in fid
         fid.create_group('bar')
-        self.assert_('bar' in fid)
+        assert 'bar' in fid
         fid.close()
 
     def test_nonexistent_file(self):
@@ -202,7 +202,7 @@ class TestDrivers(TestCase):
     def test_sec2(self):
         """ Sec2 driver is supported on posix """
         fid = File(self.mktemp(), 'w', driver='sec2')
-        self.assert_(fid)
+        self.assertTrue(fid)
         self.assertEqual(fid.driver, 'sec2')
         fid.close()
 
@@ -210,7 +210,7 @@ class TestDrivers(TestCase):
         """ Core driver is supported (no backing store) """
         fname = self.mktemp()
         fid = File(fname, 'w', driver='core', backing_store=False)
-        self.assert_(fid)
+        self.assertTrue(fid)
         self.assertEqual(fid.driver, 'core')
         fid.close()
         self.assertFalse(os.path.exists(fname))
@@ -222,7 +222,7 @@ class TestDrivers(TestCase):
         fid.create_group('foo')
         fid.close()
         fid = File(fname, 'r')
-        self.assert_('foo' in fid)
+        assert 'foo' in fid
         fid.close()
 
     def test_readonly(self):
@@ -232,8 +232,8 @@ class TestDrivers(TestCase):
         fid.create_group('foo')
         fid.close()
         fid = File(fname, 'r', driver='core')
-        self.assert_(fid)
-        self.assert_('foo' in fid)
+        self.assertTrue(fid)
+        assert 'foo' in fid
         with self.assertRaises(ValueError):
             fid.create_group('bar')
         fid.close()
@@ -243,7 +243,7 @@ class TestDrivers(TestCase):
         fname = self.mktemp()
         fid = File(fname, 'w', driver='core', block_size=1024,
                    backing_store=False)
-        self.assert_(fid)
+        self.assertTrue(fid)
         fid.close()
 
     @ut.skipUnless(mpi, "Parallel HDF5 is required for MPIO driver test")
@@ -384,7 +384,7 @@ class TestUserblock(TestCase):
 
         f = h5py.File(name, 'r')
         try:
-            self.assert_("Foobar" in f)
+            assert "Foobar" in f
         finally:
             f.close()
 
@@ -489,9 +489,9 @@ class TestClose(TestCase):
     def test_close(self):
         """ Close file via .close method """
         fid = File(self.mktemp())
-        self.assert_(fid)
+        self.assertTrue(fid)
         fid.close()
-        self.assert_(not fid)
+        self.assertFalse(fid)
 
     def test_closed_file(self):
         """ Trying to modify closed file raises ValueError """

--- a/h5py/tests/old/test_group.py
+++ b/h5py/tests/old/test_group.py
@@ -957,11 +957,11 @@ class TestCopy(TestCase):
 
         self.f1.copy(foo, 'baz', without_attrs=True)
         self.assertArrayEqual(self.f1['baz'], np.array([1,2,3]))
-        self.assert_('bar' not in self.f1['baz'].attrs)
+        assert 'bar' not in self.f1['baz'].attrs
 
         self.f2.copy(foo, 'baz', without_attrs=True)
         self.assertArrayEqual(self.f2['baz'], np.array([1,2,3]))
-        self.assert_('bar' not in self.f2['baz'].attrs)
+        assert 'bar' not in self.f2['baz'].attrs
 
     @ut.skipIf(h5py.version.hdf5_version_tuple < (1,8,9),
                "Bug in HDF5<1.8.8 prevents copying open dataset")


### PR DESCRIPTION
While looking at [a CI test log](https://travis-ci.org/h5py/h5py/jobs/477786641), I noticed that there was a lot of output warning about deprecated assertion methods `assertEquals` and `assert_`. I think it's worth cleaning them up so it's easier to see other information in test logs.

- `assertEquals()` I find-and-replaced to `assertEqual()`, which is the standard name
- `assert_()` I changed by hand to various things that seemed like a good idea. In many cases I've just used a bare `assert` statement, relying on either the explicit message or on pytest's magic to give informative errors.