### PR TITLE
Allow indexing a dataset with an empty list

### DIFF
--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -280,7 +280,6 @@ dataset with shape (10, 10)::
 
 The following restrictions exist:
 
-* List selections may not be empty
 * Selection coordinates must be given in increasing order
 * Duplicate selections are ignored
 * Very long lists (> 1000 elements) may produce poor performance
@@ -296,6 +295,9 @@ list of points to select, so be careful when using it with large masks::
     >>> result.shape
     (49,)
 
+.. versionchanged:: 2.10
+   Selecting using an empty list is now allowed.
+   This returns an array with length 0 in the relevant dimension.
 
 .. _dataset_iter:
 

--- a/h5py/tests/hl/test_dataset_getitem.py
+++ b/h5py/tests/hl/test_dataset_getitem.py
@@ -471,6 +471,30 @@ class Test2DZeroFloat(TestCase):
         self.assertNumpyBehavior(self.dset, self.data, np.s_[:,[0,1,2]])
 
 
+class Test2DFloat(TestCase):
+
+    def setUp(self):
+        TestCase.setUp(self)
+        self.data = np.ones((5,3), dtype='f')
+        self.dset = self.f.create_dataset('x', data=self.data)
+
+    def test_ndim(self):
+        """ Verify number of dimensions """
+        self.assertEqual(self.dset.ndim, 2)
+
+    def test_shape(self):
+        """ Verify shape """
+        self.assertEqual(self.dset.shape, (5, 3))
+
+    def test_indexlist(self):
+        """ see issue #473 """
+        self.assertNumpyBehavior(self.dset, self.data, np.s_[:,[0,1,2]])
+
+    def test_index_emptylist(self):
+        self.assertNumpyBehavior(self.dset, self.data, np.s_[:, []])
+        self.assertNumpyBehavior(self.dset, self.data, np.s_[[]])
+
+
 class TestVeryLargeArray(TestCase):
 
     def setUp(self):

--- a/h5py/tests/hl/test_dataset_getitem.py
+++ b/h5py/tests/hl/test_dataset_getitem.py
@@ -314,13 +314,9 @@ class Test1DZeroFloat(TestCase):
         with self.assertRaises(ValueError):
             self.dset[0]
 
-    # FIXME: Under NumPy this works and returns a shape-(0,) array
-    # Also, at the moment it rasies UnboundLocalError (!)
-    @ut.expectedFailure
     def test_indexlist(self):
         """ index list """
-        with self.assertRaises(ValueError):
-            self.dset[[]]
+        self.assertNumpyBehavior(self.dset, self.data, np.s_[[]])
 
     def test_mask(self):
         """ mask -> ndarray of matching shape """
@@ -416,8 +412,6 @@ class Test1DFloat(TestCase):
     def test_indexlist_numpyarray_ellipsis(self):
         self.assertNumpyBehavior(self.dset, self.data, np.s_[np.array([1, 2, 5]), ...])
 
-    # Another UnboundLocalError
-    @ut.expectedFailure
     def test_indexlist_empty(self):
         self.assertNumpyBehavior(self.dset, self.data, np.s_[[]])
 
@@ -472,7 +466,6 @@ class Test2DZeroFloat(TestCase):
         """ Verify shape """
         self.assertEqual(self.dset.shape, (0, 3))
 
-    @ut.expectedFailure
     def test_indexlist(self):
         """ see issue #473 """
         self.assertNumpyBehavior(self.dset, self.data, np.s_[:,[0,1,2]])


### PR DESCRIPTION
As described in #1169, this mirrors numpy's behaviour, and gets rid of a couple of failing tests. I also fixed #473 along the way.

#778 is a more complete reworking of the fancy indexing machinery, which allows fancy indexing on multiple axes at the same time. But this is a comparatively small and straightforward change.