### PR TITLE
Clean up tests using deprecated features

### DIFF
--- a/h5py/tests/hl/test_datatype.py
+++ b/h5py/tests/hl/test_datatype.py
@@ -204,7 +204,7 @@ class TestOffsets(TestCase):
         })
         data = np.empty(10, dtype=dt)
         data['f1'] = np.random.rand(data.size)
-        data['f2'] = np.random.random_integers(-10, 10, data.size)
+        data['f2'] = np.random.randint(-10, 11, data.size)
         data['f3'] = np.random.rand(data.size)*-1
 
         fname = self.mktemp()

--- a/h5py/tests/old/test_attrs.py
+++ b/h5py/tests/old/test_attrs.py
@@ -20,7 +20,11 @@ from __future__ import absolute_import
 import six
 
 import numpy as np
-import collections
+
+try:
+    from collections.abc import MutableMapping
+except ImportError:  # Python < 3.3
+    from collections import MutableMapping
 
 from ..common import TestCase, ut
 
@@ -147,8 +151,8 @@ class TestMutableMapping(BaseAttrs):
     behaves as expected
     '''
     def test_resolution(self):
-        assert issubclass(AttributeManager, collections.MutableMapping)
-        assert isinstance(self.f.attrs, collections.MutableMapping)
+        assert issubclass(AttributeManager, MutableMapping)
+        assert isinstance(self.f.attrs, MutableMapping)
 
     def test_validity(self):
         '''

--- a/h5py/tests/old/test_attrs_data.py
+++ b/h5py/tests/old/test_attrs_data.py
@@ -248,7 +248,7 @@ class TestWriteException(BaseAttrs):
     def test_write(self):
         """ ValueError on string write wipes out attribute """
 
-        s = b"Hello\x00\Hello"
+        s = b"Hello\x00Hello"
 
         try:
             self.f.attrs['x'] = s

--- a/h5py/tests/old/test_group.py
+++ b/h5py/tests/old/test_group.py
@@ -19,12 +19,16 @@
 
 from __future__ import absolute_import
 
-import collections
 import numpy as np
 import os
 import os.path
 import sys
 from tempfile import mkdtemp
+
+try:
+    from collections.abc import MutableMapping
+except ImportError:  # Python < 3.3
+    from collections import MutableMapping
 
 import six
 
@@ -1066,9 +1070,9 @@ class TestMutableMapping(BaseGroup):
     behaves as expected
     '''
     def test_resolution(self):
-        assert issubclass(Group, collections.MutableMapping)
+        assert issubclass(Group, MutableMapping)
         grp = self.f.create_group("K")
-        assert isinstance(grp, collections.MutableMapping)
+        assert isinstance(grp, MutableMapping)
 
     def test_validity(self):
         '''


### PR DESCRIPTION
This squashes warnings from the tests about unrecognised escapes, a moved class in `collections.abc`, and a deprecated numpy method.