### PR TITLE
Update __repr__ to provide more convinient interface for browsing h5…

### DIFF
--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -310,7 +310,9 @@ class KeysViewHDF5(KeysView):
     def __str__(self):
         return "<KeysViewHDF5 {}>".format(list(self))
 
-    __repr__ = __str__
+    def __repr__(self):
+        return '\n'.join(["<KeysViewHDF5>:"] + ["  + " + key for key in list(self)])
+
 
 class ValuesViewHDF5(ValuesView):
 

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -461,8 +461,9 @@ class File(Group):
             filename = self.filename
             if isinstance(filename, bytes):  # Can't decode fname
                 filename = filename.decode('utf8', 'replace')
-            r = u'<HDF5 file "%s" (mode %s)>' % (os.path.basename(filename),
+            r = u'<HDF5 file "%s" (mode %s)>\n' % (os.path.basename(filename),
                                                  self.mode)
+            r += repr(self.keys())
 
         if six.PY2:
             return r.encode('utf8')

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -570,7 +570,8 @@ class Group(HLObject, MutableMappingHDF5):
             namestr = (
                 u'"%s"' % self.name
             ) if self.name is not None else u"(anonymous)"
-            r = u'<HDF5 group %s (%d members)>' % (namestr, len(self))
+            r = u'<HDF5 group %s (%d members)>\n' % (namestr, len(self))
+            r += repr(self.keys())
 
         if six.PY2:
             return r.encode('utf8')


### PR DESCRIPTION
… files interactively.

This is a short commit to improve the readability of the repr output. Despite being originally denied, I hope this can be reconsidered as it considerably improves the ability of an interactive user to browse an HDF5 container while not otherwise affecting the performance or design of the library. Minimal improvements (as seen here) I believe could go a long way.

An example of the changes in use:

```
In [1]: import h5py as h5                                                                                             

In [2]: f = h5.File('output.h5', 'r')                                                                                 

In [3]: f                                                                                                             
Out[3]: 
<HDF5 file "output.h5" (mode r)>
<KeysViewHDF5>:
  + numeric
  + waveform

In [4]: f['waveform']                                                                                                 
Out[4]: 
<HDF5 group "/waveform" (9 members)>
<KeysViewHDF5>:
  + ECG.I
  + ECG.II
  + ECG.III
  + ECG.MCL
  + ECG.V
  + ECG.aVR
  + Pleth
  + PlethT
  + Resp

In [5]: f['waveform']['ECG.I']                                                                                        
Out[5]: 
<HDF5 group "/waveform/ECG.I" (3 members)>
<KeysViewHDF5>:
  + data
  + meta
  + unit
```

#566