### PR TITLE
docs/build.rst: Fix bulleted list

### DIFF
--- a/docs/build.rst
+++ b/docs/build.rst
@@ -78,9 +78,11 @@ when building from source.
 Source installation
 -------------------
 To install h5py from source, you need three things installed:
+
 * A supported Python version with development headers
 * HDF5 1.8.4 or newer with development headers
 * A C compiler
+
 OS-specific instructions for installing HDF5, Python and a C compiler are in the next few
 sections.
 


### PR DESCRIPTION
Added blank lines required for Sphinx to render as a bulleted list.

### Before:

<img width="840" alt="Screen Shot 2019-03-16 at 9 16 46 AM" src="https://user-images.githubusercontent.com/305268/54478196-d42b0380-47cc-11e9-935b-91df54d59a65.png">

### After:

<img width="841" alt="Screen Shot 2019-03-16 at 9 17 21 AM" src="https://user-images.githubusercontent.com/305268/54478193-c8d7d800-47cc-11e9-91a2-3a503494adf5.png">