### PR TITLE
Add IPython formatters to provide more convinient interface for browsing HDF5 files interactively

### DIFF
--- a/h5py/__init__.py
+++ b/h5py/__init__.py
@@ -64,6 +64,9 @@ from .h5t import (special_dtype, check_dtype,
     check_vlen_dtype, check_string_dtype, check_enum_dtype, check_ref_dtype,
 )
 
+from ._ipython import (
+    enable_ipython_completer, enable_ipython_formatter, enable_ipython)
+
 from . import version
 from .version import version as __version__
 
@@ -86,29 +89,6 @@ def run_tests(args=''):
     # requirements, e.g. pytest
     from .tests import run_tests
     return run_tests(args)
-
-
-def enable_ipython_completer():
-    """ Call this from an interactive IPython session to enable tab-completion
-    of group and attribute names.
-    """
-    import sys
-    if 'IPython' in sys.modules:
-        ip_running = False
-        try:
-            from IPython.core.interactiveshell import InteractiveShell
-            ip_running = InteractiveShell.initialized()
-        except ImportError:
-            # support <ipython-0.11
-            from IPython import ipapi as _ipapi
-            ip_running = _ipapi.get() is not None
-        except Exception:
-            pass
-        if ip_running:
-            from . import ipy_completer
-            return ipy_completer.load_ipython_extension()
-
-    raise RuntimeError('Completer must be enabled in active ipython session')
 
 
 # --- Legacy API --------------------------------------------------------------

--- a/h5py/_ipython/__init__.py
+++ b/h5py/_ipython/__init__.py
@@ -1,0 +1,47 @@
+#+
+#
+# This file is part of h5py, a low-level Python interface to the HDF5 library.
+#
+# Contributed by Anthony Wertz
+#
+# http://h5py.alfven.org
+# License: BSD  (See LICENSE.txt for full license)
+#
+#-
+
+# pylint: disable=eval-used,protected-access
+
+"""
+    This provides an interface for enabling IPython extensions.
+"""
+
+def enable_ipython_completer():
+    """ Call this from an interactive IPython session to enable tab-completion
+    of group and attribute names.
+    """
+    from .utils import is_ipython_initialized
+    if is_ipython_initialized():
+        from . import completer
+        return completer.load_ipython_extension()
+
+    raise RuntimeError('Completer must be enabled in active ipython session')
+
+
+def enable_ipython_formatter():
+    """ Call this from an interactive IPython session to enable prettier printing
+    of h5py objects.
+    """
+    from .utils import is_ipython_initialized
+    if is_ipython_initialized():
+        from . import formatter
+        return formatter.load_ipython_extension()
+
+    raise RuntimeError('Formatter must be enabled in active ipython session')
+
+
+def enable_ipython(completer=True, formatter=True):
+    """ Call this from an interactive IPython session to enable multiple
+    convenience extensions for IPython.
+    """
+    if completer: enable_ipython_completer()
+    if formatter: enable_ipython_formatter()

--- a/h5py/_ipython/completer.py
+++ b/h5py/_ipython/completer.py
@@ -44,20 +44,11 @@ from __future__ import absolute_import
 import posixpath
 import re
 import readline
-from ._hl.attrs import AttributeManager
-from ._hl.base import HLObject
+from .utils import get_ipython
+from .._hl.attrs import AttributeManager
+from .._hl.base import HLObject
 
 
-try:
-    # >=ipython-1.0
-    from IPython import get_ipython
-except ImportError:
-    try:
-        # support >=ipython-0.11, <ipython-1.0
-        from IPython.core.ipapi import get as get_ipython
-    except ImportError:
-        # support <ipython-0.11
-        from IPython.ipapi import get as get_ipython
 try:
     # support >=ipython-0.11
     from IPython.utils import generics

--- a/h5py/_ipython/formatter.py
+++ b/h5py/_ipython/formatter.py
@@ -1,0 +1,78 @@
+#+
+#
+# This file is part of h5py, a low-level Python interface to the HDF5 library.
+#
+# Contributed by Anthony Wertz
+#
+# http://h5py.alfven.org
+# License: BSD  (See LICENSE.txt for full license)
+#
+#-
+
+# pylint: disable=eval-used,protected-access
+
+"""
+    This is the h5py formatter extension for ipython.  It is loaded by
+    calling the function h5py.enable_ipython_formatter() from within an
+    interactive IPython session.
+"""
+
+from __future__ import absolute_import
+
+import six
+import os
+from .utils import get_ipython
+
+
+def __pprint_KeysViewHDF5(obj, p, cycle):
+    p.text('\n'.join(["<KeysViewHDF5>:"] + ["  + " + key for key in list(obj)]))
+
+
+def __pprint_Group(obj, p, cycle):
+    if not obj:
+        r = u"<Closed HDF5 group>"
+    else:
+        namestr = (
+            u'"%s"' % obj.name
+        ) if obj.name is not None else u"(anonymous)"
+        r = u'<HDF5 group %s (%d members)>\n' % (namestr, len(obj))
+
+    if six.PY2:
+        r = r.encode('utf8')
+
+    p.text(r)
+    __pprint_KeysViewHDF5(obj.keys(), p, cycle)
+
+
+def __pprint_File(obj, p, cycle):
+    if not obj.id:
+        r = u'<Closed HDF5 file>'
+    else:
+        # Filename has to be forced to Unicode if it comes back bytes
+        # Mode is always a "native" string
+        filename = obj.filename
+        if isinstance(filename, bytes):  # Can't decode fname
+            filename = filename.decode('utf8', 'replace')
+        r = u'<HDF5 file "%s" (mode %s)>\n' % (os.path.basename(filename),
+                                                obj.mode)
+
+    if six.PY2:
+        r = r.encode('utf8')
+    
+    p.text(r)
+    __pprint_Group(obj, p, cycle)
+
+
+def load_ipython_extension(ip=None):
+    """ Load formatter function into IPython """
+    if ip is None:
+        ip = get_ipython()
+    
+    from .._hl.base import KeysViewHDF5
+    from .._hl.group import Group
+    from .._hl.files import File
+
+    text_formatter = ip.display_formatter.formatters['text/plain']
+    text_formatter.for_type(KeysViewHDF5, __pprint_KeysViewHDF5)
+    text_formatter.for_type(Group, __pprint_Group)
+    text_formatter.for_type(File, __pprint_File)

--- a/h5py/_ipython/utils.py
+++ b/h5py/_ipython/utils.py
@@ -1,0 +1,55 @@
+#+
+#
+# This file is part of h5py, a low-level Python interface to the HDF5 library.
+#
+# Contributed by Anthony Wertz
+#
+# http://h5py.alfven.org
+# License: BSD  (See LICENSE.txt for full license)
+#
+#-
+
+# pylint: disable=eval-used,protected-access
+
+"""
+    This provides a common set of functionality for interacting with IPython.
+"""
+
+from __future__ import absolute_import
+
+__get_ipython = None
+
+def get_ipython():
+    global __get_ipython
+    if __get_ipython is None:
+        try:
+            # >=ipython-1.0
+            from IPython import get_ipython as get_ipy
+        except ImportError:
+            try:
+                # support >=ipython-0.11, <ipython-1.0
+                from IPython.core.ipapi import get as get_ipy
+            except ImportError:
+                # support <ipython-0.11
+                from IPython.ipapi import get as get_ipy
+        __get_ipython = get_ipy
+    return __get_ipython()
+
+
+def is_ipython_initialized():
+    """ Determine whether or not an IPython interactive shell is initialized.
+    """
+    import sys
+    ip_running = False
+    if 'IPython' in sys.modules:
+        try:
+            from IPython.core.interactiveshell import InteractiveShell
+            ip_running = InteractiveShell.initialized()
+        except ImportError:
+            # support <ipython-0.11
+            from IPython import ipapi as _ipapi
+            ip_running = _ipapi.get() is not None
+        except Exception:
+            pass
+
+    return ip_running

--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,7 @@ setup(
   license = 'BSD',
   url = 'http://www.h5py.org',
   download_url = 'https://pypi.python.org/pypi/h5py',
-  packages = ['h5py', 'h5py._hl', 'h5py.tests',
+  packages = ['h5py', 'h5py._hl', 'h5py._ipython', 'h5py.tests',
               'h5py.tests.old', 'h5py.tests.hl',
               'h5py.tests.hl.test_vds'],
   package_data = package_data,


### PR DESCRIPTION
This commit attempts to enable pretty printing of some HDF5 objects.

An example of the changes in use:

```
In [1]: import h5py

In [2]: f = h5py.File('output.h5', 'r')

In [3]: f
Out[3]: <HDF5 file "output.h5" (mode r)>

In [4]: h5py.enable_ipython_formatter()

In [5]: f
Out[5]:
<HDF5 file "output.h5" (mode r)>
<HDF5 group "/" (2 members)>
<KeysViewHDF5>:
  + numeric
  + waveform

In [6]: f['waveform']
Out[6]:
<HDF5 group "/waveform" (9 members)>
<KeysViewHDF5>:
  + ECG.I
  + ECG.II
  + ECG.III
  + ECG.MCL
  + ECG.V
  + ECG.aVR
  + Pleth
  + PlethT
  + Resp
```

#566