### PR TITLE
Refuse to pickle high-level objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -157,7 +157,7 @@ matrix:
 
     - python: pypy
       env:
-      - TOXENV=pypy-test-deps
+      - TOXENV=pypy3-test-deps
   allow_failures:
     - python: pypy
     - python: 'nightly'

--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -307,6 +307,9 @@ class HLObject(CommonStateObject):
         """
         raise TypeError("h5py objects cannot be pickled")
 
+    def __getstate__(self):
+        # Pickle protocols 0 and 1 use this instead of __getnewargs__
+        raise TypeError("h5py objects cannot be pickled")
 
 # --- Dictionary-style interface ----------------------------------------------
 

--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -296,7 +296,16 @@ class HLObject(CommonStateObject):
     __nonzero__ = __bool__
 
     def __getnewargs__(self):
-        raise Exception("h5py objects cannot be pickled")
+        """Disable pickle.
+
+        Handles for HDF5 objects can't be reliably deserialised, because the
+        recipient may not have access to the same files. So we do this to
+        fail early.
+
+        If you really want to pickle h5py objects and can live with some
+        limitations, look at the h5pickle project on PyPI.
+        """
+        raise TypeError("h5py objects cannot be pickled")
 
 
 # --- Dictionary-style interface ----------------------------------------------

--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -295,6 +295,9 @@ class HLObject(CommonStateObject):
             return bool(self.id)
     __nonzero__ = __bool__
 
+    def __getnewargs__(self):
+        raise Exception("h5py objects cannot be pickled")
+
 
 # --- Dictionary-style interface ----------------------------------------------
 

--- a/h5py/tests/old/test_file.py
+++ b/h5py/tests/old/test_file.py
@@ -21,6 +21,8 @@ import tempfile
 
 import six
 
+from six.moves import cPickle
+
 from ..common import ut, TestCase, UNICODE_FILENAMES, closed_tempfile
 from h5py import File
 from h5py.h5py_warnings import H5pyDeprecationWarning
@@ -621,3 +623,10 @@ class TestPathlibSupport(TestCase):
             with File(f, 'w') as h5f2:
                 normal_name = h5f2.filename
             self.assertEqual(pathlib_name, normal_name)
+
+class TestPickle(TestCase):
+    """Check that h5py.File can't be pickled"""
+    def test_dump_error(self):
+        with File(self.mktemp(), 'w') as f1:
+            with self.assertRaises(TypeError):
+                cPickle.dumps(f1)

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 # We want an envlist like
-# envlist = {py27,py34,py35,py36,pypy}-{test}-{deps,mindeps}-{,mpi4py}-{,pre},nightly,docs,check-manifest,checkreadme
+# envlist = {py27,py34,py35,py36,py37,pypy3}-{test}-{deps,mindeps}-{,mpi4py}-{,pre},nightly,docs,check-manifest,checkreadme
 # but we want to skip mpi and pre by default, so this envlist is below
-envlist = {py27,py34,py35,py36,py37,pypy}-{test}-{deps,mindeps},nightly,docs,check-manifest,checkreadme
+envlist = {py27,py34,py35,py36,py37,pypy3}-{test}-{deps,mindeps},nightly,docs,check-manifest,checkreadme
 
 [testenv]
 deps =
@@ -30,7 +30,7 @@ setenv =
     COVERAGE_FILE={toxinidir}/.coverage
 # needed otherwise coverage cannot find the file when reporting
 basepython =
-    pypy: {env:TOXPYTHON:pypy}
+    pypy3: {env:TOXPYTHON:pypy3}
     py27: {env:TOXPYTHON:python2.7}
     py34: {env:TOXPYTHON:python3.4}
     py35: {env:TOXPYTHON:python3.5}


### PR DESCRIPTION
We can't unpickle these objects reliably, so it's better to fail early with a clear error.

Closes #531.