### PR TITLE
Edit error messages for external entries

### DIFF
--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -76,11 +76,11 @@ def _external_entry(name, offset=0, size=h5f.UNLIMITED):
     """ Check for and return a well-formed entry tuple for
     a call to h5p.set_external. """
     if not isinstance(name, six.string_types):
-        raise TypeError('external entry for offset must be a string')
+        raise TypeError("External entry's name must be a string")
     if not isinstance(offset, six.integer_types):
-        raise TypeError('external entry for offset must be an integer')
+        raise TypeError("External entry's offset must be an integer")
     if not isinstance(size, six.integer_types):
-        raise TypeError('external entry for size must be an integer')
+        raise TypeError("External entry's size must be an integer")
     return (filename_encode(name), offset, size)
 
 def _normalize_external(external):


### PR DESCRIPTION
* Corrected "offset" to "name" in the message for the `name` argument.
* Replaced "for" with the possessive for clarity.
* Capitalized for similarity to most messages in the package.