### PR TITLE
Don't mutate external argument while normalizing

### DIFF
--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -98,13 +98,10 @@ def _normalize_external(external):
     except TypeError:
         pass
     # check and rebuild each list entry to be well-formed
-    for idx, item in enumerate(external):
-        if isinstance(item, six.string_types):
-            item = _external_entry(item)
-        else:
-            item = _external_entry(*item)
-        external[idx] = item
-    return external
+    return [_external_entry(entry) 
+            if isinstance(entry, six.string_types) else 
+            _external_entry(*entry)
+            for entry in external]
 
 def fill_dcpl(plist, shape, dtype, chunks, compression, compression_opts,
               shuffle, fletcher32, maxshape, scaleoffset, external):

--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -98,8 +98,8 @@ def _normalize_external(external):
     except TypeError:
         pass
     # check and rebuild each list entry to be well-formed
-    return [_external_entry(entry) 
-            if isinstance(entry, six.string_types) else 
+    return [_external_entry(entry)
+            if isinstance(entry, six.string_types) else
             _external_entry(*entry)
             for entry in external]
 


### PR DESCRIPTION
Resolved an issue in which the `_hl.filters._normalize_external` function, when passed a list of iterables as its `external` argument, mutates the list. Because of that behavior, `_hl.filters.fill_dcpl`, `_hl.dataset.make_new_dset`, and `_hl.group.Group.create_dataset` mutate their `external` argument in that case.

The issue occurs in h5py v. 2.9.0 (from 733c048). The following code and output demonstrate it:

```python
import tempfile

import h5py

external = [('ext',)]
print(external)
with tempfile.TemporaryFile() as fobj:
    with h5py.File(fobj) as hfile:
        hfile.create_dataset('mutate', (4,), external=external)
print(external)
```

```
[('ext',)]
[(b'ext', 0, 18446744073709551615)]
```

The replacement code creates and returns a new list instead of mutating the passed list.