### PR TITLE
Add ds.make_scale() method.

### DIFF
--- a/docs/high/dims.rst
+++ b/docs/high/dims.rst
@@ -36,10 +36,10 @@ We can also use HDF5 datasets as dimension scales. For example, if we have::
 We are going to treat the ``x1``, ``x2``, ``y1``, and ``z1`` datasets as
 dimension scales::
 
-    f['data'].dims.create_scale(f['x1'])
-    f['data'].dims.create_scale(f['x2'], 'x2 name')
-    f['data'].dims.create_scale(f['y1'], 'y1 name')
-    f['data'].dims.create_scale(f['z1'], 'z1 name')
+    f['x1'].make_scale()
+    f['x2'].make_scale('x2 name')
+    f['y1'].make_scale('y1 name')
+    f['z1'].make_scale('z1 name')
 
 When you create a dimension scale, you may provide a name for that scale. In
 this case, the ``x1`` scale was not given a name, but the others were. Now we

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -24,7 +24,7 @@ from six.moves import xrange    # pylint: disable=redefined-builtin
 
 import numpy
 
-from .. import h5, h5s, h5t, h5r, h5d, h5p, h5fd
+from .. import h5, h5s, h5t, h5r, h5d, h5p, h5fd, h5ds
 from .base import HLObject, phil, with_phil, Empty, is_empty_dataspace
 from . import filters
 from . import selections as sel
@@ -828,3 +828,15 @@ class Dataset(HLObject):
                        dcpl.get_virtual_dsetname(j),
                        dcpl.get_virtual_srcspace(j))
                 for j in range(dcpl.get_virtual_count())]
+
+    @with_phil
+    def make_scale(self, name=''):
+        """Make this dataset an HDF5 dimension scale.
+
+        You can then attach it to dimensions of other datasets like this::
+
+            other_ds.dims[0].attach_scale(ds)
+
+        You can optionally pass a name to associate with this scale.
+        """
+        h5ds.set_scale(self._id, self._e(name))

--- a/h5py/_hl/dims.py
+++ b/h5py/_hl/dims.py
@@ -12,8 +12,10 @@
 """
 
 from __future__ import absolute_import
+import warnings
 
 from .. import h5ds
+from ..h5py_warnings import H5pyDeprecationWarning
 from . import base
 from .base import phil, with_phil
 from .dataset import Dataset
@@ -180,5 +182,8 @@ class DimensionManager(base.MappingHDF5, base.CommonStateObject):
 
         Provide the dataset and a name for the scale.
         """
-        with phil:
-            h5ds.set_scale(dset.id, self._e(name))
+        warnings.warn("other_ds.dims.create_scale(ds, name) is deprecated. "
+                      "Use ds.make_scale(name) instead.",
+                      H5pyDeprecationWarning, stacklevel=2,
+                     )
+        dset.make_scale(name)

--- a/h5py/tests/old/test_dimension_scales.py
+++ b/h5py/tests/old/test_dimension_scales.py
@@ -108,12 +108,12 @@ class TestH5DSBindings(BaseDataset):
 
 class TestDimensionManager(BaseDataset):
 
-    def test_create_scale(self):
+    def test_make_scale(self):
         # test recreating or renaming an existing scale:
-        self.f['data'].dims.create_scale(self.f['x1'], b'foobar')
+        self.f['x1'].make_scale(b'foobar')
         self.assertEqual(self.f['data'].dims[2]['foobar'], self.f['x1'])
         # test creating entirely new scale:
-        self.f['data'].dims.create_scale(self.f['data2'], b'foobaz')
+        self.f['data2'].make_scale(b'foobaz')
         self.f['data'].dims[2].attach_scale(self.f['data2'])
         self.assertEqual(self.f['data'].dims[2]['foobaz'], self.f['data2'])
 


### PR DESCRIPTION
Replaces `other_ds.dims.create_scale(ds)`, which is deprecated here.

Making `ds` into a dimension scale doesn't affect or use the dimensions of `other_ds` at all, so it's confusing to expose the functionality through `other_ds.dims`.

Closes gh-830