### PR TITLE
ENH: Add custom tab completions for IPython.

### DIFF
--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -416,6 +416,14 @@ class MappingHDF5(Mapping):
             """ Get a view object on member items """
             return ItemsViewHDF5(self)
 
+    def _ipython_key_completions_(self):
+        """ Custom tab completions for __getitem__ in IPython >=5.0. """
+        keys = self.keys()
+        # keys() is lazy in Python 3.
+        if not isinstance(keys, list):
+            keys = list(keys)
+        return keys
+
 
 class MutableMappingHDF5(MappingHDF5, MutableMapping):
 

--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -418,11 +418,7 @@ class MappingHDF5(Mapping):
 
     def _ipython_key_completions_(self):
         """ Custom tab completions for __getitem__ in IPython >=5.0. """
-        keys = self.keys()
-        # keys() is lazy in Python 3.
-        if not isinstance(keys, list):
-            keys = list(keys)
-        return keys
+        return sorted(self.keys())
 
 
 class MutableMappingHDF5(MappingHDF5, MutableMapping):

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -576,13 +576,6 @@ class Group(HLObject, MutableMappingHDF5):
             return r.encode('utf8')
         return r
 
-    def _ipython_key_completions_(self):
-        """ Custom tab completions for __getitem__ in IPython >=5.0."""
-        keys = self.keys()
-        # keys() is lazy in Python 2.
-        if not isinstance(keys, list):
-            return list(keys)
-
 
 class HardLink(object):
 

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -576,6 +576,13 @@ class Group(HLObject, MutableMappingHDF5):
             return r.encode('utf8')
         return r
 
+    def _ipython_key_completions_(self):
+        """ Custom tab completions for __getitem__ in IPython >=5.0."""
+        keys = self.keys()
+        # keys() is lazy in Python 2.
+        if not isinstance(keys, list):
+            return list(keys)
+
 
 class HardLink(object):
 

--- a/h5py/tests/hl/test_completions.py
+++ b/h5py/tests/hl/test_completions.py
@@ -1,0 +1,52 @@
+from ..common import TestCase
+
+
+class TestCompletions(TestCase):
+
+    def test_group_completions(self):
+        # Test completions on top-level file.
+        g = self.f.create_group('g')
+        self.f.create_group('h')
+        self.f.create_dataset('data', [1, 2, 3])
+        self.assertEqual(
+            self.f._ipython_key_completions_(),
+            [u'data', u'g', u'h'],
+        )
+
+        self.f.create_group('data2', [1, 2, 3])
+        self.assertEqual(
+            self.f._ipython_key_completions_(),
+            [u'data', u'data2', u'g', u'h'],
+        )
+
+        # Test on subgroup.
+        g.create_dataset('g_data1', [1, 2, 3])
+        g.create_dataset('g_data2', [4, 5, 6])
+        self.assertEqual(
+            g._ipython_key_completions_(),
+            [u'g_data1', u'g_data2'],
+        )
+
+        g.create_dataset('g_data3', [7, 8, 9])
+        self.assertEqual(
+            g._ipython_key_completions_(),
+            [u'g_data1', u'g_data2', u'g_data3'],
+        )
+
+    def test_attrs_completions(self):
+        attrs = self.f.attrs
+
+        # Write out of alphabetical order to test that completions come back in
+        # alphabetical order, as opposed to, say, insertion order.
+        attrs['b'] = 1
+        attrs['a'] = 2
+        self.assertEqual(
+            attrs._ipython_key_completions_(),
+            [u'a', u'b']
+        )
+
+        attrs['c'] = 3
+        self.assertEqual(
+            attrs._ipython_key_completions_(),
+            [u'a', u'b', u'c']
+        )


### PR DESCRIPTION
I often explore hdf5 files interactively in IPython using h5py. Defining [`_ipython_key_completions_`](https://ipython.readthedocs.io/en/stable/config/integrating.html) on `Group` allows IPython to generate tab completions for `__getitem__` lookups on groups.

Assuming this is of interest to others, one question I have is whether this belongs here or on `MappingHDF5`, which is where `keys` is actually defined. The other consumers of MappingHDF5 are DimensionManager and AttributeManager. AttributeManager seems like it would benefit from this. I'm not sure about DimensionManager (I don't think I've interacted with `.dims`).