### PR TITLE
Require pkg-config on Unix platforms

### DIFF
--- a/docs/build.rst
+++ b/docs/build.rst
@@ -83,6 +83,9 @@ To install h5py from source, you need three things installed:
 * HDF5 1.8.4 or newer with development headers
 * A C compiler
 
+On Unix platforms, you also need ``pkg-config`` unless you explicitly specify
+a path for HDF5 as described in :ref:`custom_install`.
+
 OS-specific instructions for installing HDF5, Python and a C compiler are in the next few
 sections.
 

--- a/setup_build.py
+++ b/setup_build.py
@@ -94,7 +94,10 @@ class h5py_build_ext(build_ext):
                     settings['library_dirs'].extend(pkgcfg['library_dirs'])
                     settings['define_macros'].extend(pkgcfg['define_macros'])
             except EnvironmentError:
-                pass
+                if os.name != 'nt':
+                    print("h5py requires pkg-config unless the HDF5 path is explicitly specified",
+                          file=sys.stderr)
+                    raise
             settings['include_dirs'].extend(FALLBACK_PATHS['include_dirs'])
             settings['library_dirs'].extend(FALLBACK_PATHS['library_dirs'])
 

--- a/setup_build.py
+++ b/setup_build.py
@@ -5,6 +5,8 @@
     linking.
 """
 
+from __future__ import print_function
+
 try:
     from setuptools import Extension
 except ImportError:


### PR DESCRIPTION
We currently require the Python [pkgconfig](https://pypi.org/project/pkgconfig/) wrapper for building from source, but try to fall back to default locations if the underlying `pkg-config` command is not found. But this has caused some confusion (#1181) when the default locations aren't right.

This PR would make the `pkg-config` command required on Unix systems, unless you explicitly specify the path to an HDF5 installation. So rather than failing because it's trying to use an incorrect path, leaving you trying to figure out how to solve that, it should fail with an error that `pkg-config` is missing, which has a more obvious resolution.

The drawback is that in some cases, using the default fallback paths presumably does work. This would break these, requiring the user to install `pkg-config` and the necessary `.pc` file for hdf5. I don't know how common these cases are, or how difficult it might be to resolve them.

Closes gh-1181