### PR TITLE
Add Whatsnew for 2.10, some other docs improvements

### DIFF
--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -426,6 +426,14 @@ Reference
 
        You can optionally pass a name to associate with this scale.
 
+    .. method:: virtual_sources
+
+       If this dataset is a :doc:`virtual dataset </vds>`, return a list of
+       named tuples: ``(vspace, file_name, dset_name, src_space)``,
+       describing which parts of the dataset map to which source datasets.
+       The two 'space' members are low-level
+       :class:`SpaceID <low:h5py.h5s.SpaceID>` objects.
+
     .. attribute:: shape
 
         NumPy-style shape tuple giving dataset dimensions.
@@ -483,6 +491,10 @@ Reference
        If this dataset is stored in one or more external files, this is a list
        of 3-tuples, like the ``external=`` parameter to
        :meth:`Group.create_dataset`. Otherwise, it is ``None``.
+
+    .. attribute:: is_virtual
+
+       True if this dataset is a :doc:`virtual dataset </vds>`, otherwise False.
 
     .. attribute:: dims
 

--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -416,6 +416,16 @@ Reference
 
         Return the size of the first axis.
 
+    .. method:: make_scale(name='')
+
+       Make this dataset an HDF5 :ref:`dimension scale <dimension_scales>`.
+
+       You can then attach it to dimensions of other datasets like this::
+
+           other_ds.dims[0].attach_scale(ds)
+
+       You can optionally pass a name to associate with this scale.
+
     .. attribute:: shape
 
         NumPy-style shape tuple giving dataset dimensions.

--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -478,6 +478,12 @@ Reference
         type-appropriate default value.  Can't be changed after the dataset is
         created.
 
+    .. attribute:: external
+
+       If this dataset is stored in one or more external files, this is a list
+       of 3-tuples, like the ``external=`` parameter to
+       :meth:`Group.create_dataset`. Otherwise, it is ``None``.
+
     .. attribute:: dims
 
         Access to :ref:`dimension_scales`.

--- a/docs/high/group.rst
+++ b/docs/high/group.rst
@@ -369,6 +369,11 @@ Reference
                         ``True``.  Default is
                         ``h5.get_config().track_order``.
 
+        :keyword external: Store the dataset in one or more external, non-HDF5
+            files. This should be a list of tuples of
+            ``(filename[, offset[, size]])``, to store data from ``offset`` to
+            ``offset + size`` in the specified file. The last file in the list
+            may have size ``h5py.h5s.UNLIMITED`` to let it grow as needed.
 
     .. method:: require_dataset(name, shape=None, dtype=None, exact=None, **kwds)
 

--- a/docs/high/group.rst
+++ b/docs/high/group.rst
@@ -408,6 +408,18 @@ Reference
         shape and dtype, in which case the provided values take precedence over
         those from `other`.
 
+    .. method:: create_virtual_dataset(name, layout, fillvalue=None)
+
+       Create a new virtual dataset in this group. See :doc:`/vds` for more
+       details.
+
+       :param str name:
+           Name of the dataset (absolute or relative).
+       :param VirtualLayout layout:
+           Defines what source data fills which parts of the virtual dataset.
+       :param fillvalue:
+           The value to use where there is no data.
+
     .. attribute:: attrs
 
         :ref:`attributes` for this group.

--- a/docs/vds.rst
+++ b/docs/vds.rst
@@ -36,14 +36,15 @@ Creating virtual datasets in h5py
 
 To make a virtual dataset using h5py, you need to:
 
-1. Create a ``VirtualLayout`` object representing the dimensions and data type
+1. Create a :class:`VirtualLayout` object representing the dimensions and data type
    of the virtual dataset.
-2. Create a number of ``VirtualSource`` objects, representing the datasets the
-   array will be built from. ``VirtualSource`` objects can be created either
+2. Create a number of :class:`VirtualSource` objects, representing the datasets
+   the array will be built from. These objects can be created either
    from an h5py :class:`Dataset`, or from a filename, dataset name and shape.
-   This can be done even before the file exists.
+   This can be done even before the source file exists.
 3. Map slices from the sources into the layout.
-4. Convert the ``VirtualLayout`` object into a virtual dataset in an HDF5 file.
+4. Convert the :class:`VirtualLayout` object into a virtual dataset in an HDF5
+   file.
 
 The following snippet creates a virtual dataset to stack
 together four 1D datasets from separate files into a 2D dataset::
@@ -79,3 +80,44 @@ found in the examples folder:
   - `dual_pco_edge.py <https://github.com/h5py/h5py/blob/master/examples/dual_pco_edge.py>`_
   - `eiger_use_case.py <https://github.com/h5py/h5py/blob/master/examples/eiger_use_case.py>`_
   - `percival_use_case.py <https://github.com/h5py/h5py/blob/master/examples/percival_use_case.py>`_
+
+Reference
+---------
+
+.. class:: VirtualLayout(shape, dtype=None, maxshape=None)
+
+   Object for building a virtual dataset.
+
+   Instantiate this class to define a virtual dataset, assign
+   :class:`VirtualSource` objects to slices of it, and then pass it to
+   :meth:`Group.create_virtual_dataset` to add the virtual dataset to a file.
+
+   This class does not allow access to the data; the virtual dataset must
+   be created in a file before it can be used.
+
+   :param tuple shape: The full shape of the virtual dataset.
+   :param dtype: Numpy dtype or string.
+   :param tuple maxshape: The virtual dataset is resizable up to this shape.
+     Use None for axes you want to be unlimited.
+
+.. class:: VirtualSource(path_or_dataset, name=None, shape=None, dtype=None, \
+                         maxshape=None)
+
+   Source definition for virtual data sets.
+
+   Instantiate this class to represent an entire source dataset, and then
+   slice it to indicate which regions should be used in the virtual dataset.
+
+   :param path_or_dataset:
+       The path to a file, or a :class:`Dataset` object. If a dataset is given,
+       no other parameters are allowed, as the relevant values are taken from
+       the dataset instead.
+   :param str name:
+       The name of the source dataset within the file.
+   :param tuple shape:
+       The full shape of the source dataset.
+   :param dtype:
+       Numpy dtype or string.
+   :param tuple maxshape:
+       The source dataset is resizable up to this shape. Use None for
+       axes you want to be unlimited.

--- a/docs/whatsnew/2.10.rst
+++ b/docs/whatsnew/2.10.rst
@@ -1,0 +1,83 @@
+What's new in h5py 2.10
+=======================
+
+New features
+------------
+
+- HDF5 8-bit bitfield data can now be read either as uint8 or booleans
+  (:issue:`821`). Pytables stores booleans as this type.
+  For now, you must pick which type to use explicitly::
+
+      with dset.astype(numpy.uint8):   # or numpy.bool
+          arr = dset[:]
+
+- Numpy arrays of integers can now be used for fancy indexing, where previously
+  a Python list was required (:issue:`963`).
+- Fancy indexing now allows an empty list or array (:issue:`1174`).
+- New functions and constants for getting and identifying :ref:`special data
+  types <special_types>` - :func:`string_dtype`, :func:`vlen_dtype`,
+  :func:`enum_dtype`, ``ref_dtype`` and ``regionref_dtype`` replace
+  :func:`special_dtype`. For identifying string, vlen and enum dtypes,
+  :func:`check_string_dtype`, :func:`check_vlen_dtype` and
+  :func:`check_enum_dtype` replace :func:`check_dtype` (:issue:`1132`).
+- A new method :meth:`~.Dataset.make_scale` to conveniently make a dataset into
+  a :ref:`dimension scale <dimension_scales>` (:issue:`830`, :issue:`1212`).
+- Several examples were updated to run on Python 3 (:issue:`1149`).
+
+Deprecations
+------------
+
+- The default behaviour of ``h5py.File`` with no specified mode is deprecated
+  (:issue:`1143`).
+  It currently tries to create a file or open it for read/write access,
+  silently falling back to read-only depending on permissions. From h5py 3.0,
+  the default will be read-only.
+
+  Ideally, code should pass an explicit mode each time a file is opened.
+  If that is not practical, and you want to suppress the deprecation warnings,
+  you can either:
+
+   - set ``h5.get_config().default_file_mode = 'r'`` (or another available mode)
+   - or set the environment variable ``H5PY_DEFAULT_READONLY`` to any non-empty
+     string, to adopt the future default.
+
+- This is expected to be the last h5py release to support Python 2.7 and 3.4.
+
+Exposing HDF5 functions
+-----------------------
+
+
+Bugfixes
+--------
+
+- Fixed random selection of data type when reading 64-bit floats on Windows
+  where Python uses random dictionary order (:issue:`1051`, :issue:`1134`).
+- Pickling h5py objects now fails explicitly. It previously failed on
+  unpickling, and we can't reliably serialise and restore handles to HDF5
+  objects anyway (:issue:`531`, :issue:`1194`). If you need to use these objects
+  in other processes, you could explicitly serialise the filename and the name
+  of the object inside the file. Or consider `h5pickle
+  <https://github.com/Exteris/h5pickle/>`_, which does the same implicitly.
+- Creating a dataset with external storage can no longer mutate the ``external``
+  list parameter passed in (:issue:`1205`). It also has improved error messages
+  (:issue:`1204`).
+- Certain deprecation warnings will now show the relevant line of code which
+  uses the deprecated feature (:issue:`1146`).
+
+Building h5py
+-------------
+
+- The version of HDF5 can now be automatically detected on Windows
+  (:issue:`1123`).
+- Building h5py from source on Unix platforms now requires either ``pkg-config``
+  or an explicitly specified path to HDF5 (:issue:`1231`).
+  Previously it had a hardcoded default path, but when this was wrong,
+  the failures were unnecessarily confusing.
+- The Cython 'language level' is now explicitly set to 2, to prepare h5py
+  for changing defaults in Cython (:issue:`1171`).
+
+Development
+-----------
+
+h5py's tests are now run by pytest (:issue:`1003`), and coverage reports are
+automatically generated `on Codecov <https://codecov.io/gh/h5py/h5py>`_.

--- a/docs/whatsnew/index.rst
+++ b/docs/whatsnew/index.rst
@@ -8,6 +8,7 @@ These document the changes between minor (or major) versions of h5py.
 
 .. toctree::
 
+    2.10
     2.9
     2.8
     2.7.1

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -143,14 +143,16 @@ class Group(HLObject, MutableMappingHDF5):
         def create_virtual_dataset(self, name, layout, fillvalue=None):
             """Create a new virtual dataset in this group.
 
-            Creates the virtual dataset from a list of virtual maps, any
-            gaps are filled with a specified fill value.
+            See virtual datasets in the docs for more information.
 
             name
                 (str) Name of the new dataset
 
-            virtual_target
-                Defines the sources for the virtual dataset
+            layout
+                (VirtualLayout) Defines the sources for the virtual dataset
+
+            fillvalue
+                The value to use where there is no data.
 
             """
             from .vds import VDSmap

--- a/h5py/_hl/vds.py
+++ b/h5py/_hl/vds.py
@@ -39,7 +39,7 @@ class VirtualSource(object):
 
     path_or_dataset
         The path to a file, or an h5py dataset. If a dataset is given,
-        the other parameters are ignored, and the relevant values taken from
+        no other parameters are allowed, as the relevant values are taken from
         the dataset instead.
     name
         The name of the source dataset within the file.
@@ -113,7 +113,7 @@ class VirtualLayout(object):
     dtype
         Numpy dtype or string.
     maxshape
-        The source dataset is resizable up to this shape. Use None for
+        The virtual dataset is resizable up to this shape. Use None for
         axes you want to be unlimited.
     """
     def __init__(self, shape, dtype=None, maxshape=None):


### PR DESCRIPTION
I started writing up the release notes for 2.10 based on [closed issues and merged PRs](https://github.com/h5py/h5py/milestone/16?closed=1). Then I remembered that I'd noticed a couple of things missing from the reference documentation, and added them, and went down a bit of a rabbit hole.