### PR TITLE
DOC: Add warning that h5py not does support nested compound types

### DIFF
--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -256,6 +256,10 @@ Broadcasting is implemented using repeated hyperslab selections, and is
 safe to use with very large target selections.  It is supported for the above
 "simple" (integer, slice and ellipsis) slicing only.
 
+.. warning::
+   Currently h5py does not support nested compound types, see :issue:`1197` for
+   more information.
+
 
 .. _dataset_fancy:
 


### PR DESCRIPTION
This adds a warning to the docs that nested compound types are not supported (see #1197, but this isn't an actual fix for that).