### PR TITLE
Build & configure cleanups, extra info

### DIFF
--- a/setup_build.py
+++ b/setup_build.py
@@ -16,12 +16,11 @@ import sys
 import os
 import os.path as op
 import subprocess
-from functools import reduce
 import api_gen
 
 
 def localpath(*args):
-    return op.abspath(reduce(op.join, (op.dirname(__file__),)+args))
+    return op.abspath(op.join(op.dirname(__file__), *args))
 
 
 MODULES =  ['defs','_errors','_objects','_proxy', 'h5fd', 'h5z',

--- a/setup_configure.py
+++ b/setup_configure.py
@@ -238,6 +238,8 @@ def autodetect_version(hdf5_dir=None):
     if path is None:
         path = "libhdf5.so"
 
+    print("Loading library to get version:", path)
+
     lib = ctypes.cdll.LoadLibrary(path)
 
     major = ctypes.c_uint()

--- a/setup_configure.py
+++ b/setup_configure.py
@@ -193,10 +193,6 @@ def autodetect_version(hdf5_dir=None):
 
     hdf5_dir: optional HDF5 install directory to look in (containing "lib")
     """
-
-    import os
-    import sys
-    import os.path as op
     import re
     import ctypes
     from ctypes import byref


### PR DESCRIPTION
I think it would be useful for debugging build issues (e.g. #1237) to know what library path it tries to load to autodetect the version number.

I also spotted a couple of minor cleanups, which shouldn't make any material difference.