### PR TITLE
Don't catch exceptions when trying to autodetect HDF5 version in build

### DIFF
--- a/setup_configure.py
+++ b/setup_configure.py
@@ -157,12 +157,8 @@ class configure(Command):
         if self.hdf5_version is None:
             self.hdf5_version = oldsettings.get('env_hdf5_version')
         if self.hdf5_version is None:
-            try:
-                self.hdf5_version = autodetect_version(self.hdf5)
-                print("Autodetected HDF5 %s" % self.hdf5_version)
-            except Exception as e:
-                sys.stderr.write("Autodetection skipped [%s]\n" % e)
-                self.hdf5_version = '1.8.4'
+            self.hdf5_version = autodetect_version(self.hdf5)
+            print("Autodetected HDF5 %s" % self.hdf5_version)
 
         if self.mpi is None:
             self.mpi = oldsettings.get('cmd_mpi')


### PR DESCRIPTION
If it can't find libhdf5, or can't get the version, let the build bail out rather than trying to continue.

This is part of a general move to make builds fail fast. Before wheels & conda were in widespread use, many more people would have had to install h5py from source, so there was probably more pressure for the build system to smooth over corner cases and try to build anyway. Now that people who just want the package installed can mostly get pre-built binaries, it's probably better to do less guesswork and error out if there are things the build system can't work out.