### PR TITLE
Move check for HDF5 build & runtime versions earlier

### DIFF
--- a/h5py/__init__.py
+++ b/h5py/__init__.py
@@ -31,6 +31,16 @@ except ImportError:
     else:
         raise
 
+from . import version
+
+if version.hdf5_version_tuple != version.hdf5_built_version_tuple:
+    _warn(("h5py is running against HDF5 {0} when it was built against {1}, "
+           "this may cause problems").format(
+            '{0}.{1}.{2}'.format(*version.hdf5_version_tuple),
+            '{0}.{1}.{2}'.format(*version.hdf5_built_version_tuple)
+    ))
+
+
 _errors.silence_errors()
 
 from ._conv import register_converters as _register_converters
@@ -64,19 +74,11 @@ from .h5t import (special_dtype, check_dtype,
     check_vlen_dtype, check_string_dtype, check_enum_dtype, check_ref_dtype,
 )
 
-from . import version
 from .version import version as __version__
 
 
 if version.hdf5_version_tuple[:3] >= get_config().vds_min_hdf5_version:
     from ._hl.vds import VirtualSource, VirtualLayout
-
-if version.hdf5_version_tuple != version.hdf5_built_version_tuple:
-    _warn(("h5py is running against HDF5 {0} when it was built against {1}, "
-           "this may cause problems").format(
-            '{0}.{1}.{2}'.format(*version.hdf5_version_tuple),
-            '{0}.{1}.{2}'.format(*version.hdf5_built_version_tuple)
-    ))
 
 
 def run_tests(args=''):


### PR DESCRIPTION
If the HDF5 version we're loaded against does not match the version we were built against, we can get errors loading various submodules, as it e.g. tries to load symbols that aren't there.

We have a check to warn about this, but if there's an error before execution gets to it, the warning can't be shown. So this moves it nearer the start of the module, where it will hopefully show an informative error message in more cases.

From discussion on #1237.