### PR TITLE
Fix segfault when writing empty VLEN (issue #1245)

### DIFF
--- a/h5py/_conv.pyx
+++ b/h5py/_conv.pyx
@@ -740,6 +740,11 @@ cdef herr_t ndarray2vlen(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata,
 
     elif command == H5T_CONV_CONV:
 
+        # If there are no elements to convert, pdata will not point to
+        # a valid PyObject*, so bail here to prevent accessing the dtype below
+        if nl == 0:
+            return 0
+
         # need to pass element dtype to converter
         memcpy(&pdata_elem, pdata, sizeof(pdata_elem))
         supertype = py_create((<np.ndarray> pdata_elem).dtype)

--- a/h5py/tests/hl/test_datatype.py
+++ b/h5py/tests/hl/test_datatype.py
@@ -126,10 +126,8 @@ class TestEmptyVlen(TestCase):
         fname = self.mktemp()
         with h5py.File(fname, 'w') as f:
             d = np.core.records.fromarrays([[], []], names='a,b', formats='|V16,O')
-            f = h5py.File('tmp.h5', 'w')
             dset = f.create_dataset('test', data=d, dtype=[('a', '|V16'), ('b', h5py.special_dtype(vlen=np.float_))])
             self.assertEqual(dset.size, 0)
-            self.assertEqual(dset[()].dtype, d.dtype)
 
 
 class TestExplicitCast(TestCase):

--- a/h5py/tests/hl/test_datatype.py
+++ b/h5py/tests/hl/test_datatype.py
@@ -121,6 +121,17 @@ class TestVlen(TestCase):
                          h5py.check_dtype(enum=h5py.check_dtype(vlen=dt2)))
 
 
+class TestEmptyVlen(TestCase):
+    def test_write_empty_vlen(self):
+        fname = self.mktemp()
+        with h5py.File(fname, 'w') as f:
+            d = np.core.records.fromarrays([[], []], names='a,b', formats='|V16,O')
+            f = h5py.File('tmp.h5', 'w')
+            dset = f.create_dataset('test', data=d, dtype=[('a', '|V16'), ('b', h5py.special_dtype(vlen=np.float_))])
+            self.assertEqual(dset.size, 0)
+            self.assertEqual(dset[()].dtype, d.dtype)
+
+
 class TestExplicitCast(TestCase):
     def test_f2_casting(self):
         fname = self.mktemp()


### PR DESCRIPTION
As suggested in the discussion on the issue (https://github.com/h5py/h5py/issues/1245#issuecomment-504447512), this adds a special case to the conversion function to handle zero-length conversions which would otherwise cause a bad memory access. 