### PR TITLE
Use mpirun when testing MPI

### DIFF
--- a/h5py/tests/test_filters.py
+++ b/h5py/tests/test_filters.py
@@ -13,6 +13,7 @@
 """
 import numpy as np
 import h5py
+import pytest
 
 from .common import ut, TestCase, insubprocess
 
@@ -78,6 +79,7 @@ def test_filter_ref_obj(writable_file):
     assert ds.compression_opts == 8
 
 
+@pytest.mark.mpi_skip
 @insubprocess
 def test_unregister_filter(request):
     if h5py.h5z.filter_avail(h5py.h5z.FILTER_LZF):

--- a/h5py/tests/test_h5pl.py
+++ b/h5py/tests/test_h5pl.py
@@ -20,6 +20,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+@pytest.mark.mpi_skip
 @insubprocess
 @subproc_env({'HDF5_PLUGIN_PATH': 'h5py_plugin_test'})
 def test_default(request):
@@ -27,6 +28,7 @@ def test_default(request):
     assert h5pl.get(0) == b'h5py_plugin_test'
 
 
+@pytest.mark.mpi_skip
 @insubprocess
 @subproc_env({'HDF5_PLUGIN_PATH': 'h5py_plugin_test'})
 def test_append(request):
@@ -36,6 +38,7 @@ def test_append(request):
     assert h5pl.get(1) == b'/opt/hdf5/vendor-plugin'
 
 
+@pytest.mark.mpi_skip
 @insubprocess
 @subproc_env({'HDF5_PLUGIN_PATH': 'h5py_plugin_test'})
 def test_prepend(request):
@@ -45,6 +48,7 @@ def test_prepend(request):
     assert h5pl.get(1) == b'h5py_plugin_test'
 
 
+@pytest.mark.mpi_skip
 @insubprocess
 @subproc_env({'HDF5_PLUGIN_PATH': 'h5py_plugin_test'})
 def test_insert(request):
@@ -54,6 +58,7 @@ def test_insert(request):
     assert h5pl.get(1) == b'h5py_plugin_test'
 
 
+@pytest.mark.mpi_skip
 @insubprocess
 @subproc_env({'HDF5_PLUGIN_PATH': 'h5py_plugin_test'})
 def test_replace(request):
@@ -62,6 +67,7 @@ def test_replace(request):
     assert  h5pl.get(0) == b'/opt/hdf5/vendor-plugin'
 
 
+@pytest.mark.mpi_skip
 @insubprocess
 def test_remove(request):
     h5pl.remove(0)

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ commands =
     test: python -c "import sys; print('64 bit?', sys.maxsize > 2**32)"
     test: python {toxinidir}/ci/fix_paths.py
     test-!mpi4py: python -m pytest --pyargs h5py --cov=h5py -rxXs --cov-config={toxinidir}/.coveragerc {posargs}
-    test-mpi4py: mpirun -n {env:MPI_N_PROCS:2} {envpython} -m pytest --pyargs h5py --cov=h5py -rxXs --cov-config={toxinidir}/.coveragerc --with-mpi {posargs}
+    test-mpi4py: mpirun -n {env:MPI_N_PROCS:2} {envpython} -m pytest --pyargs h5py -rxXs --with-mpi {posargs}
 changedir =
     test: {toxworkdir}
 passenv =

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist = {py36,py37,pypy3}-{test}-{deps,mindeps},nightly,docs,apidocs,checkread
 deps =
     test: pytest
     test: pytest-cov
+    test: pytest-mpi>=0.2
 
     py36-deps: cython>=0.23
     py37-deps: cython>=0.29
@@ -26,14 +27,22 @@ deps =
     tables-deps: tables>=3.4.4
     tables-mindeps: tables==3.4.4
 
+# see pytest.ini for additional common options to pytest
 commands =
     test: python -c "import sys; print('64 bit?', sys.maxsize > 2**32)"
     test: python {toxinidir}/ci/fix_paths.py
-    test: python -m pytest --pyargs h5py --cov=h5py --cov-config={toxinidir}/.coveragerc {posargs}
+    test-!mpi4py: python -m pytest --pyargs h5py --cov=h5py -rxXs --cov-config={toxinidir}/.coveragerc {posargs}
+    test-mpi4py: mpirun -n {env:MPI_N_PROCS:2} {envpython} -m pytest --pyargs h5py --cov=h5py -rxXs --cov-config={toxinidir}/.coveragerc --with-mpi {posargs}
 changedir =
     test: {toxworkdir}
 passenv =
     HDF5_DIR
+    HDF5_MPI
+    MPI_N_PROCS
+    OMPI_* # used to configure OpenMPI
+    CC
+whitelist_externals =
+    mpirun
 setenv =
     COVERAGE_FILE={toxinidir}/.coverage_dir/coverage-{envname}
 # needed otherwise coverage cannot find the file when reporting


### PR DESCRIPTION
This provides more freedom to specify HDF5 locations (which I needed for testing the MPI builds), and runs the tests under MPI (apart from those known to not work, e.g. those using subprocess). I fixed the existing MPI tests, and added some docs about how to test with MPI.

This depends on https://pypi.org/project/pytest-mpi/, which I created because it seems that the `conftest.py` must the at the root level for cli args to work (see https://stackoverflow.com/questions/52447767/using-pytest-addoptions-in-a-non-root-conftest-py), I'm happy to move it under the h5py org and/or give people access (on github, pypi and other services) if people think that's appropriate (I plan on adding docs and tests, happy to restructure it also, I basically used an existing pytest plugin I wrote as a template).

Before this gets merged, can people run this on their systems (and if report any lockups, the tests should run very fast, so if you're waiting a while, there's probably a problem).

#1206 will need to be rebased on this (let me know if there are more features we should expose with pytest-mpi).