### PR TITLE
Expose H5PL low-level API

### DIFF
--- a/docs_api/h5pl.rst
+++ b/docs_api/h5pl.rst
@@ -1,0 +1,5 @@
+Module H5PL
+===========
+
+.. automodule:: h5py.h5pl
+    :members:

--- a/docs_api/index.rst
+++ b/docs_api/index.rst
@@ -35,6 +35,7 @@ Contents
     h5l
     h5o
     h5p
+    h5pl
     h5r
     h5s
     h5t

--- a/h5py/__init__.py
+++ b/h5py/__init__.py
@@ -52,7 +52,7 @@ _register_lzf()
 
 # --- Public API --------------------------------------------------------------
 
-from . import h5a, h5d, h5ds, h5f, h5fd, h5g, h5r, h5s, h5t, h5p, h5z
+from . import h5a, h5d, h5ds, h5f, h5fd, h5g, h5r, h5s, h5t, h5p, h5z, h5pl
 
 from ._hl import filters
 from ._hl.base import is_hdf5, HLObject, Empty

--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -391,7 +391,17 @@ hdf5:
   MPI herr_t H5Pset_fapl_mpio(hid_t fapl_id, MPI_Comm comm, MPI_Info info)
   MPI herr_t H5Pget_fapl_mpio(hid_t fapl_id, MPI_Comm *comm, MPI_Info *info)
 
-  # === H5R - Reference API ===================================================
+  # === H5PL - Plugin Interface ===================================================
+
+  1.10.1 herr_t H5PLappend(const char *search_path);
+  1.10.1 herr_t H5PLprepend(const char *search_path);
+  1.10.1 herr_t H5PLreplace(const char *search_path, unsigned int index);
+  1.10.1 herr_t H5PLinsert(const char *search_path, unsigned int index);
+  1.10.1 herr_t H5PLremove(unsigned int index);
+  1.10.1 ssize_t H5PLget(unsigned int index, char *path_buf, size_t buf_size);
+  1.10.1 herr_t H5PLsize(unsigned int *num_paths);
+
+# === H5R - Reference API ===================================================
 
   herr_t    H5Rcreate(void *ref, hid_t loc_id, char *name, H5R_type_t ref_type,  hid_t space_id)
   hid_t     H5Rdereference(hid_t obj_id, H5R_type_t ref_type, void *ref)

--- a/h5py/h5pl.pxd
+++ b/h5py/h5pl.pxd
@@ -7,12 +7,14 @@
 # License:  Standard 3-clause BSD; see "license.txt" for full license terms
 #           and contributor agreement.
 
+include "config.pxi"
 from defs cimport *
 
-cpdef append(const char* search_path)
-cpdef prepend(const char* search_path)
-cpdef replace(const char* search_path, unsigned int index)
-cpdef insert(const char* search_path, unsigned int index)
-cpdef remove(unsigned int index)
-cpdef get(unsigned int index)
-cpdef size()
+IF HDF5_VERSION >= (1, 10, 1):
+    cpdef append(const char* search_path)
+    cpdef prepend(const char* search_path)
+    cpdef replace(const char* search_path, unsigned int index)
+    cpdef insert(const char* search_path, unsigned int index)
+    cpdef remove(unsigned int index)
+    cpdef get(unsigned int index)
+    cpdef size()

--- a/h5py/h5pl.pxd
+++ b/h5py/h5pl.pxd
@@ -1,0 +1,18 @@
+# This file is part of h5py, a Python interface to the HDF5 library.
+#
+# http://www.h5py.org
+#
+# Copyright 2008-2019 Andrew Collette and contributors
+#
+# License:  Standard 3-clause BSD; see "license.txt" for full license terms
+#           and contributor agreement.
+
+from defs cimport *
+
+cpdef append(const char* search_path)
+cpdef prepend(const char* search_path)
+cpdef replace(const char* search_path, unsigned int index)
+cpdef insert(const char* search_path, unsigned int index)
+cpdef remove(unsigned int index)
+cpdef get(unsigned int index)
+cpdef size()

--- a/h5py/h5pl.pyx
+++ b/h5py/h5pl.pyx
@@ -42,10 +42,10 @@ IF HDF5_VERSION >= (1, 10, 1):
         cpdef size_t n
         cpdef char* buf = NULL
 
-        n = H5PLget(index, NULL, 0) + 1
-        buf = <char*>emalloc(sizeof(char)*n)
+        n = H5PLget(index, NULL, 0)
+        buf = <char*>emalloc(sizeof(char)*(n + 1))
         try:
-            H5PLget(index, buf, n)
+            H5PLget(index, buf, n + 1)
             return PyBytes_FromStringAndSize(buf, n)
         finally:
             efree(buf)

--- a/h5py/h5pl.pyx
+++ b/h5py/h5pl.pyx
@@ -9,6 +9,8 @@
 
 """
     Provides access to the low-level HDF5 "H5PL" plugins interface.
+
+    These functions are only available with HDF5 1.10.1 or later.
 """
 
 include "config.pxi"

--- a/h5py/h5pl.pyx
+++ b/h5py/h5pl.pyx
@@ -8,7 +8,7 @@
 #           and contributor agreement.
 
 """
-    HDF5 plugin interface.
+    Provides access to the low-level HDF5 "H5PL" plugins interface.
 """
 
 include "config.pxi"
@@ -18,27 +18,46 @@ from utils cimport emalloc, efree
 
 IF HDF5_VERSION >= (1, 10, 1):
     cpdef append(const char* search_path):
-        """(STRING search_path)"""
+        """(STRING search_path)
+
+        Add a directory to the end of the plugin search path.
+        """
         H5PLappend(search_path)
 
     cpdef prepend(const char* search_path):
-        """(STRING search_path)"""
+        """(STRING search_path)
+
+        Add a directory to the start of the plugin search path.
+        """
         H5PLprepend(search_path)
 
     cpdef replace(const char* search_path, unsigned int index):
-        """(STRING search_path, UINT index)"""
+        """(STRING search_path, UINT index)
+
+        Replace the directory at the given index in the plugin search path.
+        """
         H5PLreplace(search_path, index)
 
     cpdef insert(const char* search_path, unsigned int index):
-        """(STRING search_path, UINT index)"""
+        """(STRING search_path, UINT index)
+
+        Insert a directory at the given index in the plugin search path.
+        """
         H5PLinsert(search_path, index)
 
     cpdef remove(unsigned int index):
-        """(UINT index)"""
+        """(UINT index)
+
+        Remove the specified entry from the plugin search path.
+        """
         H5PLremove(index)
 
     cpdef get(unsigned int index):
-        """(UINT index) => STRING"""
+        """(UINT index) => STRING
+
+        Get the directory path at the given index (starting from 0) in the
+        plugin search path. Returns a Python bytes object.
+        """
         cpdef size_t n
         cpdef char* buf = NULL
 
@@ -51,7 +70,10 @@ IF HDF5_VERSION >= (1, 10, 1):
             efree(buf)
 
     cpdef size():
-        """() => UINT"""
+        """() => UINT
+
+        Get the number of directories currently in the plugin search path.
+        """
         cpdef unsigned int n = 0
         H5PLsize(&n)
         return n

--- a/h5py/h5pl.pyx
+++ b/h5py/h5pl.pyx
@@ -11,45 +11,47 @@
     HDF5 plugin interface.
 """
 
+include "config.pxi"
 from utils cimport emalloc, efree
 
 # === C API ===================================================================
 
-cpdef append(const char* search_path):
-    """(STRING search_path)"""
-    H5PLappend(search_path)
+IF HDF5_VERSION >= (1, 10, 1):
+    cpdef append(const char* search_path):
+        """(STRING search_path)"""
+        H5PLappend(search_path)
 
-cpdef prepend(const char* search_path):
-    """(STRING search_path)"""
-    H5PLprepend(search_path)
+    cpdef prepend(const char* search_path):
+        """(STRING search_path)"""
+        H5PLprepend(search_path)
 
-cpdef replace(const char* search_path, unsigned int index):
-    """(STRING search_path, UINT index)"""
-    H5PLreplace(search_path, index)
+    cpdef replace(const char* search_path, unsigned int index):
+        """(STRING search_path, UINT index)"""
+        H5PLreplace(search_path, index)
 
-cpdef insert(const char* search_path, unsigned int index):
-    """(STRING search_path, UINT index)"""
-    H5PLinsert(search_path, index)
+    cpdef insert(const char* search_path, unsigned int index):
+        """(STRING search_path, UINT index)"""
+        H5PLinsert(search_path, index)
 
-cpdef remove(unsigned int index):
-    """(UINT index)"""
-    H5PLremove(index)
+    cpdef remove(unsigned int index):
+        """(UINT index)"""
+        H5PLremove(index)
 
-cpdef get(unsigned int index):
-    """(UINT index) => STRING"""
-    cpdef size_t n
-    cpdef char* buf = NULL
+    cpdef get(unsigned int index):
+        """(UINT index) => STRING"""
+        cpdef size_t n
+        cpdef char* buf = NULL
 
-    n = H5PLget(index, NULL, 0) + 1
-    buf = <char*>emalloc(sizeof(char)*n)
-    try:
-        H5PLget(index, buf, n)
-        return PyBytes_FromStringAndSize(buf, n)
-    finally:
-        efree(buf)
+        n = H5PLget(index, NULL, 0) + 1
+        buf = <char*>emalloc(sizeof(char)*n)
+        try:
+            H5PLget(index, buf, n)
+            return PyBytes_FromStringAndSize(buf, n)
+        finally:
+            efree(buf)
 
-cpdef size():
-    """() => UINT"""
-    cpdef unsigned int n = 0
-    H5PLsize(&n)
-    return n
+    cpdef size():
+        """() => UINT"""
+        cpdef unsigned int n = 0
+        H5PLsize(&n)
+        return n

--- a/h5py/h5pl.pyx
+++ b/h5py/h5pl.pyx
@@ -11,6 +11,7 @@
     Provides access to the low-level HDF5 "H5PL" plugins interface.
 
     These functions are only available with HDF5 1.10.1 or later.
+    They are probably not thread safe.
 """
 
 include "config.pxi"

--- a/h5py/h5pl.pyx
+++ b/h5py/h5pl.pyx
@@ -1,0 +1,55 @@
+# This file is part of h5py, a Python interface to the HDF5 library.
+#
+# http://www.h5py.org
+#
+# Copyright 2008-2019 Andrew Collette and contributors
+#
+# License:  Standard 3-clause BSD; see "license.txt" for full license terms
+#           and contributor agreement.
+
+"""
+    HDF5 plugin interface.
+"""
+
+from utils cimport emalloc, efree
+
+# === C API ===================================================================
+
+cpdef append(const char* search_path):
+    """(STRING search_path)"""
+    H5PLappend(search_path)
+
+cpdef prepend(const char* search_path):
+    """(STRING search_path)"""
+    H5PLprepend(search_path)
+
+cpdef replace(const char* search_path, unsigned int index):
+    """(STRING search_path, UINT index)"""
+    H5PLreplace(search_path, index)
+
+cpdef insert(const char* search_path, unsigned int index):
+    """(STRING search_path, UINT index)"""
+    H5PLinsert(search_path, index)
+
+cpdef remove(unsigned int index):
+    """(UINT index)"""
+    H5PLremove(index)
+
+cpdef get(unsigned int index):
+    """(UINT index) => STRING"""
+    cpdef size_t n
+    cpdef char* buf = NULL
+
+    n = H5PLget(index, NULL, 0) + 1
+    buf = <char*>emalloc(sizeof(char)*n)
+    try:
+        H5PLget(index, buf, n)
+        return PyBytes_FromStringAndSize(buf, n)
+    finally:
+        efree(buf)
+
+cpdef size():
+    """() => UINT"""
+    cpdef unsigned int n = 0
+    H5PLsize(&n)
+    return n

--- a/h5py/tests/old/test_h5pl.py
+++ b/h5py/tests/old/test_h5pl.py
@@ -75,34 +75,34 @@ class TestSearchPaths(ut.TestCase):
     @sandboxed
     def test_default(self):
         self.assertEqual(h5pl.size(), 1)
-        self.assertTrue(h5pl.get(0).endswith(b'hdf5/lib/plugin\x00'))
+        self.assertTrue(h5pl.get(0).endswith(b'hdf5/lib/plugin'))
 
     @sandboxed
     def test_append(self):
         h5pl.append(b'/opt/hdf5/vendor-plugin')
         self.assertEqual(h5pl.size(), 2)
-        self.assertTrue(h5pl.get(0).endswith(b'hdf5/lib/plugin\x00'))
-        self.assertEqual(h5pl.get(1), b'/opt/hdf5/vendor-plugin\x00')
+        self.assertTrue(h5pl.get(0).endswith(b'hdf5/lib/plugin'))
+        self.assertEqual(h5pl.get(1), b'/opt/hdf5/vendor-plugin')
 
     @sandboxed
     def test_prepend(self):
         h5pl.prepend(b'/opt/hdf5/vendor-plugin')
         self.assertEqual(h5pl.size(), 2)
-        self.assertEqual(h5pl.get(0), b'/opt/hdf5/vendor-plugin\x00')
-        self.assertTrue(h5pl.get(1).endswith(b'hdf5/lib/plugin\x00'))
+        self.assertEqual(h5pl.get(0), b'/opt/hdf5/vendor-plugin')
+        self.assertTrue(h5pl.get(1).endswith(b'hdf5/lib/plugin'))
 
     @sandboxed
     def test_insert(self):
         h5pl.insert(b'/opt/hdf5/vendor-plugin', 0)
         self.assertEqual(h5pl.size(), 2)
-        self.assertEqual(h5pl.get(0), b'/opt/hdf5/vendor-plugin\x00')
-        self.assertTrue(h5pl.get(1).endswith(b'hdf5/lib/plugin\x00'))
+        self.assertEqual(h5pl.get(0), b'/opt/hdf5/vendor-plugin')
+        self.assertTrue(h5pl.get(1).endswith(b'hdf5/lib/plugin'))
 
     @sandboxed
     def test_replace(self):
         h5pl.replace(b'/opt/hdf5/vendor-plugin', 0)
         self.assertEqual(h5pl.size(), 1)
-        self.assertEqual(h5pl.get(0), b'/opt/hdf5/vendor-plugin\x00')
+        self.assertEqual(h5pl.get(0), b'/opt/hdf5/vendor-plugin')
 
     @sandboxed
     def test_remove(self):

--- a/h5py/tests/old/test_h5pl.py
+++ b/h5py/tests/old/test_h5pl.py
@@ -9,104 +9,57 @@
 
 from __future__ import absolute_import
 
-try:
-    import unittest2 as ut
-except ImportError:
-    import unittest as ut
+import pytest
 
 import h5py
 from h5py import h5pl
-
-import inspect
-import functools
-import subprocess
-import tempfile
-import sys
-import os
-import platform
+from h5py.tests.common import insubprocess
 
 
-def sandboxed(test):
-
-    @functools.wraps(test)
-    def wrapper(*args):
-        lines, start = inspect.getsourcelines(test)
-        source = '\n'.join(lines[1:])  # remove this decorator
-
-        with tempfile.NamedTemporaryFile('w', prefix='sandbox-', suffix='.py', delete=False) as f:
-            f.write('''
-try:
-    import unittest2 as ut
-except ImportError:
-    import unittest as ut
-
-import h5py
-from h5py import h5pl
-
-class {}(ut.TestCase):
-{}
-'''.format((test.__qualname__.split('.')[0])
-           if hasattr(test, '__qualname__') else 'Test',
-           source, check=True))
-
-            fname = f.name
-            try:
-                # support Windows
-                f.close()
-
-                env = dict(os.environ)
-                # as per https://support.hdfgroup.org/HDF5/doc/Advanced/DynamicallyLoadedFilters/HDF5DynamicallyLoadedFilters.pdf,
-                # in case your HDF5 setup has it different
-                # (e.g. https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=826522)
-                if platform.system() == 'Windows':
-                    env['HDF5_PLUGIN_PATH'] = os.path.expandvars('%ALLUSERSPROFILE%/hdf5/lib/plugin')
-                else:
-                    env['HDF5_PLUGIN_PATH'] = '/usr/local/hdf5/lib/plugin'
-
-                subprocess.check_call((sys.executable, '-m', 'pytest', '-q', fname),
-                                      env=env)
-            finally:
-                os.remove(fname)
-
-    return wrapper
+# pytestmark is a special name - the skipif marker applies to the whole file
+pytestmark = pytest.mark.skipif(
+    h5py.version.hdf5_version_tuple < (1, 10, 1), reason='HDF5 1.10.1+ required'
+)
 
 
-@ut.skipUnless(h5py.version.hdf5_version_tuple >= (1, 10, 1), 'HDF5 1.10.1+ required')
-class TestSearchPaths(ut.TestCase):
+@insubprocess
+def test_default(request):
+    assert h5pl.size() == 1
+    assert h5pl.get(0).endswith(b'hdf5/lib/plugin')
 
-    @sandboxed
-    def test_default(self):
-        self.assertEqual(h5pl.size(), 1)
-        self.assertTrue(h5pl.get(0).endswith(b'hdf5/lib/plugin'))
 
-    @sandboxed
-    def test_append(self):
-        h5pl.append(b'/opt/hdf5/vendor-plugin')
-        self.assertEqual(h5pl.size(), 2)
-        self.assertTrue(h5pl.get(0).endswith(b'hdf5/lib/plugin'))
-        self.assertEqual(h5pl.get(1), b'/opt/hdf5/vendor-plugin')
+@insubprocess
+def test_append(request):
+    h5pl.append(b'/opt/hdf5/vendor-plugin')
+    assert h5pl.size() == 2
+    assert h5pl.get(0).endswith(b'hdf5/lib/plugin')
+    assert h5pl.get(1) == b'/opt/hdf5/vendor-plugin'
 
-    @sandboxed
-    def test_prepend(self):
-        h5pl.prepend(b'/opt/hdf5/vendor-plugin')
-        self.assertEqual(h5pl.size(), 2)
-        self.assertEqual(h5pl.get(0), b'/opt/hdf5/vendor-plugin')
-        self.assertTrue(h5pl.get(1).endswith(b'hdf5/lib/plugin'))
 
-    @sandboxed
-    def test_insert(self):
-        h5pl.insert(b'/opt/hdf5/vendor-plugin', 0)
-        self.assertEqual(h5pl.size(), 2)
-        self.assertEqual(h5pl.get(0), b'/opt/hdf5/vendor-plugin')
-        self.assertTrue(h5pl.get(1).endswith(b'hdf5/lib/plugin'))
+@insubprocess
+def test_prepend(request):
+    h5pl.prepend(b'/opt/hdf5/vendor-plugin')
+    assert h5pl.size() == 2
+    assert h5pl.get(0) == b'/opt/hdf5/vendor-plugin'
+    assert h5pl.get(1).endswith(b'hdf5/lib/plugin')
 
-    @sandboxed
-    def test_replace(self):
-        h5pl.replace(b'/opt/hdf5/vendor-plugin', 0)
-        self.assertEqual(h5pl.size(), 1)
-        self.assertEqual(h5pl.get(0), b'/opt/hdf5/vendor-plugin')
 
-    @sandboxed
-    def test_remove(self):
-        h5pl.remove(0)
-        self.assertEqual(h5pl.size(), 0)
+@insubprocess
+def test_insert(request):
+    h5pl.insert(b'/opt/hdf5/vendor-plugin', 0)
+    assert h5pl.size() == 2
+    assert h5pl.get(0) == b'/opt/hdf5/vendor-plugin'
+    assert h5pl.get(1).endswith(b'hdf5/lib/plugin')
+
+
+@insubprocess
+def test_replace(request):
+    h5pl.replace(b'/opt/hdf5/vendor-plugin', 0)
+    assert  h5pl.size() == 1
+    assert  h5pl.get(0) == b'/opt/hdf5/vendor-plugin'
+
+
+@insubprocess
+def test_remove(request):
+    h5pl.remove(0)
+    assert h5pl.size() == 0

--- a/h5py/tests/old/test_h5pl.py
+++ b/h5py/tests/old/test_h5pl.py
@@ -13,7 +13,7 @@ import pytest
 
 import h5py
 from h5py import h5pl
-from h5py.tests.common import insubprocess
+from h5py.tests.common import insubprocess, subproc_env
 
 
 # pytestmark is a special name - the skipif marker applies to the whole file
@@ -23,36 +23,41 @@ pytestmark = pytest.mark.skipif(
 
 
 @insubprocess
+@subproc_env({'HDF5_PLUGIN_PATH': 'h5py_plugin_test'})
 def test_default(request):
     assert h5pl.size() == 1
-    assert h5pl.get(0).endswith(b'hdf5/lib/plugin')
+    assert h5pl.get(0) == b'h5py_plugin_test'
 
 
 @insubprocess
+@subproc_env({'HDF5_PLUGIN_PATH': 'h5py_plugin_test'})
 def test_append(request):
     h5pl.append(b'/opt/hdf5/vendor-plugin')
     assert h5pl.size() == 2
-    assert h5pl.get(0).endswith(b'hdf5/lib/plugin')
+    assert h5pl.get(0) == b'h5py_plugin_test'
     assert h5pl.get(1) == b'/opt/hdf5/vendor-plugin'
 
 
 @insubprocess
+@subproc_env({'HDF5_PLUGIN_PATH': 'h5py_plugin_test'})
 def test_prepend(request):
     h5pl.prepend(b'/opt/hdf5/vendor-plugin')
     assert h5pl.size() == 2
     assert h5pl.get(0) == b'/opt/hdf5/vendor-plugin'
-    assert h5pl.get(1).endswith(b'hdf5/lib/plugin')
+    assert h5pl.get(1) == b'h5py_plugin_test'
 
 
 @insubprocess
+@subproc_env({'HDF5_PLUGIN_PATH': 'h5py_plugin_test'})
 def test_insert(request):
     h5pl.insert(b'/opt/hdf5/vendor-plugin', 0)
     assert h5pl.size() == 2
     assert h5pl.get(0) == b'/opt/hdf5/vendor-plugin'
-    assert h5pl.get(1).endswith(b'hdf5/lib/plugin')
+    assert h5pl.get(1) == b'h5py_plugin_test'
 
 
 @insubprocess
+@subproc_env({'HDF5_PLUGIN_PATH': 'h5py_plugin_test'})
 def test_replace(request):
     h5pl.replace(b'/opt/hdf5/vendor-plugin', 0)
     assert  h5pl.size() == 1

--- a/h5py/tests/old/test_h5pl.py
+++ b/h5py/tests/old/test_h5pl.py
@@ -17,40 +17,82 @@ except ImportError:
 import h5py
 from h5py import h5pl
 
-from ..common import TestCase
+import inspect
+import functools
+import subprocess
+import tempfile
+import sys
+import os
 
-@ut.skip('The tests have side effects')
+
+def sandboxed(test):
+
+    @functools.wraps(test)
+    def wrapper(*args):
+        lines, start = inspect.getsourcelines(test)
+        source = '\n'.join(lines[1:])  # remove this decorator
+
+        with tempfile.NamedTemporaryFile('w', dir='.', prefix='sandbox-', suffix='.py', delete=False) as f:
+            f.write('''
+try:
+    import unittest2 as ut
+except ImportError:
+    import unittest as ut
+
+import h5py
+from h5py import h5pl
+
+class {}(ut.TestCase):
+{}
+'''.format(test.__qualname__.split('.')[0], source, check=True))
+            fname = f.name
+            try:
+                # support Windows
+                f.close()
+                subprocess.run((sys.executable, '-m', 'pytest', '-q', fname),
+                               check=True)
+            finally:
+                os.remove(fname)
+
+    return wrapper
+
+
 @ut.skipUnless(h5py.version.hdf5_version_tuple >= (1, 10, 1), 'HDF5 1.10.1+ required')
-class TestSearchPaths(TestCase):
+class TestSearchPaths(ut.TestCase):
 
+    @sandboxed
     def test_default(self):
         self.assertEqual(h5pl.size(), 1)
         self.assertTrue(h5pl.get(0).endswith(b'hdf5/plugins\x00'))
 
+    @sandboxed
     def test_append(self):
         h5pl.append(b'/opt/hdf5/vendor-plugins')
         self.assertEqual(h5pl.size(), 2)
-        print(h5pl.get(0))
         self.assertTrue(h5pl.get(0).endswith(b'hdf5/plugins\x00'))
         self.assertEqual(h5pl.get(1), b'/opt/hdf5/vendor-plugins\x00')
 
+    @sandboxed
     def test_prepend(self):
         h5pl.prepend(b'/opt/hdf5/vendor-plugins')
         self.assertEqual(h5pl.size(), 2)
         self.assertEqual(h5pl.get(0), b'/opt/hdf5/vendor-plugins\x00')
         self.assertTrue(h5pl.get(1).endswith(b'hdf5/plugins\x00'))
 
+    @sandboxed
     def test_insert(self):
         h5pl.insert(b'/opt/hdf5/vendor-plugins', 0)
         self.assertEqual(h5pl.size(), 2)
         self.assertEqual(h5pl.get(0), b'/opt/hdf5/vendor-plugins\x00')
         self.assertTrue(h5pl.get(1).endswith(b'hdf5/plugins\x00'))
 
+    @sandboxed
     def test_replace(self):
         h5pl.replace(b'/opt/hdf5/vendor-plugins', 0)
         self.assertEqual(h5pl.size(), 1)
         self.assertEqual(h5pl.get(0), b'/opt/hdf5/vendor-plugins\x00')
 
+    @sandboxed
     def test_remove(self):
         h5pl.remove(0)
         self.assertEqual(h5pl.size(), 0)

--- a/h5py/tests/old/test_h5pl.py
+++ b/h5py/tests/old/test_h5pl.py
@@ -1,0 +1,56 @@
+# This file is part of h5py, a Python interface to the HDF5 library.
+#
+# http://www.h5py.org
+#
+# Copyright 2008-2019 Andrew Collette and contributors
+#
+# License:  Standard 3-clause BSD; see "license.txt" for full license terms
+#           and contributor agreement.
+
+from __future__ import absolute_import
+
+try:
+    import unittest2 as ut
+except ImportError:
+    import unittest as ut
+
+import h5py
+from h5py import h5pl
+
+from ..common import TestCase
+
+@ut.skip('The tests have side effects')
+@ut.skipUnless(h5py.version.hdf5_version_tuple >= (1, 10, 1), 'HDF5 1.10.1+ required')
+class TestSearchPaths(TestCase):
+
+    def test_default(self):
+        self.assertEqual(h5pl.size(), 1)
+        self.assertTrue(h5pl.get(0).endswith(b'hdf5/plugins\x00'))
+
+    def test_append(self):
+        h5pl.append(b'/opt/hdf5/vendor-plugins')
+        self.assertEqual(h5pl.size(), 2)
+        print(h5pl.get(0))
+        self.assertTrue(h5pl.get(0).endswith(b'hdf5/plugins\x00'))
+        self.assertEqual(h5pl.get(1), b'/opt/hdf5/vendor-plugins\x00')
+
+    def test_prepend(self):
+        h5pl.prepend(b'/opt/hdf5/vendor-plugins')
+        self.assertEqual(h5pl.size(), 2)
+        self.assertEqual(h5pl.get(0), b'/opt/hdf5/vendor-plugins\x00')
+        self.assertTrue(h5pl.get(1).endswith(b'hdf5/plugins\x00'))
+        
+    def test_insert(self):
+        h5pl.insert(b'/opt/hdf5/vendor-plugins', 0)
+        self.assertEqual(h5pl.size(), 2)
+        self.assertEqual(h5pl.get(0), b'/opt/hdf5/vendor-plugins\x00')
+        self.assertTrue(h5pl.get(1).endswith(b'hdf5/plugins\x00'))
+
+    def test_replace(self):
+        h5pl.replace(b'/opt/hdf5/vendor-plugins', 0)
+        self.assertEqual(h5pl.size(), 1)
+        self.assertEqual(h5pl.get(0), b'/opt/hdf5/vendor-plugins\x00')
+
+    def test_remove(self):
+        h5pl.remove(0)
+        self.assertEqual(h5pl.size(), 0)

--- a/h5py/tests/old/test_h5pl.py
+++ b/h5py/tests/old/test_h5pl.py
@@ -53,7 +53,7 @@ class {}(ut.TestCase):
                 # support Windows
                 f.close()
 
-                env = {**os.environ}
+                env = dict(os.environ)
                 if 'HDF5_PLUGIN_PATH' in env:
                     del env['HDF5_PLUGIN_PATH']
 

--- a/h5py/tests/old/test_h5pl.py
+++ b/h5py/tests/old/test_h5pl.py
@@ -39,7 +39,7 @@ class TestSearchPaths(TestCase):
         self.assertEqual(h5pl.size(), 2)
         self.assertEqual(h5pl.get(0), b'/opt/hdf5/vendor-plugins\x00')
         self.assertTrue(h5pl.get(1).endswith(b'hdf5/plugins\x00'))
-        
+
     def test_insert(self):
         h5pl.insert(b'/opt/hdf5/vendor-plugins', 0)
         self.assertEqual(h5pl.size(), 2)

--- a/h5py/tests/old/test_h5pl.py
+++ b/h5py/tests/old/test_h5pl.py
@@ -58,8 +58,10 @@ class {}(ut.TestCase):
                 # as per https://support.hdfgroup.org/HDF5/doc/Advanced/DynamicallyLoadedFilters/HDF5DynamicallyLoadedFilters.pdf,
                 # in case your HDF5 setup has it different
                 # (e.g. https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=826522)
-                env['HDF5_PLUGIN_PATH'] = os.path.expandvars('%ALLUSERSPROFILE%/hdf5/lib/plugin') \
-                    if platform.system() == 'Windows' else '/usr/local/hdf5/lib/plugin'
+                if platform.system() == 'Windows':
+                    env['HDF5_PLUGIN_PATH'] = os.path.expandvars('%ALLUSERSPROFILE%/hdf5/lib/plugin')
+                else:
+                    env['HDF5_PLUGIN_PATH'] = '/usr/local/hdf5/lib/plugin'
 
                 subprocess.check_call((sys.executable, '-m', 'pytest', '-q', fname),
                                       env=env)

--- a/h5py/tests/old/test_h5pl.py
+++ b/h5py/tests/old/test_h5pl.py
@@ -44,8 +44,8 @@ from h5py import h5pl
 
 class {}(ut.TestCase):
 {}
-'''.format((test.__qualname__.split('.')[0]) if hasattr(test, '__qualname__')
-           else test.im_class.__name__,
+'''.format((test.__qualname__.split('.')[0])
+           if hasattr(test, '__qualname__') else 'Test',
            source, check=True))
 
             fname = f.name
@@ -71,6 +71,7 @@ class TestSearchPaths(ut.TestCase):
     @sandboxed
     def test_default(self):
         self.assertEqual(h5pl.size(), 1)
+        print(h5pl.get(0))
         self.assertTrue(h5pl.get(0).endswith(b'hdf5/plugins\x00'))
 
     @sandboxed

--- a/setup_build.py
+++ b/setup_build.py
@@ -29,7 +29,8 @@ MODULES =  ['defs','_errors','_objects','_proxy', 'h5fd', 'h5z',
             'h5p',
             'h5d', 'h5a', 'h5f', 'h5g',
             'h5l', 'h5o',
-            'h5ds', 'h5ac']
+            'h5ds', 'h5ac',
+            'h5pl']
 
 
 EXTRA_SRC = {'h5z': [ localpath("lzf/lzf_filter.c"),


### PR DESCRIPTION
This is a continuation of #1166. I've updated it to use the `@insubprocess` decorator @scopatz added, fixed the tests running in a conda environment (conda-forge configures a non-default plugin directory when building HDF5), and added some docs for the new functions.

Remaining questions:

1. Currently the path APIs accept and return bytes. Although this is technically correct for Unix paths, it's more common in Python to work with paths as strings. We're a bit inconsistent elsewhere - the low-level API for an external link returns bytes, but getting the source of a virtual dataset returns str. I'm leaning towards staying with bytes in the low-level API.
2. Do we want to do any locking? On #1166, @tacaswell said they shouldn't need the phil lock, but there might be reasons to have a separate lock for the plugin search path:

>  We may also want to lock them between eachother (as I can imagine an append and a remove colliding and ending up with a "gap" in the hdf5 datastrucutres....).

I'm tentatively marking this for 2.10, but I don't mind if we bump it to a later release.