### PR TITLE
Only install numpy and cython when required

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,8 @@ SETUP_REQUIRES = RUN_REQUIRES + [NUMPY_DEP, 'Cython>=0.23', 'pkgconfig']
 
 # Needed to avoid trying to install numpy/cython on pythons which the latest
 # versions don't support
-if ("sdist" in sys.argv and "bdist_wheel" not in sys.argv and
-    "install" not in sys.argv) or "check" in sys.argv:
-    use_setup_requires = False
-else:
-    use_setup_requires = True
+use_setup_requires = any(parameter in sys.argv for parameter in
+    ("bdist_wheel", "build", "install", "test"))
 
 
 # --- Custom Distutils commands -----------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ SETUP_REQUIRES = RUN_REQUIRES + [NUMPY_DEP, 'Cython>=0.23', 'pkgconfig']
 # Needed to avoid trying to install numpy/cython on pythons which the latest
 # versions don't support
 use_setup_requires = any(parameter in sys.argv for parameter in
-    ("bdist_wheel", "build", "install", "test"))
+    ("bdist_wheel", "build", "configure", "install", "test"))
 
 
 # --- Custom Distutils commands -----------------------------------------------


### PR DESCRIPTION
Change from a negative list to a positive parameter list, as to exclude
odd setup.py parameters such as 'egg_info', which is used when
downloading dependencies via pip. Resolves #1257.