### PR TITLE
Modify interface for external storage

### DIFF
--- a/docs/high/group.rst
+++ b/docs/high/group.rst
@@ -354,8 +354,8 @@ Reference
 
         :keyword external: Store the dataset in one or more external, non-HDF5
             files. This should be a list of tuples of
-            ``(filename[, offset[, size]])``, to store data from ``offset`` to
-            ``offset + size`` in the specified file. The last file in the list
+            ``(name[, offset[, size]])``, to store data from ``offset`` to
+            ``offset + size`` in the named file. The last file in the list
             may have size ``h5py.h5f.UNLIMITED`` to let it grow as needed.
 
     .. method:: require_dataset(name, shape=None, dtype=None, exact=None, **kwds)

--- a/docs/high/group.rst
+++ b/docs/high/group.rst
@@ -353,12 +353,13 @@ Reference
                         ``h5.get_config().track_order``.
 
         :keyword external: Store the dataset in one or more external, non-HDF5
-            files. This should be a list of tuples of ``(name, offset, size)``
-            to store data from ``offset`` to ``offset + size`` in the named
-            file. Each name must be a str, bytes, or os.PathLike; each offset
-            and size, an integer. The last file in the list may have size
-            ``h5py.h5f.UNLIMITED`` to let it grow as needed. If only a name is
-            given instead of a list of tuples, it is equivalent to
+            files. This should be an iterable (such as a list) of tuples of
+            ``(name, offset, size)`` to store data from ``offset`` to
+            ``offset + size`` in the named file. Each name must be a str,
+            bytes, or os.PathLike; each offset and size, an integer. The last
+            file in the sequence may have size ``h5py.h5f.UNLIMITED`` to let
+            it grow as needed. If only a name is given instead of an iterable
+            of tuples, it is equivalent to
             ``[(name, 0, h5py.h5f.UNLIMITED)]``.
 
     .. method:: require_dataset(name, shape=None, dtype=None, exact=None, **kwds)

--- a/docs/high/group.rst
+++ b/docs/high/group.rst
@@ -356,7 +356,7 @@ Reference
             files. This should be a list of tuples of
             ``(filename[, offset[, size]])``, to store data from ``offset`` to
             ``offset + size`` in the specified file. The last file in the list
-            may have size ``h5py.h5s.UNLIMITED`` to let it grow as needed.
+            may have size ``h5py.h5f.UNLIMITED`` to let it grow as needed.
 
     .. method:: require_dataset(name, shape=None, dtype=None, exact=None, **kwds)
 

--- a/docs/high/group.rst
+++ b/docs/high/group.rst
@@ -355,8 +355,11 @@ Reference
         :keyword external: Store the dataset in one or more external, non-HDF5
             files. This should be a list of tuples of ``(name, offset, size)``
             to store data from ``offset`` to ``offset + size`` in the named
-            file. The last file in the list may have size
-            ``h5py.h5f.UNLIMITED`` to let it grow as needed.
+            file. Each name must be a str, bytes, or os.PathLike; each offset
+            and size, an integer. The last file in the list may have size
+            ``h5py.h5f.UNLIMITED`` to let it grow as needed. If only a name is
+            given instead of a list of tuples, it is equivalent to
+            ``[(name, 0, h5py.h5f.UNLIMITED)]``.
 
     .. method:: require_dataset(name, shape=None, dtype=None, exact=None, **kwds)
 

--- a/docs/high/group.rst
+++ b/docs/high/group.rst
@@ -353,10 +353,10 @@ Reference
                         ``h5.get_config().track_order``.
 
         :keyword external: Store the dataset in one or more external, non-HDF5
-            files. This should be a list of tuples of
-            ``(name[, offset[, size]])``, to store data from ``offset`` to
-            ``offset + size`` in the named file. The last file in the list
-            may have size ``h5py.h5f.UNLIMITED`` to let it grow as needed.
+            files. This should be a list of tuples of ``(name, offset, size)``
+            to store data from ``offset`` to ``offset + size`` in the named
+            file. The last file in the list may have size
+            ``h5py.h5f.UNLIMITED`` to let it grow as needed.
 
     .. method:: require_dataset(name, shape=None, dtype=None, exact=None, **kwds)
 

--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -105,9 +105,7 @@ def _normalize_external(external):
         return [_external_entry((external, 0, h5f.UNLIMITED))]
     except TypeError:
         pass
-    if not isinstance(external, (list)):
-        raise TypeError('external should be a list of tuples of (name, offset, size)')
-    # check and rebuild each list entry to be well-formed
+    # Check and rebuild each entry to be well-formed.
     return [_external_entry(entry) for entry in external]
 
 def fill_dcpl(plist, shape, dtype, chunks, compression, compression_opts,

--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -88,7 +88,7 @@ def _normalize_external(external):
         # accept a solitary file string
         return [_external_entry(external)]
     if not isinstance(external, (list)):
-        raise ValueError('external should be a list of tuples of (file[, offset[, size]])')
+        raise TypeError('external should be a list of tuples of (file[, offset[, size]])')
     try:
         # accept a single entry, not in a list
         return [_external_entry(*external)]

--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -88,7 +88,7 @@ def _normalize_external(external):
         # accept a solitary file string
         return [_external_entry(external)]
     if not isinstance(external, (list)):
-        raise TypeError('external should be a list of tuples of (file[, offset[, size]])')
+        raise TypeError('external should be a list of tuples of (name[, offset[, size]])')
     try:
         # accept a single entry, not in a list
         return [_external_entry(*external)]

--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -81,21 +81,23 @@ def _external_entry(entry):
         raise TypeError(
             "Each external entry must be a tuple of (name, offset, size)")
     name, offset, size = entry  # raise ValueError without three elements
-    if not isinstance(name, str):
-        raise TypeError("External entry's name must be a string")
+    name = filename_encode(name)
     if not isinstance(offset, int):
         raise TypeError("External entry's offset must be an integer")
     if not isinstance(size, int):
         raise TypeError("External entry's size must be an integer")
-    return (filename_encode(name), offset, size)
+    return (name, offset, size)
 
 def _normalize_external(external):
     """ Normalize external into a well-formed list of tuples and return. """
     if external is None:
         return []
-    elif isinstance(external, str):
-        # accept a solitary file string
+    try:
+        # Accept a solitary name---a str, bytes, or os.PathLike acceptable to
+        # filename_encode.
         return [_external_entry((external, 0, h5f.UNLIMITED))]
+    except TypeError:
+        pass
     if not isinstance(external, (list)):
         raise TypeError('external should be a list of tuples of (name, offset, size)')
     # check and rebuild each list entry to be well-formed

--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -38,6 +38,8 @@
         Tuple of available filter names for encoding
 """
 
+import operator
+
 import numpy as np
 from .compat import filename_encode
 from .. import h5z, h5p, h5d, h5f
@@ -82,10 +84,15 @@ def _external_entry(entry):
             "Each external entry must be a tuple of (name, offset, size)")
     name, offset, size = entry  # raise ValueError without three elements
     name = filename_encode(name)
+<<<<<<< HEAD
     if not isinstance(offset, int):
         raise TypeError("External entry's offset must be an integer")
     if not isinstance(size, int):
         raise TypeError("External entry's size must be an integer")
+=======
+    offset = operator.index(offset)
+    size = operator.index(size)
+>>>>>>> Ensure integral offset and size without isinstance
     return (name, offset, size)
 
 def _normalize_external(external):

--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -89,16 +89,8 @@ def _normalize_external(external):
         return [_external_entry(external)]
     if not isinstance(external, (list)):
         raise TypeError('external should be a list of tuples of (name[, offset[, size]])')
-    try:
-        # accept a single entry, not in a list
-        return [_external_entry(*external)]
-    except TypeError:
-        pass
     # check and rebuild each list entry to be well-formed
-    return [_external_entry(entry)
-            if isinstance(entry, str) else
-            _external_entry(*entry)
-            for entry in external]
+    return [_external_entry(*entry) for entry in external]
 
 def fill_dcpl(plist, shape, dtype, chunks, compression, compression_opts,
               shuffle, fletcher32, maxshape, scaleoffset, external):

--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -84,15 +84,8 @@ def _external_entry(entry):
             "Each external entry must be a tuple of (name, offset, size)")
     name, offset, size = entry  # raise ValueError without three elements
     name = filename_encode(name)
-<<<<<<< HEAD
-    if not isinstance(offset, int):
-        raise TypeError("External entry's offset must be an integer")
-    if not isinstance(size, int):
-        raise TypeError("External entry's size must be an integer")
-=======
     offset = operator.index(offset)
     size = operator.index(size)
->>>>>>> Ensure integral offset and size without isinstance
     return (name, offset, size)
 
 def _normalize_external(external):

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -122,13 +122,13 @@ class Group(HLObject, MutableMappingHDF5):
             (T/F) Track attribute creation order if True. If omitted use
             global default h5.get_config().track_order.
         external
-            (List of tuples) Sets the external storage property, thus
+            (Iterable of tuples) Sets the external storage property, thus
             designating that the dataset will be stored in one or more
-            non-HDF5 files external to the HDF5 file.  Adds each listed tuple
+            non-HDF5 files external to the HDF5 file.  Adds each tuple
             of (name, offset, size) to the dataset's list of external files.
             Each name must be a str, bytes, or os.PathLike; each offset and
-            size, an integer.  If only a name is given instead of a list of
-            tuples, it is equivalent to [(name, 0, h5py.h5f.UNLIMITED)].
+            size, an integer.  If only a name is given instead of an iterable
+            of tuples, it is equivalent to [(name, 0, h5py.h5f.UNLIMITED)].
         """
         if 'track_order' not in kwds:
             kwds['track_order'] = h5.get_config().track_order

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -126,6 +126,9 @@ class Group(HLObject, MutableMappingHDF5):
             designating that the dataset will be stored in one or more
             non-HDF5 files external to the HDF5 file.  Adds each listed tuple
             of (name, offset, size) to the dataset's list of external files.
+            Each name must be a str, bytes, or os.PathLike; each offset and
+            size, an integer.  If only a name is given instead of a list of
+            tuples, it is equivalent to [(name, 0, h5py.h5f.UNLIMITED)].
         """
         if 'track_order' not in kwds:
             kwds['track_order'] = h5.get_config().track_order

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -125,7 +125,7 @@ class Group(HLObject, MutableMappingHDF5):
             (List of tuples) Sets the external storage property, thus
             designating that the dataset will be stored in one or more
             non-HDF5 file(s) external to the HDF5 file. Adds each listed
-            tuple of (file[, offset[, size]]) to the dataset's list of
+            tuple of (name[, offset[, size]]) to the dataset's list of
             external files.
         """
         if 'track_order' not in kwds:

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -124,9 +124,8 @@ class Group(HLObject, MutableMappingHDF5):
         external
             (List of tuples) Sets the external storage property, thus
             designating that the dataset will be stored in one or more
-            non-HDF5 file(s) external to the HDF5 file. Adds each listed
-            tuple of (name[, offset[, size]]) to the dataset's list of
-            external files.
+            non-HDF5 files external to the HDF5 file.  Adds each listed tuple
+            of (name, offset, size) to the dataset's list of external files.
         """
         if 'track_order' not in kwds:
             kwds['track_order'] = h5.get_config().track_order

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -600,12 +600,12 @@ class TestExternal(BaseDataset):
         self.f.create_dataset('foo', (6, 100),
                               external=pathlib.Path(self.mktemp()))
 
-    def test_multi(self):
-        """ External argument may contain multiple tuples """
+    def test_iter_multi(self):
+        """ External argument may be an iterable of multiple tuples """
 
         ext_file = self.mktemp()
         N = 100
-        external = [(ext_file, x * 1000, 1000) for x in range(N)]
+        external = iter((ext_file, x * 1000, 1000) for x in range(N))
         dset = self.f.create_dataset('poo', (6, 100), external=external)
         assert len(dset.external) == N
 

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -591,9 +591,8 @@ class TestExternal(BaseDataset):
         ext_file = self.mktemp()
 
         self.f.create_dataset('foo', shape, external=ext_file)
-        self.f.create_dataset('bar', shape, external=[ext_file])
-        self.f.create_dataset('moo', shape, external=[ext_file, 0])
-        self.f.create_dataset('car', shape, external=[ext_file, 0, h5f.UNLIMITED])
+        self.f.create_dataset('bar', shape, external=[(ext_file,)])
+        self.f.create_dataset('moo', shape, external=[(ext_file, 0)])
 
         N = 100
         external = [(ext_file, x * 1000, 1000) for x in range(N)]
@@ -607,6 +606,9 @@ class TestExternal(BaseDataset):
         ext_file = self.mktemp()
 
         for external in [
+            [ext_file],
+            [ext_file, 0],
+            [ext_file, 0, h5f.UNLIMITED],
             [(ext_file, 0, "h5f.UNLIMITED")],
             [(ext_file, 0, h5f.UNLIMITED, 0)],
         ]:

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -591,8 +591,6 @@ class TestExternal(BaseDataset):
         ext_file = self.mktemp()
 
         self.f.create_dataset('foo', shape, external=ext_file)
-        self.f.create_dataset('bar', shape, external=[(ext_file,)])
-        self.f.create_dataset('moo', shape, external=[(ext_file, 0)])
 
         N = 100
         external = [(ext_file, x * 1000, 1000) for x in range(N)]
@@ -605,14 +603,16 @@ class TestExternal(BaseDataset):
         shape = (6, 100)
         ext_file = self.mktemp()
 
-        for external in [
-            [ext_file],
-            [ext_file, 0],
-            [ext_file, 0, h5f.UNLIMITED],
-            [(ext_file, 0, "h5f.UNLIMITED")],
-            [(ext_file, 0, h5f.UNLIMITED, 0)],
+        for exc_type, external in [
+            (TypeError, [ext_file]),
+            (TypeError, [ext_file, 0]),
+            (TypeError, [ext_file, 0, h5f.UNLIMITED]),
+            (ValueError, [(ext_file,)]),
+            (ValueError, [(ext_file, 0)]),
+            (ValueError, [(ext_file, 0, h5f.UNLIMITED, 0)]),
+            (TypeError, [(ext_file, 0, "h5f.UNLIMITED")]),
         ]:
-            with self.assertRaises(TypeError):
+            with self.assertRaises(exc_type):
                 self.f.create_dataset('foo', shape, external=external)
 
 

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -16,6 +16,10 @@
     2. Type conversion for read and write (currently untested)
 """
 
+try:
+    import pathlib
+except ImportError:
+    pathlib = None
 import sys
 import numpy as np
 import platform
@@ -584,10 +588,17 @@ class TestExternal(BaseDataset):
             contents = fid.read()
         assert contents == testdata.tostring()
 
-    def test_name(self):
-        """ External argument may be a file name only """
+    def test_name_str(self):
+        """ External argument may be a file name str only """
 
         self.f.create_dataset('foo', (6, 100), external=self.mktemp())
+
+    @ut.skipIf(pathlib is None, "pathlib module not installed")
+    def test_name_path(self):
+        """ External argument may be a file name path only """
+
+        self.f.create_dataset('foo', (6, 100),
+                              external=pathlib.Path(self.mktemp()))
 
     def test_multi(self):
         """ External argument may contain multiple tuples """

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -16,10 +16,7 @@
     2. Type conversion for read and write (currently untested)
 """
 
-try:
-    import pathlib
-except ImportError:
-    pathlib = None
+import pathlib
 import sys
 import numpy as np
 import platform
@@ -593,7 +590,6 @@ class TestExternal(BaseDataset):
 
         self.f.create_dataset('foo', (6, 100), external=self.mktemp())
 
-    @ut.skipIf(pathlib is None, "pathlib module not installed")
     def test_name_path(self):
         """ External argument may be a file name path only """
 

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -584,17 +584,18 @@ class TestExternal(BaseDataset):
             contents = fid.read()
         assert contents == testdata.tostring()
 
-    def test_other(self):
-        """ Test other forms of external lists """
+    def test_name(self):
+        """ External argument may be a file name only """
 
-        shape = (6, 100)
+        self.f.create_dataset('foo', (6, 100), external=self.mktemp())
+
+    def test_multi(self):
+        """ External argument may contain multiple tuples """
+
         ext_file = self.mktemp()
-
-        self.f.create_dataset('foo', shape, external=ext_file)
-
         N = 100
         external = [(ext_file, x * 1000, 1000) for x in range(N)]
-        dset = self.f.create_dataset('poo', shape, external=external)
+        dset = self.f.create_dataset('poo', (6, 100), external=external)
         assert len(dset.external) == N
 
     def test_invalid(self):

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -601,7 +601,7 @@ class TestExternal(BaseDataset):
         self.f.create_dataset('car', shape, external=[ext_file, 0, h5f.UNLIMITED])
 
         N = 100
-        external = [(ext_file, x * 1000, (x + 1) * 1000) for x in range(0, N)]
+        external = [(ext_file, x * 1000, 1000) for x in range(N)]
         dset = self.f.create_dataset('poo', shape, external=external)
         assert len(dset.external) == N
 

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -565,7 +565,7 @@ class TestExternal(BaseDataset):
     """
         Feature: Datasets with the external storage property
     """
-    def test_external(self):
+    def test_contents(self):
         """ Create and access an external dataset """
 
         shape = (6, 100)
@@ -579,17 +579,12 @@ class TestExternal(BaseDataset):
 
         assert dset.external is not None
 
-        # verify file was created, and size is correct
-        import os
-        statinfo = os.stat(ext_file)
-        assert statinfo.st_size == testdata.nbytes
-
-        # verify contents
+        # verify file's existence, size, and contents
         with open(ext_file, 'rb') as fid:
             contents = fid.read()
         assert contents == testdata.tostring()
 
-    def test_external_other(self):
+    def test_other(self):
         """ Test other forms of external lists """
 
         shape = (6, 100)
@@ -605,17 +600,19 @@ class TestExternal(BaseDataset):
         dset = self.f.create_dataset('poo', shape, external=external)
         assert len(dset.external) == N
 
-    def test_external_invalid(self):
+    def test_invalid(self):
         """ Test with invalid external lists """
 
         shape = (6, 100)
         ext_file = self.mktemp()
 
-        with self.assertRaises(TypeError):
-            self.f.create_dataset('foo', shape, external=[(ext_file, 0, "h5f.UNLIMITED")])
+        for external in [
+            [(ext_file, 0, "h5f.UNLIMITED")],
+            [(ext_file, 0, h5f.UNLIMITED, 0)],
+        ]:
+            with self.assertRaises(TypeError):
+                self.f.create_dataset('foo', shape, external=external)
 
-        with self.assertRaises(TypeError):
-            self.f.create_dataset('foo', shape, external=[(ext_file, 0, h5f.UNLIMITED, 0)])
 
 class TestAutoCreate(BaseDataset):
 

--- a/news/external-interface.rst
+++ b/news/external-interface.rst
@@ -23,7 +23,7 @@ Deprecations
   * a list containing tuples such as ``(name,)`` and ``(name, offset)`` that
     lack the offset or size.
 
-  Furthermore, the *name*–*offset*–*size* triplets now must be a tuple rather
+  Furthermore, each *name*–*offset*–*size* triplet now must be a tuple rather
   than an arbitrary iterable.  See also the new feature related to the
   ``external`` argument.
 

--- a/news/external-interface.rst
+++ b/news/external-interface.rst
@@ -1,0 +1,48 @@
+New features
+------------
+
+* The ``external`` argument of :meth:`Group.create_dataset`, which argument
+  specifies any external storage for the dataset, accepts more types
+  (:issue:`1260`), as follows:
+
+  * The top-level container may be any iterable, not only a list.
+  * The names of external files may be not only ``str`` but also ``bytes`` or
+    ``os.PathLike`` objects.
+  * The offsets and sizes may be *numpy* integers as well as Python integers.
+
+  See also the deprecation related to the ``external`` argument.
+
+Deprecations
+------------
+
+* The ``external`` argument of :meth:`Group.create_dataset` no longer accepts
+  the following forms (:issue:`1260`):
+
+  * a list containing *name*, [*offset*, [*size*]];
+  * a list containing *name1*, *name2*, …; and
+  * a list containing tuples such as ``(name,)`` and ``(name, offset)`` that
+    lack the offset or size.
+
+  Furthermore, the *name*–*offset*–*size* triplets now must be a tuple rather
+  than an arbitrary iterable.  See also the new feature related to the
+  ``external`` argument.
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
This pull request implements some suggestions for changes to the external storage interface. The significant changes are as follows:

-   Accepts fewer structures of the `external` argument to `Group.create_dataset`. The code here excludes the currently accepted forms
    
    *   list containing *name*, [*offset*, [*size*]],
    *   list containing *name1*, *name2*, … (which `H5Pset_external` rejects anyway), and
    *   list containing tuples such as `(name,)` and `(name, offset)` that lack the offset or size.
    
    It continues to accept the forms
    
    *   *name* and
    *   list of `(name, offset, size)` tuples.

-   Accepts more types within some parts of the `external` argument:

    *   The top-level container may be any iterable instead of only a list.
    *   The *name* may now be not only a `str` but also a `bytes` or `os.PathLike` object.
    *   The *offset* and *size* may be numpy integers as well as Python `int`s.

    However, this code requires a tuple as the container for *name*–*offset*–*size* triplets.

-   In documentation and exception messages, the PR refers to the first tuple element (the name or path of an external file) consistently as "name", like HDF's `H5Pset_external` and `h5p.set_external`, instead of "file" or "filename".

The older commits contain small fixes to code or documentation and could be applied independently of this pull request.