### PR TITLE
Fix: raise ValueError when auto-chunking a scalar dataset

### DIFF
--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -298,6 +298,9 @@ def guess_chunk(shape, maxshape, typesize):
     """
     # pylint: disable=unused-argument
 
+    if shape is None:
+        raise ValueError("Chunks not allowed for empty datasets.")
+
     # For unlimited dimensions we have to guess 1024
     shape = tuple((x if x!=0 else 1024) for i, x in enumerate(shape))
 

--- a/h5py/tests/old/test_dataset.py
+++ b/h5py/tests/old/test_dataset.py
@@ -236,6 +236,12 @@ class TestCreateChunked(BaseDataset):
         dset = self.f.create_dataset('foo', shape=(3,), dtype='S100000000', chunks=True)
         self.assertEqual(dset.chunks, (1,))
 
+    def test_auto_chunks_no_shape(self):
+        """ Auto-chunking of empty datasets not allowed"""
+        with pytest.raises(ValueError) as err:
+            self.f.create_dataset('foo', dtype='S100', chunks=True)
+        assert 'empty' in str(err.value)
+
 
 class TestCreateFillvalue(BaseDataset):
 


### PR DESCRIPTION
instead of crashing with 

```
----> 7     outp.create_dataset('events', dtype='S1000', chunks=True)


~/devel/feedstock/ep2019/virtual/lib/python3.6/site-packages/h5py/_hl/group.py in create_dataset(self, name, shape, dtype, data, **kwds)
    134 
    135         with phil:
--> 136             dsid = dataset.make_new_dset(self, shape, dtype, data, **kwds)
    137             dset = dataset.Dataset(dsid)
    138             if name is not None:

~/devel/feedstock/ep2019/virtual/lib/python3.6/site-packages/h5py/_hl/dataset.py in make_new_dset(parent, shape, dtype, data, chunks, compression, shuffle, fletcher32, maxshape, compression_opts, fillvalue, scaleoffset, track_times, external, track_order, dcpl)
    138         dcpl or h5p.create(h5p.DATASET_CREATE), shape, dtype,
    139         chunks, compression, compression_opts, shuffle, fletcher32,
--> 140         maxshape, scaleoffset, external)
    141 
    142     if fillvalue is not None:

~/devel/feedstock/ep2019/virtual/lib/python3.6/site-packages/h5py/_hl/filters.py in fill_dcpl(plist, shape, dtype, chunks, compression, compression_opts, shuffle, fletcher32, maxshape, scaleoffset, external)
    204     (chunks is None and any((shuffle, fletcher32, compression, maxshape,
    205                              scaleoffset is not None))):
--> 206         chunks = guess_chunk(shape, maxshape, dtype.itemsize)
    207 
    208     if maxshape is True:

~/devel/feedstock/ep2019/virtual/lib/python3.6/site-packages/h5py/_hl/filters.py in guess_chunk(shape, maxshape, typesize)
    303 
    304     # For unlimited dimensions we have to guess 1024
--> 305     shape = tuple((x if x!=0 else 1024) for i, x in enumerate(shape))
    306 
    307     ndims = len(shape)

TypeError: 'NoneType' object is not iterable
```