### PR TITLE
Make AttributeManager.create consistent with __setitem__

### DIFF
--- a/docs/whatsnew/2.10.rst
+++ b/docs/whatsnew/2.10.rst
@@ -76,6 +76,7 @@ Bugfixes
   systems (:issue:`1235`).
 - Documented that nested compound types are not currently supported
   (:issue:`1236`).
+- Fixed attribute ``create`` method to be consistent with ``__setattr__`` (:issue:`1265`).
 
 Building h5py
 -------------

--- a/h5py/_hl/attrs.py
+++ b/h5py/_hl/attrs.py
@@ -92,7 +92,7 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
         use a specific type or shape, or to preserve the type of an attribute,
         use the methods create() and modify().
         """
-        self.create(name, data=value, dtype=base.guess_dtype(value))
+        self.create(name, data=value)
 
     @with_phil
     def __delitem__(self, name):
@@ -115,6 +115,8 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
         """
 
         with phil:
+            if dtype is None:  # Guess dtype before modifying data
+                dtype = base.guess_dtype(data)
 
             # First, make sure we have a NumPy array.  We leave the data type
             # conversion for HDF5 to perform (other than the below exception).

--- a/h5py/tests/hl/test_attribute_create.py
+++ b/h5py/tests/hl/test_attribute_create.py
@@ -13,6 +13,7 @@
 
 from __future__ import absolute_import
 
+import six
 import numpy as np
 import h5py
 
@@ -45,6 +46,13 @@ class TestArray(TestCase):
         # See issue 498 discussion
 
         self.f.attrs.create('x', data=42, dtype='i8')
+
+    def test_str(self):
+        # See issue 1057
+        self.f.attrs.create('x', six.unichr(0x03A9))
+        out = self.f.attrs['x']
+        self.assertEqual(out, six.unichr(0x03A9))
+        self.assertIsInstance(out, six.string_types)
 
     def test_tuple_of_unicode(self):
         # Test that a tuple of unicode strings can be set as an attribute. It will


### PR DESCRIPTION
This PR moves the call to `base.guess_dtype` from `AttributeManager.__setitem__` to the beginning of `AttributeManager.create` so that both ways handle the `dtype` in a consistent way.

This closes #1057