### PR TITLE
Fix python setup.py test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,12 +70,17 @@ class test(Command):
         buildobj.run()
 
         oldpath = sys.path
+        oldcwd = os.getcwd()
+        build_lib_dir = op.abspath(buildobj.build_lib)
         try:
-            sys.path = [op.abspath(buildobj.build_lib)] + oldpath
+            sys.path = [build_lib_dir] + oldpath
+            os.chdir(build_lib_dir)
+
             import h5py
             sys.exit(h5py.run_tests())
         finally:
             sys.path = oldpath
+            os.chdir(oldcwd)
 
 
 CMDCLASS = {'build_ext': setup_build.h5py_build_ext,


### PR DESCRIPTION
This PR changes the current working directory in `setup.py` before calling `h5py.run_tests` in order to load `h5py` from `build/lib-*` during the test.
Changing `sys.path` is not enough since tests are run as a subprocess.
`python -m pytest` (used by `run_tests`) adds the current working directory to `sys.path` which makes it works.

closes #1266