### PR TITLE
Get low-level AttrID from high-level attributes interface

### DIFF
--- a/docs/high/attr.rst
+++ b/docs/high/attr.rst
@@ -91,6 +91,11 @@ Reference
 
         Retrieve `name`, or `default` if no such attribute exists.
 
+    .. method:: get_id(name)
+
+       Get the low-level :class:`AttrID <low:h5py.h5a.AttrID>` for the named
+       attribute.
+
     .. method:: create(name, data, shape=None, dtype=None)
 
         Create a new attribute, with control over the shape and type.  Any

--- a/h5py/_hl/attrs.py
+++ b/h5py/_hl/attrs.py
@@ -84,6 +84,11 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
             return arr[()]
         return arr
 
+    def get_id(self, name):
+        """Get a low-level AttrID object for the named attribute.
+        """
+        return h5a.open(self._id, self._e(name))
+
     @with_phil
     def __setitem__(self, name, value):
         """ Set a new attribute, overwriting any existing attribute.

--- a/h5py/tests/old/test_attrs.py
+++ b/h5py/tests/old/test_attrs.py
@@ -80,6 +80,13 @@ class TestAccess(BaseAttrs):
         with self.assertRaises(KeyError):
             self.f.attrs['a']
 
+    def test_get_id(self):
+        self.f.attrs['a'] = 4.0
+        aid = self.f.attrs.get_id('a')
+        assert isinstance(aid, h5a.AttrID)
+
+        with self.assertRaises(KeyError):
+            self.f.attrs.get_id('b')
 
 class TestDelete(BaseAttrs):
 


### PR DESCRIPTION
With a new public method:

```python
aid = ds.attrs.get_id('a')
aid.get_type()  # example AttrID method
```

Closes #797.