### PR TITLE
use MPI-aware temp files for mpio tests

### DIFF
--- a/h5py/tests/common.py
+++ b/h5py/tests/common.py
@@ -67,6 +67,16 @@ class TestCase(ut.TestCase):
             dir = self.tempdir
         return tempfile.mktemp(suffix, prefix, dir=self.tempdir)
 
+    def mktemp_mpi(self, comm=None, suffix='.hdf5', prefix='', dir=None):
+        if comm is None:
+            from mpi4py import MPI
+            comm = MPI.COMM_WORLD
+        fname = None
+        if comm.Get_rank() == 0:
+            fname = self.mktemp(suffix, prefix, dir)
+        fname = comm.bcast(fname, 0)
+        return fname
+
     def setUp(self):
         self.f = h5py.File(self.mktemp(), 'w')
 

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -260,8 +260,9 @@ class TestDrivers(TestCase):
         """ MPIO driver and options """
         from mpi4py import MPI
 
-        fname = self.mktemp()
-        with File(fname, 'w', driver='mpio', comm=MPI.COMM_WORLD) as f:
+        comm=MPI.COMM_WORLD
+        fname = self.mktemp_mpi(comm)
+        with File(fname, 'w', driver='mpio', comm=comm) as f:
             self.assertTrue(f)
             self.assertEqual(f.driver, 'mpio')
 
@@ -272,8 +273,9 @@ class TestDrivers(TestCase):
         """ Enable atomic mode for MPIO driver """
         from mpi4py import MPI
 
-        fname = self.mktemp()
-        with File(fname, 'w', driver='mpio', comm=MPI.COMM_WORLD) as f:
+        comm=MPI.COMM_WORLD
+        fname = self.mktemp_mpi(comm)
+        with File(fname, 'w', driver='mpio', comm=comm) as f:
             self.assertFalse(f.atomic)
             f.atomic = True
             self.assertTrue(f.atomic)
@@ -583,8 +585,9 @@ class TestClose(TestCase):
         """ MPIO driver and options """
         from mpi4py import MPI
 
-        fname = self.mktemp()
-        f = File(fname, 'w', driver='mpio', comm=MPI.COMM_WORLD)
+        comm=MPI.COMM_WORLD
+        fname = self.mktemp_mpi(comm)
+        f = File(fname, 'w', driver='mpio', comm=comm)
         f.create_group("test")
         f.close()
         f.close()


### PR DESCRIPTION
MPI (driver=mpio) file tests currently hang since mktemp() is used to
generate a temporary file which is different for each process. mpio
files must have the same name for all processes.

This patch ensures only one temporary file is generated for mpio tests
and used by all processes.  Pattern adapted from mpi4py tests, see
https://bitbucket.org/mpi4py/mpi4py/src/master/test/test_io.py

Closes: #1285