### PR TITLE
Require Python >= 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,25 +30,6 @@ matrix:
     # needed to work around https://github.com/travis-ci/travis-ci/issues/4794
     # TODO: We should see if we can replace this with installing python via pyenv # based on toxenv
 
-    # Python 3.5
-    - python: 3.5
-      env:
-      - TOXENV=py35-test-deps
-    - python: 3.5
-      env:
-      - TOXENV=py35-test-mindeps
-    - python: 3.5
-      env:
-      - TOXENV=py35-test-deps
-        TOX_TESTENV_PASSENV=LANG LC_ALL
-        LANG=C
-        LC_ALL=C
-    - python: 3.5
-      env:
-      - TOXENV=py35-test-deps
-        HDF5_VERSION=1.10.1
-        HDF5_DIR=$HDF5_CACHE_DIR/$HDF5_VERSION
-
     # Python 3.6
     - python: 3.6
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,44 +30,6 @@ matrix:
     # needed to work around https://github.com/travis-ci/travis-ci/issues/4794
     # TODO: We should see if we can replace this with installing python via pyenv # based on toxenv
 
-    # Python 2.7
-    - python: 2.7
-      env:
-      - TOXENV=py27-test-deps
-    - python: 2.7
-      env:
-      - TOXENV=py27-test-mindeps
-    - python: 2.7
-      env:
-      - TOXENV=py27-test-deps
-        TOX_TESTENV_PASSENV=LANG LC_ALL
-        LANG=C
-        LC_ALL=C
-    - python: 2.7
-      env:
-      - TOXENV=py27-test-deps
-        HDF5_VERSION=1.10.1
-        HDF5_DIR=$HDF5_CACHE_DIR/$HDF5_VERSION
-
-    # Python 3.4
-    - python: 3.4
-      env:
-      - TOXENV=py34-test-deps
-    - python: 3.4
-      env:
-      - TOXENV=py34-test-mindeps
-    - python: 3.4
-      env:
-      - TOXENV=py34-test-deps
-        TOX_TESTENV_PASSENV=LANG LC_ALL
-        LANG=C
-        LC_ALL=C
-    - python: 3.4
-      env:
-      - TOXENV=py34-test-deps
-        HDF5_VERSION=1.10.1
-        HDF5_DIR=$HDF5_CACHE_DIR/$HDF5_VERSION
-
     # Python 3.5
     - python: 3.5
       env:
@@ -125,17 +87,6 @@ matrix:
 
     # MPI tests
     # TODO: We should test with newer versions of HDF5
-    - python: 2.7
-      env:
-      - TOXENV=py27-test-mindeps-mpi4py
-      - CC="mpicc"
-      - HDF5_MPI="ON"
-      addons:
-        apt:
-          packages:
-            - openmpi-bin         # 1.6.5 based on trusty
-            - libopenmpi-dev
-            - libhdf5-openmpi-dev # 1.8.11 based on trusty
     - python: 3.6
       env:
       - TOXENV=py36-test-mindeps-mpi4py

--- a/AUTHORS
+++ b/AUTHORS
@@ -121,5 +121,3 @@ Authors are sorted by number of commits.
 * Niru Maheswaranathan
 * Paco Hope
 * Felix Yan
-
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,10 +58,10 @@ environment:
 install:
   # We need wheel installed to build wheels
   - "%PYTHON%\\python.exe -m pip install --upgrade wheel pip setuptools"
-  - "py -3.5 -m pip install --upgrade wheel pip setuptools virtualenv"
-  - "py -3.5 -m pip install requests"
-  - "py -3.5 ci\\appveyor\\get_hdf5.py"
-  - "py -3.5 -m pip install tox codecov tox-appveyor"
+  - "py -3.6 -m pip install --upgrade wheel pip setuptools virtualenv"
+  - "py -3.6 -m pip install requests"
+  - "py -3.6 ci\\appveyor\\get_hdf5.py"
+  - "py -3.6 -m pip install tox codecov tox-appveyor"
 
 build: off
 
@@ -73,7 +73,7 @@ test_script:
   # Note that you must use the environment variable %PYTHON% to refer to
   # the interpreter you're using - Appveyor does not do anything special
   # to put the Python evrsion you want to use on PATH.
-  - "ci\\appveyor\\build.cmd py -3.5 -m tox -v"
+  - "ci\\appveyor\\build.cmd py -3.6 -m tox -v"
 
 # This is commented out as there's no easy way to deal with numpy dropping
 # older python versions without a recent pip/setuptools.
@@ -93,4 +93,4 @@ cache:
   - "C:\\hdf5"
 
 on_success:
-  - "py -3.5 -m codecov"
+  - "py -3.6 -m codecov"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,19 @@ environment:
       HDF5_VSVERSION: "14"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
 
+    - PYTHON: "C:\\Python37"
+      TOXENV: "py37-test-deps"
+      HDF5_VSVERSION: "14"
+      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
+
     - PYTHON: "C:\\Python36-x64"
       TOXENV: "py36-test-deps"
       TOX_APPVEYOR_X64: "1"
+      HDF5_VSVERSION: "14-64"
+      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
+
+    - PYTHON: "C:\\Python37"
+      TOXENV: "py37-test-deps"
       HDF5_VSVERSION: "14-64"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
 
@@ -25,8 +35,21 @@ environment:
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
       HDF5_VERSION: "1.10.1"
 
+    - PYTHON: "C:\\Python37"
+      TOXENV: "py37-test-deps"
+      HDF5_VSVERSION: "14"
+      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
+      HDF5_VERSION: "1.10.1"
+
     - PYTHON: "C:\\Python36-x64"
       TOXENV: "py36-test-deps"
+      TOX_APPVEYOR_X64: "1"
+      HDF5_VSVERSION: "14-64"
+      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
+      HDF5_VERSION: "1.10.1"
+
+    - PYTHON: "C:\\Python37-x64"
+      TOXENV: "py37-test-deps"
       TOX_APPVEYOR_X64: "1"
       HDF5_VSVERSION: "14-64"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,20 +6,9 @@ environment:
   matrix:
 
     ### USING HDF5 1.8 ###
-    - PYTHON: "C:\\Python35"
-      TOXENV: "py35-test-deps"
-      HDF5_VSVERSION: "14"
-      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
-
     - PYTHON: "C:\\Python36"
       TOXENV: "py36-test-deps"
       HDF5_VSVERSION: "14"
-      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
-
-    - PYTHON: "C:\\Python35-x64"
-      TOXENV: "py35-test-deps"
-      TOX_APPVEYOR_X64: "1"
-      HDF5_VSVERSION: "14-64"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
 
     - PYTHON: "C:\\Python36-x64"
@@ -29,22 +18,10 @@ environment:
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
 
     ### USING HDF5 1.10 ###
-    - PYTHON: "C:\\Python35"
-      TOXENV: "py35-test-deps"
-      HDF5_VSVERSION: "14"
-      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
-      HDF5_VERSION: "1.10.1"
 
     - PYTHON: "C:\\Python36"
       TOXENV: "py36-test-deps"
       HDF5_VSVERSION: "14"
-      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
-      HDF5_VERSION: "1.10.1"
-
-    - PYTHON: "C:\\Python35-x64"
-      TOXENV: "py35-test-deps"
-      TOX_APPVEYOR_X64: "1"
-      HDF5_VSVERSION: "14-64"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
       HDF5_VERSION: "1.10.1"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ environment:
       HDF5_VSVERSION: "14-64"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
 
-    - PYTHON: "C:\\Python37"
+    - PYTHON: "C:\\Python37-x64"
       TOXENV: "py37-test-deps"
       HDF5_VSVERSION: "14-64"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,7 @@ environment:
 
     - PYTHON: "C:\\Python37-x64"
       TOXENV: "py37-test-deps"
+      TOX_APPVEYOR_X64: "1"
       HDF5_VSVERSION: "14-64"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,16 +6,6 @@ environment:
   matrix:
 
     ### USING HDF5 1.8 ###
-    - PYTHON: "C:\\Python27"
-      TOXENV: "py27-test-deps"
-      HDF5_VSVERSION: "9"
-      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
-
-    - PYTHON: "C:\\Python34"
-      TOXENV: "py34-test-deps"
-      HDF5_VSVERSION: "10"
-      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
-
     - PYTHON: "C:\\Python35"
       TOXENV: "py35-test-deps"
       HDF5_VSVERSION: "14"
@@ -24,19 +14,6 @@ environment:
     - PYTHON: "C:\\Python36"
       TOXENV: "py36-test-deps"
       HDF5_VSVERSION: "14"
-      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
-
-    - PYTHON: "C:\\Python27-x64"
-      TOXENV: "py27-test-deps"
-      TOX_APPVEYOR_X64: "1"
-      HDF5_VSVERSION: "9-64"
-      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
-
-    - PYTHON: "C:\\Python34-x64"
-      TOXENV: "py34-test-deps"
-      TOX_APPVEYOR_X64: "1"
-      HDF5_VSVERSION: "10-64"
-      DISTUTILS_USE_SDK: "1"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
 
     - PYTHON: "C:\\Python35-x64"
@@ -52,12 +29,6 @@ environment:
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
 
     ### USING HDF5 1.10 ###
-    - PYTHON: "C:\\Python27"
-      TOXENV: "py27-test-deps"
-      HDF5_VSVERSION: "9"
-      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
-      HDF5_VERSION: "1.10.1"
-
     - PYTHON: "C:\\Python35"
       TOXENV: "py35-test-deps"
       HDF5_VSVERSION: "14"
@@ -67,13 +38,6 @@ environment:
     - PYTHON: "C:\\Python36"
       TOXENV: "py36-test-deps"
       HDF5_VSVERSION: "14"
-      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
-      HDF5_VERSION: "1.10.1"
-
-    - PYTHON: "C:\\Python27-x64"
-      TOXENV: "py27-test-deps"
-      TOX_APPVEYOR_X64: "1"
-      HDF5_VSVERSION: "9-64"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
       HDF5_VERSION: "1.10.1"
 

--- a/setup.py
+++ b/setup.py
@@ -156,6 +156,6 @@ setup(
   ext_modules = [Extension('h5py.x',['x.c'])],  # To trick build into running build_ext
   install_requires = RUN_REQUIRES,
   setup_requires = SETUP_REQUIRES if use_setup_requires else [],
-  python_requires='>=3.5',
+  python_requires='>=3.6',
   cmdclass = CMDCLASS,
 )

--- a/setup.py
+++ b/setup.py
@@ -156,5 +156,6 @@ setup(
   ext_modules = [Extension('h5py.x',['x.c'])],  # To trick build into running build_ext
   install_requires = RUN_REQUIRES,
   setup_requires = SETUP_REQUIRES if use_setup_requires else [],
+  python_requires='>=3.5',
   cmdclass = CMDCLASS,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,25 +1,23 @@
 [tox]
 # We want an envlist like
-# envlist = {py27,py34,py35,py36,py37,pypy3}-{test}-{deps,mindeps}-{,mpi4py}-{,pre},nightly,docs,check-manifest,checkreadme
+# envlist = {py36,py37,pypy3}-{test}-{deps,mindeps}-{,mpi4py}-{,pre},nightly,docs,check-manifest,checkreadme
 # but we want to skip mpi and pre by default, so this envlist is below
-envlist = {py35,py36,py37,pypy3}-{test}-{deps,mindeps},nightly,docs,check-manifest,checkreadme
+envlist = {py36,py37,pypy3}-{test}-{deps,mindeps},nightly,docs,check-manifest,checkreadme
 
 [testenv]
 deps =
     test: pytest
     test: pytest-cov
 
-    py{35,36}-deps: cython>=0.23
+    py36-deps: cython>=0.23
     py37-deps: cython>=0.29
 
-    py35-deps: numpy>=1.10.0.post2
     py36-deps: numpy>=1.12
     py37-deps: numpy>=1.14.3
 
-    py{35,36}-mindeps: cython==0.23
+    py36-mindeps: cython==0.23
     py37-mindeps: cython==0.29
 
-    py35-mindeps: numpy==1.10.0.post2
     py36-mindeps: numpy==1.12
     py37-mindeps: numpy==1.14.3
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,28 +2,23 @@
 # We want an envlist like
 # envlist = {py27,py34,py35,py36,py37,pypy3}-{test}-{deps,mindeps}-{,mpi4py}-{,pre},nightly,docs,check-manifest,checkreadme
 # but we want to skip mpi and pre by default, so this envlist is below
-envlist = {py27,py34,py35,py36,py37,pypy3}-{test}-{deps,mindeps},nightly,docs,check-manifest,checkreadme
+envlist = {py35,py36,py37,pypy3}-{test}-{deps,mindeps},nightly,docs,check-manifest,checkreadme
 
 [testenv]
 deps =
     test: pytest
     test: pytest-cov
-    py27-test: unittest2
 
-    py{27,34,35,36}-deps: cython>=0.23
+    py{35,36}-deps: cython>=0.23
     py37-deps: cython>=0.29
 
-    py27-deps: numpy>=1.7
-    py34-deps: numpy>=1.9
     py35-deps: numpy>=1.10.0.post2
     py36-deps: numpy>=1.12
     py37-deps: numpy>=1.14.3
 
-    py{27,34,35,36}-mindeps: cython==0.23
+    py{35,36}-mindeps: cython==0.23
     py37-mindeps: cython==0.29
 
-    py27-mindeps: numpy==1.7
-    py34-mindeps: numpy==1.9
     py35-mindeps: numpy==1.10.0.post2
     py36-mindeps: numpy==1.12
     py37-mindeps: numpy==1.14.3


### PR DESCRIPTION
As discussed in #1177, we're looking to drop Python 2 support now that 2.10 is out. I'm in favour of doing so for 2.11 - I know it seems like a breaking change, but the metadata should mean that most Python 2 users automatically get the last compatible version (`pip install h5py` is smart enough to work this out).

While we're at it, Python 3.4 is also end-of-life, so we may as well drop it. I'd be open to dropping 3.5 as well, but this PR doesn't yet.

Pulling out compatibility code can come later - this just updates the package metadata and trims the CI jobs we no longer need.