### PR TITLE
Hide ds.value attribute from Jedi completion

### DIFF
--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -789,6 +789,14 @@ class Dataset(HLObject):
             return r.encode('utf8')
         return r
 
+    def __dir__(self):
+        names = set(super().__dir__())
+        # ds.value is deprecated, and we want to ensure that Jedi doesn't try
+        # to call the property (https://github.com/h5py/h5py/issues/1312), so
+        # this hides it from tab completions.
+        names.discard('value')
+        return sorted(names)
+
     if hasattr(h5d.DatasetID, "refresh"):
         @with_phil
         def refresh(self):

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1186,3 +1186,13 @@ class TestLowOpen(BaseDataset):
         del dset
         dsid = h5py.h5d.open(self.f.id, b'x', dapl)
         self.assertIsInstance(dsid, h5py.h5d.DatasetID)
+
+
+def test_hide_value_from_jedi():
+    from io import BytesIO
+    buf = BytesIO()
+    with h5py.File(buf, 'w') as fout:
+        fout['test'] = [1, 2, 3]
+        with pytest.warns(UserWarning):
+            assert hasattr(fout['test'], 'value')
+        assert 'value' not in dir(fout['test'])


### PR DESCRIPTION
Since this is deprecated anyway, we may as well hide it from tab completion entirely.

I've checked this manually, but I haven't tried to write an automated test for Jedi's behaviour.

Closes gh-1312