### PR TITLE
CI: Add azure pipelines ci

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,228 @@
+# from matplotlib's azure setup
+
+variables:
+  HDF5_CACHE_DIR: $(Pipeline.Workspace)/cache/hdf5
+  PIP_CACHE_DIR: $(Pipeline.Workspace)/cache/pip
+  CCACHE_DIR: $(Pipeline.Workspace)/cache/ccache
+
+jobs:
+
+- job: 'ubuntu1604'
+  pool:
+    vmImage: ubuntu-16.04
+  strategy:
+    matrix:
+    # system independent tests
+      docs:
+        TOXENV: docs
+        python.version: '3.6'
+      check-manifest:
+        TOXENV: check-manifest
+        python.version: '3.6'
+      checkreadme:
+        TOXENV: checkreadme
+        python.version: '3.6'
+      pre-commit:
+        TOXENV: pre-commit
+        python.version: '3.6'
+    # default tests against supported python version
+      py36-deps:
+        python.version: '3.6'
+        TOXENV: py36-test-deps
+      py37-deps:
+        python.version: '3.7'
+        TOXENV: py37-test-deps
+    # test minimum versions of (python) deps
+      py36-mindeps:
+        python.version: '3.6'
+        TOXENV: py36-test-mindeps
+      py37-mindeps:
+        python.version: '3.7'
+        TOXENV: py37-test-mindeps
+    # test pre-release versions of (python) deps
+      py36-deps-pre:
+        python.version: '3.6'
+        TOXENV: py36-test-deps-pre
+      py37-deps-pre:
+        python.version: '3.7'
+        TOXENV: py37-test-deps-pre
+    # test against newer HDF5
+      py36-deps-hdf51103:
+        python.version: '3.6'
+        TOXENV: py36-test-deps
+        HDF5_VERSION: 1.10.3
+        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
+      py37-deps-hdf51103:
+        python.version: '3.7'
+        TOXENV: py37-test-deps
+        HDF5_VERSION: 1.10.3
+        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
+      py36-deps-hdf51104:
+        python.version: '3.6'
+        TOXENV: py36-test-deps
+        HDF5_VERSION: 1.10.4
+        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
+      py37-deps-hdf51104:
+        python.version: '3.7'
+        TOXENV: py37-test-deps
+        HDF5_VERSION: 1.10.4
+        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
+      py36-deps-hdf51105:
+        python.version: '3.6'
+        TOXENV: py36-test-deps
+        HDF5_VERSION: 1.10.5
+        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
+      py37-deps-hdf51105:
+        python.version: '3.7'
+        TOXENV: py37-test-deps
+        HDF5_VERSION: 1.10.5
+        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
+    # test pytables compat tests
+      py36-mindeps-tables:
+        python.version: '3.6'
+        TOXENV: py36-test-mindeps-tables
+      py37-mindeps-tables:
+        python.version: '3.7'
+        TOXENV: py37-test-mindeps-tables
+    # do mpi tests
+#      py36-deps-hdf51105-mpi:
+#        python.version: '3.6'
+#        TOXENV: py36-test-mindeps-mpi4py
+#        HDF5_VERSION: 1.10.5
+#        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
+#        HDF5_MPI: ON
+#        CC: mpicc
+#      py37-deps-hdf51105-mpi:
+#        python.version: '3.7'
+#        TOXENV: py37-test-mindeps-mpi4py
+#        HDF5_VERSION: 1.10.5
+#        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
+#        HDF5_MPI: ON
+#        CC: mpicc
+    maxParallel: 4
+
+  steps:
+    - template: ci/azure-pipelines-steps.yml
+      parameters:
+        platform: ubuntu
+        installer: apt
+        shell: unix
+
+- job: 'Windows'
+  pool:
+    vmImage: vs2017-win2016
+  strategy:
+    matrix:
+    # default tests against supported python version
+      py36-deps:
+        python.version: '3.6'
+        TOXENV: py36-test-deps
+        HDF5_VERSION: 1.10.1
+        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
+        HDF5_VSVERSION: "15-64"
+      py37-deps:
+        python.version: '3.7'
+        TOXENV: py37-test-deps
+        HDF5_VERSION: 1.10.1
+        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
+        HDF5_VSVERSION: "15-64"
+    # test minimum versions of (python) deps
+      py36-mindeps:
+        python.version: '3.6'
+        TOXENV: py36-test-mindeps
+        HDF5_VERSION: 1.10.1
+        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
+        HDF5_VSVERSION: "15-64"
+      py37-mindeps:
+        python.version: '3.7'
+        TOXENV: py37-test-mindeps
+        HDF5_VERSION: 1.10.1
+        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
+        HDF5_VSVERSION: "15-64"
+    # test pre-release versions of (python) deps
+      py36-deps-pre:
+        python.version: '3.6'
+        TOXENV: py36-test-deps-pre
+        HDF5_VERSION: 1.10.1
+        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
+        HDF5_VSVERSION: "15-64"
+      py37-deps-pre:
+        python.version: '3.7'
+        TOXENV: py37-test-deps-pre
+        HDF5_VERSION: 1.10.1
+        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
+        HDF5_VSVERSION: "15-64"
+    maxParallel: 4
+
+  steps:
+    - template: ci/azure-pipelines-steps.yml
+      parameters:
+        platform: windows
+        installer: nuget
+        shell: cmd
+
+- job: 'macOS1013'
+  pool:
+    vmImage: xcode9-macos10.13
+  strategy:
+    matrix:
+    # default tests against supported python version
+      py36-deps:
+        python.version: '3.6'
+        TOXENV: py36-test-deps
+      py37-deps:
+        python.version: '3.7'
+        TOXENV: py37-test-deps
+    # test minimum versions of (python) deps
+      py36-mindeps:
+        python.version: '3.6'
+        TOXENV: py36-test-mindeps
+      py37-mindeps:
+        python.version: '3.7'
+        TOXENV: py37-test-mindeps
+    # test pre-release versions of (python) deps
+      py36-deps-pre:
+        python.version: '3.6'
+        TOXENV: py36-test-deps-pre
+      py37-deps-pre:
+        python.version: '3.7'
+        TOXENV: py37-test-deps-pre
+    # test against newer HDF5
+#      py36-deps-hdf51103:
+#        python.version: '3.6'
+#        TOXENV: py36-test-deps
+#        HDF5_VERSION: 1.10.3
+#        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
+#      py37-deps-hdf51103:
+#        python.version: '3.7'
+#        TOXENV: py37-test-deps
+#        HDF5_VERSION: 1.10.3
+#        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
+#      py36-deps-hdf51104:
+#        python.version: '3.6'
+#        TOXENV: py36-test-deps
+#        HDF5_VERSION: 1.10.4
+#        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
+#      py37-deps-hdf51104:
+#        python.version: '3.7'
+#        TOXENV: py37-test-deps
+#        HDF5_VERSION: 1.10.4
+#        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
+#      py36-deps-hdf51105:
+#        python.version: '3.6'
+#        TOXENV: py36-test-deps
+#        HDF5_VERSION: 1.10.5
+#        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
+#      py37-deps-hdf51105:
+#        python.version: '3.7'
+#        TOXENV: py37-test-deps
+#        HDF5_VERSION: 1.10.5
+#        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
+    maxParallel: 4
+
+  steps:
+    - template: ci/azure-pipelines-steps.yml
+      parameters:
+        platform: macos
+        installer: brew
+        shell: unix

--- a/ci/appveyor/get_hdf5.py
+++ b/ci/appveyor/get_hdf5.py
@@ -38,9 +38,13 @@ VSVERSION_TO_GENERATOR = {
     "9": "Visual Studio 9 2008",
     "10": "Visual Studio 10 2010",
     "14": "Visual Studio 14 2015",
+    "15": "Visual Studio 15 2017",
+    "16": "Visual Studio 16 2019",
     "9-64": "Visual Studio 9 2008 Win64",
     "10-64": "Visual Studio 10 2010 Win64",
     "14-64": "Visual Studio 14 2015 Win64",
+    "15-64": "Visual Studio 15 2017 Win64",
+    "16-64": "Visual Studio 16 2019 Win64",
 }
 
 

--- a/ci/azure-pipelines-steps.yml
+++ b/ci/azure-pipelines-steps.yml
@@ -1,0 +1,63 @@
+parameters:
+  platform: none
+  installer: none
+
+steps:
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '$(python.version)'
+    architecture: 'x64'
+  displayName: 'Use Python $(python.version)'
+  condition: and(succeeded(), ne(variables['python.version'], 'Pre'))
+
+  #- task: stevedower.python.InstallPython.InstallPython@1
+  #  displayName: 'Use prerelease Python'
+  #  inputs:
+  #    prerelease: true
+  #  condition: and(succeeded(), eq(variables['python.version'], 'Pre'))
+
+- ${{ if eq(parameters.installer, 'nuget') }}:
+  - task: NuGetToolInstaller@0
+    displayName: 'Use latest available Nuget'
+
+  - script: |
+      nuget install libpng-msvc14-x64 -ExcludeVersion -OutputDirectory "$(build.BinariesDirectory)"
+      nuget install zlib-msvc14-x64 -ExcludeVersion -OutputDirectory "$(build.BinariesDirectory)"
+      echo ##vso[task.prependpath]$(build.BinariesDirectory)\libpng-msvc14-x64\build\native\bin_release
+      echo ##vso[task.prependpath]$(build.BinariesDirectory)\zlib-msvc14-x64\build\native\bin_release
+      echo ##vso[task.setvariable variable=CL]/I$(build.BinariesDirectory)\libpng-msvc14-x64\build\native\include /I$(build.BinariesDirectory)\zlib-msvc14-x64\build\native\include
+      echo ##vso[task.setvariable variable=LINK]/LIBPATH:$(build.BinariesDirectory)\libpng-msvc14-x64\build\native\lib_release /LIBPATH:$(build.BinariesDirectory)\zlib-msvc14-x64\build\native\lib_release
+    displayName: 'Install dependencies with nuget'
+- ${{ if eq(parameters.installer, 'brew') }}:
+  - script: |
+      brew install pkg-config hdf5 ccache open-mpi
+    displayName: 'Install dependencies with brew'
+- ${{ if eq(parameters.installer, 'apt') }}:
+  - script: |
+      sudo apt-get install libhdf5-serial-dev ccache openmpi-bin libopenmpi-dev
+    displayName: 'Install dependencies with apt'
+
+- script: |
+    python -m pip install --upgrade pip
+    pip install tox codecov
+  displayName: 'Install dependencies with pip'
+
+- script: env
+  displayName: 'print env'
+
+- ${{ if eq(parameters.shell, 'unix') }}:
+    - script: |
+        ./ci/travis/get_hdf5_if_needed.sh
+      displayName: 'ensure HDF5'
+- ${{ if eq(parameters.shell, 'cmd') }}:
+    - script: |
+        py -3.7 -m pip install requests
+        py -3.7 ci\\appveyor\\get_hdf5.py
+      displayName: 'ensure HDF5'
+
+- script: env
+  displayName: 'print env'
+
+- script: |
+    tox
+  displayName: 'tox'

--- a/ci/azure-pipelines-steps.yml
+++ b/ci/azure-pipelines-steps.yml
@@ -61,3 +61,7 @@ steps:
 - script: |
     tox
   displayName: 'tox'
+
+- script: |
+    codecov
+  displayName: 'codecov'


### PR DESCRIPTION
Assuming the rebased version passes, this should be ready to merge. The commented out sections currently do not pass (for a number of reasons as noted below), but it's probably worth having a framework that works rather than waiting on those final fixes (and this adds macOS to the systems we are running a CI on)
Some comments:
* On some OSes/setups newer HDF5 fails, so we'll need to look into that
* Building HDF5 from source is failing on macOS for some reason, those tests are commented out, but we should work out why we fail to build on macOS
* Caching isn't set up yet (we may want to wait until the feature stabilises)
* I haven't added every test on travis yet, so don't stop testing on travis (I'll create a PR once this is merged which drop unneeded travis tests)
* This is currently only running 64-bit tests, I haven't worked out where exactly to specify bit-size yet, so don't stop testing on appveyor (I'll also create a PR to drop unneeded appveyor tests) 