### PR TITLE
Added 'value attribute' to list of attributes

### DIFF
--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -15,6 +15,7 @@ NumPy operations like slicing, along with a variety of descriptive attributes:
   - **shape** attribute
   - **size** attribute
   - **dtype** attribute
+  - **value** attribute
 
 h5py supports most NumPy dtypes, and uses the same character codes (e.g.
 ``'f'``, ``'i8'``) and dtype machinery as


### PR DESCRIPTION
There was no mention of the value attribute. While this attribute can be usefull in many use cases where there's a difference between the data in the dataset, and a HDF5Dataset object

```
print(dset)
> <HDF5 dataset "dset": shape (), type "|S3130">
```
```
print(dset.value)
> b'\x80\x03csklearn.neighbors.kd_tree\nnewObj\nq\x00csklearn.neighbors.kd_tree...
```