### PR TITLE
Allow dset.astype() to be indexed, not only used as a context manager

### DIFF
--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -399,14 +399,20 @@ Reference
 
     .. method:: astype(dtype)
 
-        Return a context manager allowing you to read data as a particular
+        Return a wrapper allowing you to read data as a particular
         type.  Conversion is handled by HDF5 directly, on the fly::
 
             >>> dset = f.create_dataset("bigint", (1000,), dtype='int64')
-            >>> with dset.astype('int16'):
-            ...     out = dset[:]
+            >>> out = dset.astype('int16')[:]
             >>> out.dtype
             dtype('int16')
+
+        .. versionchanged:: 3.0
+           Allowed reading through the wrapper object. In earlier versions,
+           :meth:`astype` had to be used as a context manager:
+
+               >>> with dset.astype('int16'):
+               ...     out = dset[:]
 
     .. method:: resize(size, axis=None)
 

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -247,11 +247,10 @@ class Dataset(HLObject):
     """
 
     def astype(self, dtype):
-        """ Get a context manager allowing you to perform reads to a
+        """ Get a wrapper allowing you to perform reads to a
         different destination type, e.g.:
 
-        >>> with dataset.astype('f8'):
-        ...     double_precision = dataset[0:100:2]
+        >>> double_precision = dataset.astype('f8')[0:100:2]
         """
         return AstypeWrapper(self, dtype)
 

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -201,19 +201,20 @@ def make_new_virtual_dset(parent, shape, sources, dtype=None,
                       dcpl=dcpl)
 
 
-class AstypeContext(object):
-
+class AstypeWrapper(object):
+    """Wrapper to convert data on reading from a dataset.
     """
-        Context manager which allows changing the type read from a dataset.
-    """
-
     def __init__(self, dset, dtype):
         self._dset = dset
         self._dtype = numpy.dtype(dtype)
 
+    def __getitem__(self, args):
+        return self._dset.__getitem__(args, new_dtype=self._dtype)
+
     def __enter__(self):
         # pylint: disable=protected-access
         self._dset._local.astype = self._dtype
+        return self
 
     def __exit__(self, *args):
         # pylint: disable=protected-access
@@ -252,7 +253,7 @@ class Dataset(HLObject):
         >>> with dataset.astype('f8'):
         ...     double_precision = dataset[0:100:2]
         """
-        return AstypeContext(self, dtype)
+        return AstypeWrapper(self, dtype)
 
     if MPI:
         @property
@@ -469,7 +470,7 @@ class Dataset(HLObject):
             yield self[i]
 
     @with_phil
-    def __getitem__(self, args):
+    def __getitem__(self, args, new_dtype=None):
         """ Read a slice from the HDF5 dataset.
 
         Takes slices and recarray-style field names (more than one is
@@ -490,7 +491,9 @@ class Dataset(HLObject):
         names = tuple(x for x in args if isinstance(x, str))
         args = tuple(x for x in args if not isinstance(x, str))
 
-        new_dtype = getattr(self._local, 'astype', None)
+        if new_dtype is None:
+            new_dtype = getattr(self._local, 'astype', None)
+
         if new_dtype is not None:
             new_dtype = readtime_dtype(new_dtype, names)
         else:

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1014,19 +1014,22 @@ class TestRegionRefs(BaseDataset):
 
 
 class TestAstype(BaseDataset):
-
+    """.astype() wrapper & context manager
     """
-        .astype context manager
-    """
-
-    def test_astype(self):
-
+    def test_astype_ctx(self):
         dset = self.f.create_dataset('x', (100,), dtype='i2')
         dset[...] = np.arange(100)
         with dset.astype('f8'):
-            self.assertEqual(dset[...].dtype, np.dtype('f8'))
-            self.assertTrue(np.all(dset[...] == np.arange(100)))
+            self.assertArrayEqual(dset[...], np.arange(100, dtype='f8'))
 
+        with dset.astype('f4') as f4ds:
+            self.assertArrayEqual(f4ds[...], np.arange(100, dtype='f4'))
+
+    def test_astype_wrapper(self):
+        dset = self.f.create_dataset('x', (100,), dtype='i2')
+        dset[...] = np.arange(100)
+        arr = dset.astype('f4')[:]
+        self.assertArrayEqual(arr, np.arange(100, dtype='f4'))
 
 class TestScalarCompound(BaseDataset):
 

--- a/news/astype-wrapper.rst
+++ b/news/astype-wrapper.rst
@@ -1,0 +1,31 @@
+New features
+------------
+
+* Casting data to a specified type on reading can now be done more easily,
+  with code like ``data = dset.astype(np.int32)[:]``, removing the need for a
+  ``with`` statement.
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
```python
with dset.astype(np.float32):
    arr = dset[:]

# Becomes:
arr = dset.astype(np.float32)[:]
```

The context manager still works, and you can also get an `as` object to slice. But I'd push people towards using the stateless version without a context manager.

`__getitem__` with optional keyword argument is... debatable. We can change that if preferred. :wink: 