### PR TITLE
Fix getting maxshape on empty datasets

### DIFF
--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -377,6 +377,9 @@ class Dataset(HLObject):
         None have no resize limit. """
         space = self.id.get_space()
         dims = space.get_simple_extent_dims(True)
+        if dims is None:
+            return None
+
         return tuple(x if x != h5s.UNLIMITED else None for x in dims)
 
     @property

--- a/h5py/tests/conftest.py
+++ b/h5py/tests/conftest.py
@@ -1,0 +1,8 @@
+import h5py
+import pytest
+
+
+@pytest.fixture()
+def writable_file(tmp_path):
+    with h5py.File(tmp_path / 'test.h5', 'w') as f:
+        yield f

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1189,3 +1189,9 @@ def test_hide_value_from_jedi():
         with pytest.warns(UserWarning):
             assert hasattr(fout['test'], 'value')
         assert 'value' not in dir(fout['test'])
+
+
+def test_empty_shape(writable_file):
+    ds = writable_file.create_dataset('empty', dtype='int32')
+    assert ds.shape is None
+    assert ds.maxshape is None

--- a/news/empty-maxshape.rst
+++ b/news/empty-maxshape.rst
@@ -1,0 +1,29 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* Fix getting ``dset.maxshape`` on empty/null datasets.
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
I'd expect `ds.maxshape` to return None, the same as `ds.shape`. It currently throws an error as it tries to iterate over None.