### PR TITLE
Change default file mode to 'r' (read-only)

### DIFF
--- a/docs/high/file.rst
+++ b/docs/high/file.rst
@@ -22,13 +22,16 @@ use.  However, there is obviously no concept of "text" vs "binary" mode.
 The file name may be a byte string or unicode string. Valid modes are:
 
     ========  ================================================
-     r        Readonly, file must exist
+     r        Readonly, file must exist (default)
      r+       Read/write, file must exist
      w        Create file, truncate if exists
      w- or x  Create file, fail if exists
-     a        Read/write if exists, create otherwise (default)
+     a        Read/write if exists, create otherwise
     ========  ================================================
 
+.. versionchanged:: 3.0
+   Files are now opened read-only by default. Earlier versions of h5py would
+   pick different modes depending on the presence and permissions of the file.
 
 .. _file_driver:
 

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -185,23 +185,6 @@ def make_fid(name, mode, userblock_size, fapl, fcpl=None, swmr=False):
             fid = h5f.open(name, h5f.ACC_RDWR, fapl=fapl)
         except IOError:
             fid = h5f.create(name, h5f.ACC_EXCL, fapl=fapl, fcpl=fcpl)
-    elif mode is None:
-        warn("The default file mode will change to 'r' (read-only) in h5py 3.0. "
-             "To suppress this warning, pass the mode you need to h5py.File(), "
-             "or set the global default h5.get_config().default_file_mode, "
-             "or set the environment variable H5PY_DEFAULT_READONLY=1. "
-             "Available modes are: 'r', 'r+', 'w', 'w-'/'x', 'a'. "
-             "See the docs for details.", H5pyDeprecationWarning, stacklevel=3)
-        # Try to open in append mode (read/write).
-        # If that fails, try readonly, and finally create a new file only
-        # if it won't clobber an existing file (ACC_EXCL).
-        try:
-            fid = h5f.open(name, h5f.ACC_RDWR, fapl=fapl)
-        except IOError:
-            try:
-                fid = h5f.open(name, h5f.ACC_RDONLY, fapl=fapl)
-            except IOError:
-                fid = h5f.create(name, h5f.ACC_EXCL, fapl=fapl, fcpl=fcpl)
     else:
         raise ValueError("Invalid mode; must be one of r, r+, w, w-, x, a")
 
@@ -327,11 +310,11 @@ class File(Group):
             created with the 'core' driver, HDF5 still requires this be
             non-empty.
         mode
-            r        Readonly, file must exist
+            r        Readonly, file must exist (default)
             r+       Read/write, file must exist
             w        Create file, truncate if exists
             w- or x  Create file, fail if exists
-            a        Read/write if exists, create otherwise (default)
+            a        Read/write if exists, create otherwise
         driver
             Name of the driver to use.  Legal values are None (default,
             recommended), 'core', 'sec2', 'stdio', 'mpio'.
@@ -397,9 +380,7 @@ class File(Group):
             if track_order is None:
                 track_order = h5.get_config().track_order
             if mode is None:
-                mode = h5.get_config().default_file_mode
-                if mode is None and os.environ.get('H5PY_DEFAULT_READONLY', ''):
-                    mode = 'r'
+                mode = h5.get_config().default_file_mode  # default: 'r'
 
             with phil:
                 fapl = make_fapl(driver, libver, rdcc_nslots, rdcc_nbytes, rdcc_w0, **kwds)

--- a/h5py/h5.pyx
+++ b/h5py/h5.pyx
@@ -60,7 +60,7 @@ cdef class H5PYConfig:
         self._t_name = b'TRUE'
         self._bytestrings = ByteStringContext()
         self._track_order = False
-        self._default_file_mode = None
+        self._default_file_mode = 'r'
 
     property complex_names:
         """ Settable 2-tuple controlling how complex numbers are saved.
@@ -153,10 +153,10 @@ cdef class H5PYConfig:
             return self._default_file_mode
 
         def __set__(self, val):
-            if val is None or val in {'r', 'r+', 'x', 'w-', 'w', 'a'}:
+            if val in {'r', 'r+', 'x', 'w-', 'w', 'a'}:
                 self._default_file_mode = val
             else:
-                raise ValueError("Invalid mode; must be one of r, r+, w, w-, x, a or None")
+                raise ValueError("Invalid mode; must be one of r, r+, w, w-, x, a")
 
 cdef H5PYConfig cfg = H5PYConfig()
 

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -40,32 +40,32 @@ class TestFileOpen(TestCase):
         """ Default semantics in the presence or absence of a file """
         fname = self.mktemp()
 
-        # No existing file; create a new file and open RW
-        with pytest.warns(H5pyDeprecationWarning):
-            with File(fname) as f:
-                self.assertTrue(f)
-                self.assertEqual(f.mode, 'r+')
+        # No existing file; error
+        with pytest.raises(OSError):
+            with File(fname):
+                pass
+
 
         # Existing readonly file; open read-only
+        with File(fname, 'w'):
+            pass
         os.chmod(fname, stat.S_IREAD)
         # Running as root (e.g. in a docker container) gives 'r+' as the file
         # mode, even for a read-only file.  See
         # https://github.com/h5py/h5py/issues/696
         exp_mode = 'r+' if os.stat(fname).st_uid == 0 and platform != "win32" else 'r'
         try:
-            with pytest.warns(H5pyDeprecationWarning):
-                with File(fname) as f:
-                    self.assertTrue(f)
-                    self.assertEqual(f.mode, exp_mode)
+            with File(fname) as f:
+                self.assertTrue(f)
+                self.assertEqual(f.mode, exp_mode)
         finally:
             os.chmod(fname, stat.S_IWRITE)
 
         # File exists but is not HDF5; raise IOError
         with open(fname, 'wb') as f:
             f.write(b'\x00')
-        with pytest.warns(H5pyDeprecationWarning):
-            with self.assertRaises(IOError):
-                File(fname)
+        with self.assertRaises(IOError):
+            File(fname)
 
     def test_create(self):
         """ Mode 'w' opens file in overwrite mode """

--- a/news/default-mode-r.rst
+++ b/news/default-mode-r.rst
@@ -1,0 +1,30 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* The default mode for opening files is now 'r' (read-only).
+  See :ref:`file_open` for other possible modes if you need to write to a file.
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
Closes #397

To briefly recap some of the reasons discussed there:

- Code which lacks permission to write to a file should fail when it tries to open the file with a suitable mode, not later when it tries to modify a file which had fallen back to read-only
- Making a typo trying to open an existing file should get you an error, not a new file
- Opening HDF5 files for writing locks them so no-one else can open them
- Opening a file read/write may [break access to virtual datasets](https://forum.hdfgroup.org/t/virtual-dataset-in-read-write-file-missing-data-from-read-only-file/5647)
- Read-only by default matches Python's built-in `open()` function