### PR TITLE
Drop and combine some testing combinations on Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,39 +13,19 @@ jobs:
   strategy:
     matrix:
     # system independent tests
-      docs:
-        TOXENV: docs
+      static-checks:
+        TOXENV: docs,check-manifest,checkreadme,pre-commit
         python.version: '3.6'
-      check-manifest:
-        TOXENV: check-manifest
+      # -deps : test with default (latest) versions of dependencies
+      # -mindeps : test with oldest supported version of (python) dependencies
+      # -deps-pre : test pre-release versions of (python) dependencies)
+      # -tables : also check compatibility with pytables
+      py36:
         python.version: '3.6'
-      checkreadme:
-        TOXENV: checkreadme
-        python.version: '3.6'
-      pre-commit:
-        TOXENV: pre-commit
-        python.version: '3.6'
-    # default tests against supported python version
-      py36-deps:
-        python.version: '3.6'
-        TOXENV: py36-test-deps
-      py37-deps:
+        TOXENV: py36-test-deps,py36-test-mindeps,py36-test-deps-pre,py36-test-mindeps-tables
+      py37:
         python.version: '3.7'
-        TOXENV: py37-test-deps
-    # test minimum versions of (python) deps
-      py36-mindeps:
-        python.version: '3.6'
-        TOXENV: py36-test-mindeps
-      py37-mindeps:
-        python.version: '3.7'
-        TOXENV: py37-test-mindeps
-    # test pre-release versions of (python) deps
-      py36-deps-pre:
-        python.version: '3.6'
-        TOXENV: py36-test-deps-pre
-      py37-deps-pre:
-        python.version: '3.7'
-        TOXENV: py37-test-deps-pre
+        TOXENV: py37-test-deps,py37-test-mindeps,py37-test-deps-pre,py37-test-deps-tables
     # test against newer HDF5
       py36-deps-hdf51103:
         python.version: '3.6'
@@ -62,13 +42,6 @@ jobs:
         TOXENV: py37-test-deps
         HDF5_VERSION: 1.10.5
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
-    # test pytables compat tests
-      py36-mindeps-tables:
-        python.version: '3.6'
-        TOXENV: py36-test-mindeps-tables
-      py37-mindeps-tables:
-        python.version: '3.7'
-        TOXENV: py37-test-mindeps-tables
     # do mpi tests
 #      py36-deps-hdf51105-mpi:
 #        python.version: '3.6'
@@ -127,27 +100,15 @@ jobs:
     vmImage: xcode9-macos10.13
   strategy:
     matrix:
-    # default tests against supported python version
-      py36-deps:
+      # -deps : test with default (latest) versions of dependencies
+      # -mindeps : test with oldest supported version of (python) dependencies
+      # -deps-pre : test pre-release versions of (python) dependencies)
+      py36:
         python.version: '3.6'
-        TOXENV: py36-test-deps
+        TOXENV: py36-test-deps,py36-test-mindeps,py36-test-deps-pre
       py37-deps:
         python.version: '3.7'
-        TOXENV: py37-test-deps
-    # test minimum versions of (python) deps
-      py36-mindeps:
-        python.version: '3.6'
-        TOXENV: py36-test-mindeps
-      py37-mindeps:
-        python.version: '3.7'
-        TOXENV: py37-test-mindeps
-    # test pre-release versions of (python) deps
-      py36-deps-pre:
-        python.version: '3.6'
-        TOXENV: py36-test-deps-pre
-      py37-deps-pre:
-        python.version: '3.7'
-        TOXENV: py37-test-deps-pre
+        TOXENV: py37-test-deps,py37-test-mindeps,py37-test-deps-pre
     # test against newer HDF5
 #      py36-deps-hdf51103:
 #        python.version: '3.6'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,25 +52,10 @@ jobs:
         TOXENV: py36-test-deps
         HDF5_VERSION: 1.10.3
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
-      py37-deps-hdf51103:
-        python.version: '3.7'
-        TOXENV: py37-test-deps
-        HDF5_VERSION: 1.10.3
-        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
-      py36-deps-hdf51104:
-        python.version: '3.6'
-        TOXENV: py36-test-deps
-        HDF5_VERSION: 1.10.4
-        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
       py37-deps-hdf51104:
         python.version: '3.7'
         TOXENV: py37-test-deps
         HDF5_VERSION: 1.10.4
-        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
-      py36-deps-hdf51105:
-        python.version: '3.6'
-        TOXENV: py36-test-deps
-        HDF5_VERSION: 1.10.5
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
       py37-deps-hdf51105:
         python.version: '3.7'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,42 +98,18 @@ jobs:
     vmImage: vs2017-win2016
   strategy:
     matrix:
-    # default tests against supported python version
-      py36-deps:
+    # -deps : test with default (latest) versions of dependencies
+    # -mindeps : test with oldest supported version of (python) dependencies
+    # -deps-pre : test pre-release versions of (python) dependencies)
+      py36:
         python.version: '3.6'
-        TOXENV: py36-test-deps
+        TOXENV: py36-test-deps,py36-test-mindeps,py36-test-deps-pre
         HDF5_VERSION: 1.10.1
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         HDF5_VSVERSION: "15-64"
-      py37-deps:
+      py37:
         python.version: '3.7'
-        TOXENV: py37-test-deps
-        HDF5_VERSION: 1.10.1
-        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
-        HDF5_VSVERSION: "15-64"
-    # test minimum versions of (python) deps
-      py36-mindeps:
-        python.version: '3.6'
-        TOXENV: py36-test-mindeps
-        HDF5_VERSION: 1.10.1
-        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
-        HDF5_VSVERSION: "15-64"
-      py37-mindeps:
-        python.version: '3.7'
-        TOXENV: py37-test-mindeps
-        HDF5_VERSION: 1.10.1
-        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
-        HDF5_VSVERSION: "15-64"
-    # test pre-release versions of (python) deps
-      py36-deps-pre:
-        python.version: '3.6'
-        TOXENV: py36-test-deps-pre
-        HDF5_VERSION: 1.10.1
-        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
-        HDF5_VSVERSION: "15-64"
-      py37-deps-pre:
-        python.version: '3.7'
-        TOXENV: py37-test-deps-pre
+        TOXENV: py37-test-deps,py37-test-mindeps,py37-test-deps-pre
         HDF5_VERSION: 1.10.1
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         HDF5_VSVERSION: "15-64"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,7 +106,7 @@ jobs:
       py36:
         python.version: '3.6'
         TOXENV: py36-test-deps,py36-test-mindeps,py36-test-deps-pre
-      py37-deps:
+      py37:
         python.version: '3.7'
         TOXENV: py37-test-deps,py37-test-mindeps,py37-test-deps-pre
     # test against newer HDF5

--- a/ci/azure-pipelines-steps.yml
+++ b/ci/azure-pipelines-steps.yml
@@ -63,5 +63,5 @@ steps:
   displayName: 'tox'
 
 - script: |
-    codecov
+    codecov -t 813fb6da-087d-4b36-a185-5a530cab3455
   displayName: 'codecov'


### PR DESCRIPTION
It's certainly good to test on a range of Python & HDF5 versions, but I think getting timely feedback is more valuable than trying the same things in lots of different combinations, and I've been finding the Azure tests quite slow. Linux jobs in particular seem to be a limiting factor, so I hope trimming a few will speed things up.

cc @aragilar 