### PR TITLE
CI: Add caching to azure

### DIFF
--- a/ci/azure-pipelines-steps.yml
+++ b/ci/azure-pipelines-steps.yml
@@ -34,6 +34,20 @@ steps:
   #    prerelease: true
   #  condition: and(succeeded(), eq(variables['python.version'], 'Pre'))
 
+# apparently azure's caching fails when nothing is added to the cache...
+- script: |
+    python -c "import os; os.makedirs(r'$(PIP_CACHE_DIR)', exist_ok=True); open(r'$(PIP_CACHE_DIR)/temp', 'w')"
+  displayName: 'Fix pip cache'
+
+- script: |
+    python -c "import os; os.makedirs(r'$(HDF5_CACHE_DIR)', exist_ok=True); open(r'$(HDF5_CACHE_DIR)/temp', 'w')"
+  displayName: 'Fix HDF5 cache'
+
+- script: |
+    python -c "import os; os.makedirs(r'$(CCACHE_DIR)', exist_ok=True); open(r'$(CCACHE_DIR)/temp', 'w')"
+  displayName: 'Fix ccache cache'
+
+
 - ${{ if eq(parameters.installer, 'nuget') }}:
   - task: NuGetToolInstaller@0
     displayName: 'Use latest available Nuget'

--- a/ci/azure-pipelines-steps.yml
+++ b/ci/azure-pipelines-steps.yml
@@ -3,6 +3,24 @@ parameters:
   installer: none
 
 steps:
+- task: CacheBeta@0
+  displayName: pip cache
+  inputs:
+    key: pip | $(Agent.OS)
+    path: $(PIP_CACHE_DIR)
+
+- task: CacheBeta@0
+  displayName: HDF5 cache
+  inputs:
+    key: HDF5 | $(Agent.OS)
+    path: $(HDF5_CACHE_DIR)
+
+- task: CacheBeta@0
+  displayName: ccache cache
+  inputs:
+    key: ccache | $(Agent.OS)
+    path: $(CCACHE_DIR)
+
 - task: UsePythonVersion@0
   inputs:
     versionSpec: '$(python.version)'


### PR DESCRIPTION
This tells azure to cache pip's wheel cache, our HDF5 builds and ccache. I suspect we'll need to change this as caching on azure evolves, but lets go with this for now. 