### PR TITLE
Special dtypes API changed in 2.10, not 2.9

### DIFF
--- a/docs/special.rst
+++ b/docs/special.rst
@@ -159,7 +159,7 @@ References have their :ref:`own section <refs>`.
 Older API
 ---------
 
-Before h5py 2.9, a single pair of functions was used to create and check for
+Before h5py 2.10, a single pair of functions was used to create and check for
 all of these special dtypes. These are still available for backwards
 compatibility, but are deprecated in favour of the functions listed above.
 


### PR DESCRIPTION
I had hoped to get #1132 in for 2.9, but it actually landed in 2.10, and I missed this.