### PR TITLE
Remove h5py.h5t.available_ftypes

### DIFF
--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -30,17 +30,10 @@ import codecs
 from collections import namedtuple
 import sys
 import operator
-from warnings import warn
 from .h5 import get_config
 import numpy as np
 from ._objects import phil, with_phil
-from .h5py_warnings import H5pyDeprecationWarning
 import platform
-
-try:
-    from collections.abc import Mapping
-except ImportError:
-    from collections import Mapping
 
 
 cfg = get_config()
@@ -266,37 +259,6 @@ cdef tuple _get_available_ftypes():
     return tuple(available_ftypes)
 
 cdef tuple _available_ftypes = _get_available_ftypes()
-
-# Old code to inform about floating point changes
-class _DeprecatedMapping(Mapping):
-    """
-    Mapping class which warns when members are accessed
-    """
-    def __init__(self, mapping, message):
-        self._mapping = mapping
-        self._message = message
-
-    def __len__(self):
-        warn(self._message, H5pyDeprecationWarning)
-        return len(self._mapping)
-
-    def __iter__(self):
-        warn(self._message, H5pyDeprecationWarning)
-        return iter(self._mapping)
-
-    def __getitem__(self, key):
-        warn(self._message, H5pyDeprecationWarning)
-        return self._mapping[key]
-
-available_ftypes = dict()
-for ftype in np.typeDict.values():
-    if np.issubdtype(ftype, np.floating):
-        available_ftypes[np.dtype(ftype).itemsize] = np.finfo(ftype)
-
-available_ftypes = _DeprecatedMapping(available_ftypes,
-    ("Do not use available_ftypes, this is not part of the public API of "
-    "h5py. See https://github.com/h5py/h5py/pull/926 for details.")
-)
 
 
 cdef (int, int, int) _correct_float_info(ftype_, finfo):

--- a/h5py/tests/test_h5t.py
+++ b/h5py/tests/test_h5t.py
@@ -7,13 +7,10 @@
 # License:  Standard 3-clause BSD; see "license.txt" for full license terms
 #           and contributor agreement.
 
-import sys
-
 import numpy as np
 
 import h5py
 from h5py import h5t
-from h5py.h5py_warnings import H5pyDeprecationWarning
 
 from .common import TestCase, ut
 
@@ -203,13 +200,3 @@ class TestTypeFloatID(TestCase):
 
         dset = f[dataset5]
         self.assertEqual(dset.dtype, np.longdouble)
-
-
-class TestDeprecation(TestCase):
-    def test_deprecation_available_ftypes(self):
-        warning_message = ("Do not use available_ftypes, this is not part of "
-            "the public API of h5py. See "
-            "https://github.com/h5py/h5py/pull/926 for details.")
-        with self.assertWarnsRegex(H5pyDeprecationWarning, warning_message) as warning:
-            from h5py.h5t import available_ftypes
-            available_ftypes[np.dtype(np.float).itemsize]

--- a/news/rm-available-ftypes.rst
+++ b/news/rm-available-ftypes.rst
@@ -1,0 +1,29 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* Remove the deprecated ``h5py.h5t.available_ftypes`` dictionary.
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
This was deprecated, with warnings, in 2.8 (gh-926).

@scopatz , please give @aragilar and @tacaswell a chance to see this before it's merged, as they discussed the original deprecation.