### PR TITLE
Drop some of the appveyor tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,18 +16,6 @@ environment:
       HDF5_VSVERSION: "14"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
 
-    - PYTHON: "C:\\Python36-x64"
-      TOXENV: "py36-test-deps"
-      TOX_APPVEYOR_X64: "1"
-      HDF5_VSVERSION: "14-64"
-      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
-
-    - PYTHON: "C:\\Python37-x64"
-      TOXENV: "py37-test-deps"
-      TOX_APPVEYOR_X64: "1"
-      HDF5_VSVERSION: "14-64"
-      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
-
     ### USING HDF5 1.10 ###
 
     - PYTHON: "C:\\Python36"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,20 +42,6 @@ environment:
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
       HDF5_VERSION: "1.10.1"
 
-    - PYTHON: "C:\\Python36-x64"
-      TOXENV: "py36-test-deps"
-      TOX_APPVEYOR_X64: "1"
-      HDF5_VSVERSION: "14-64"
-      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
-      HDF5_VERSION: "1.10.1"
-
-    - PYTHON: "C:\\Python37-x64"
-      TOXENV: "py37-test-deps"
-      TOX_APPVEYOR_X64: "1"
-      HDF5_VSVERSION: "14-64"
-      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
-      HDF5_VERSION: "1.10.1"
-
 install:
   # We need wheel installed to build wheels
   - "%PYTHON%\\python.exe -m pip install --upgrade wheel pip setuptools"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,13 +74,28 @@ jobs:
     # -deps : test with default (latest) versions of dependencies
     # -mindeps : test with oldest supported version of (python) dependencies
     # -deps-pre : test pre-release versions of (python) dependencies)
-      py36:
+    #
+    # 64 bit - HDF5 1.8
+      py36-hdf518:
+        python.version: '3.6'
+        TOXENV: py36-test-deps,py36-test-mindeps,py36-test-deps-pre
+        HDF5_VERSION: 1.8.17
+        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
+        HDF5_VSVERSION: "15-64"
+      py37-hdf518:
+        python.version: '3.7'
+        TOXENV: py37-test-deps,py37-test-mindeps,py37-test-deps-pre
+        HDF5_VERSION: 1.8.17
+        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
+        HDF5_VSVERSION: "15-64"
+    # 64 bit - HDF5 1.10
+      py36-hdf5110:
         python.version: '3.6'
         TOXENV: py36-test-deps,py36-test-mindeps,py36-test-deps-pre
         HDF5_VERSION: 1.10.1
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         HDF5_VSVERSION: "15-64"
-      py37:
+      py37-hdf5110:
         python.version: '3.7'
         TOXENV: py37-test-deps,py37-test-mindeps,py37-test-deps-pre
         HDF5_VERSION: 1.10.1


### PR DESCRIPTION
This halves the number of appveyor tests we run (now only the 32-bit ones - https://docs.microsoft.com/en-au/azure/devops/pipelines/tasks/tool/use-python-version?view=azure-devops implies that only 64 bit builders are available on azure, even if we can install 32-bit python).

See #1372 (does not close).