### PR TITLE
Drop unneeded travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ matrix:
     - python: 3.7
       env:
       - TOXENV=py37-test-deps
-        HDF5_VERSION=1.10.5
-        HDF5_DIR=$HDF5_CACHE_DIR/$HDF5_VERSION
+      - HDF5_VERSION=1.10.5
+      - HDF5_DIR=$HDF5_CACHE_DIR/$HDF5_VERSION
       os: linux-ppc64le
 
     # Builds the API docs
@@ -67,8 +67,8 @@ matrix:
     - python: "nightly"
       env:
       - TOXENV=nightly
-        HDF5_VERSION=1.10.5
-        HDF5_DIR=$HDF5_CACHE_DIR/$HDF5_VERSION
+      - HDF5_VERSION=1.10.5
+      - HDF5_DIR=$HDF5_CACHE_DIR/$HDF5_VERSION
 
     - python: pypy3
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,6 @@ env:
     - HDF5_CACHE_DIR=$HOME/.cache/hdf5
     - secure: "PVgKiZwB5Kr7KFAmjoMYtsKsVGUhDdiYq0YoMMEk/COFHpnRt/3CUKYwW+4vTCSKcaai/1ZiPUrHruCwdnU7sUkJZZdKkh2C+Vqx+DnnfAFMbLPGqgaBG2UEMtDIinXHDtV4k9wSJB2X9KPchA+kkCeB1ZPsELo7J5y2R55AcOw="
 
-  matrix:
-    - TOXENV=docs
-    - TOXENV=check-manifest
-    - TOXENV=checkreadme
-    - TOXENV=pre-commit
-
 matrix:
   include:
     # needed to work around https://github.com/travis-ci/travis-ci/issues/4794
@@ -36,38 +30,11 @@ matrix:
     - python: 3.6
       env:
       - TOXENV=py36-test-deps
-
-    - python: 3.6
-      env:
-      - TOXENV=py36-test-deps
-        HDF5_VERSION=1.10.3
-        HDF5_DIR=$HDF5_CACHE_DIR/$HDF5_VERSION
-    - python: 3.6
-      env:
-      - TOXENV=py36-test-deps-pre
-    - python: 3.6
-      env:
-      - TOXENV=py36-test-mindeps
-    - python: 3.6
-      env:
-      - TOXENV=py36-test-deps
         TOX_TESTENV_PASSENV=LANG LC_ALL
         LANG=C
         LC_ALL=C
 
     # Python 3.7
-    - python: 3.7
-      env:
-      - TOXENV=py37-test-deps
-        HDF5_VERSION=1.10.4
-        HDF5_DIR=$HDF5_CACHE_DIR/$HDF5_VERSION
-
-    - python: 3.7
-      env:
-      - TOXENV=py37-test-deps
-        HDF5_VERSION=1.10.5
-        HDF5_DIR=$HDF5_CACHE_DIR/$HDF5_VERSION
-
     - python: 3.7
       env:
       - TOXENV=py37-test-deps
@@ -89,11 +56,6 @@ matrix:
             - libopenmpi-dev
             - libhdf5-openmpi-dev # 1.8.11 based on trusty
 
-    # PyTables compatibility tests
-    - python: 3.7
-      env:
-      - TOXENV=py37-test-mindeps-tables
-
     - python: 3.7
       env:
         - TOXENV=apidocs
@@ -108,7 +70,6 @@ matrix:
           fi
         - pip install doctr
         - doctr deploy --build-tags --built-docs docs_api/_build/html $DOCTR_DEPLOY_DIR --branch-whitelist doctr
-
     # Additional python versions which are not officially supported
     - python: "nightly"
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,22 +25,29 @@ matrix:
   include:
     # needed to work around https://github.com/travis-ci/travis-ci/issues/4794
     # TODO: We should see if we can replace this with installing python via pyenv # based on toxenv
-
-    # Python 3.6
-    - python: 3.6
-      env:
-      - TOXENV=py36-test-deps
-        TOX_TESTENV_PASSENV=LANG LC_ALL
-        LANG=C
-        LC_ALL=C
-
-    # Python 3.7
+    # Test on ppc64le
     - python: 3.7
       env:
       - TOXENV=py37-test-deps
         HDF5_VERSION=1.10.5
         HDF5_DIR=$HDF5_CACHE_DIR/$HDF5_VERSION
       os: linux-ppc64le
+
+    # Builds the API docs
+    - python: 3.7
+      env:
+        - TOXENV=apidocs
+        - HDF5_VERSION=1.10.5
+        - HDF5_DIR=$HDF5_CACHE_DIR/$HDF5_VERSION
+      script:
+        - tox
+        - if [[ -z "$TRAVIS_TAG" ]]; then
+            DOCTR_DEPLOY_DIR="$TRAVIS_BRANCH";
+          else
+            DOCTR_DEPLOY_DIR="v$TRAVIS_TAG";
+          fi
+        - pip install doctr
+        - doctr deploy --build-tags --built-docs docs_api/_build/html $DOCTR_DEPLOY_DIR --branch-whitelist doctr
 
     # MPI tests
     # TODO: We should test with newer versions of HDF5
@@ -56,20 +63,6 @@ matrix:
             - libopenmpi-dev
             - libhdf5-openmpi-dev # 1.8.11 based on trusty
 
-    - python: 3.7
-      env:
-        - TOXENV=apidocs
-        - HDF5_VERSION=1.10.5
-        - HDF5_DIR=$HDF5_CACHE_DIR/$HDF5_VERSION
-      script:
-        - tox
-        - if [[ -z "$TRAVIS_TAG" ]]; then
-            DOCTR_DEPLOY_DIR="$TRAVIS_BRANCH";
-          else
-            DOCTR_DEPLOY_DIR="v$TRAVIS_TAG";
-          fi
-        - pip install doctr
-        - doctr deploy --build-tags --built-docs docs_api/_build/html $DOCTR_DEPLOY_DIR --branch-whitelist doctr
     # Additional python versions which are not officially supported
     - python: "nightly"
       env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,13 @@ jobs:
       py37:
         python.version: '3.7'
         TOXENV: py37-test-deps,py37-test-mindeps,py37-test-deps-pre,py37-test-deps-tables
+    # test when we're not in a unicode locale
+      py36-Clocale:
+        python.version: '3.6'
+        TOXENV: py36-test-deps
+        TOX_TESTENV_PASSENV: LANG LC_ALL
+        LANG: C
+        LC_ALL: C
     # test against newer HDF5
       py36-deps-hdf51103:
         python.version: '3.6'


### PR DESCRIPTION
Similar to #1375, remove unneeded tests from travis. The tests remaining are the MPI tests, which I'll drop in #1255, the ppc64le test, and the api doc builder.