### PR TITLE
Publish api docs built from master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,7 @@ matrix:
             DOCTR_DEPLOY_DIR="v$TRAVIS_TAG";
           fi
         - pip install doctr
-        - doctr deploy --build-tags --built-docs docs_api/_build/html $DOCTR_DEPLOY_DIR --branch-whitelist doctr
+        - doctr deploy --build-tags --built-docs docs_api/_build/html $DOCTR_DEPLOY_DIR
 
     # Additional python versions which are not officially supported
     - python: "nightly"


### PR DESCRIPTION
`--branch-whitelist` overrides the default of publishing docs from master. Removing it will publish docs from the master branch.