### PR TITLE
Remove deprecated File.fid attribute

### DIFF
--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -244,14 +244,6 @@ class File(Group):
 
     @property
     @with_phil
-    def fid(self):
-        """File ID (backwards compatibility) """
-        warn("File.fid has been deprecated. "
-            "Use File.id instead.", H5pyDeprecationWarning, stacklevel=2)
-        return self.id
-
-    @property
-    @with_phil
     def libver(self):
         """File format version bounds (2-tuple: low, high)"""
         bounds = self.id.get_access_plist().get_libver_bounds()

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -641,19 +641,6 @@ class TestFilename(TestCase):
             fid.close()
 
 
-class TestBackwardsCompat(TestCase):
-
-    """
-        Feature: Deprecated attributes are included to support 1.3 code
-    """
-
-    def test_fid(self):
-        """ File objects provide a .fid attribute aliased to the file ID """
-        with pytest.warns(H5pyDeprecationWarning):
-            with File(self.mktemp(), 'w') as hfile:
-                self.assertIs(hfile.fid, hfile.id)
-
-
 class TestCloseInvalidatesOpenObjectIDs(TestCase):
 
     """

--- a/news/rm-file-fid.rst
+++ b/news/rm-file-fid.rst
@@ -1,0 +1,29 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* Removed deprecated File.fid attribute. Use File.id instead.
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
`File.id` works instead. This has been described as "backwards compatibility" in the docstring since 2.0, and issued deprecation warnings since 2.9 (gh-1047).