### PR TITLE
CI: Add testing of HDF5 develop branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ addons:
   apt:
     packages:
       - libhdf5-serial-dev
+      - dh-autoreconf
+      - libtool-bin
 
 cache:
   directories:
@@ -119,9 +121,25 @@ matrix:
     - python: pypy3
       env:
       - TOXENV=pypy3-test-deps
+
+    # Development versions of HDF5
+    - python: 3.7
+      env:
+        - TOXENV=py37-test-deps
+        - HDF5_BRANCH=develop
+        - HDF5_DIR=$HDF5_CACHE_DIR/DEV/$HDF5_BRANCH
+      install:
+        - pip install tox codecov
+        - ci/travis/get_dev_hdf5.sh
+        - ls -lRa $HDF5_CACHE_DIR
   allow_failures:
     - python: pypy3
     - python: 'nightly'
+    - python: 3.7
+      env:
+        - TOXENV=py37-test-deps
+        - HDF5_BRANCH=develop
+        - HDF5_DIR=$HDF5_CACHE_DIR/DEV/$HDF5_BRANCH
 
 before_install:
   # - export PATH=/usr/lib/ccache:$PATH

--- a/ci/travis/get_dev_hdf5.sh
+++ b/ci/travis/get_dev_hdf5.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+if [ -z ${HDF5_DIR+x} ]; then
+    echo "No HDF5_DIR set, exiting"
+    exit 1
+else
+    echo "Using development HDF5"
+    pushd /tmp
+    git clone https://bitbucket.hdfgroup.org/scm/hdffv/hdf5.git hdf5
+    pushd hdf5
+    git checkout ${HDF5_BRANCH:-develop}
+    chmod u+x autogen.sh
+    ./autogen.sh
+    ./configure --prefix $HDF5_DIR $HDF5_CONFIG_ARGS
+    make -j $(nproc)
+    make install
+    popd
+    popd
+fi

--- a/news/hdf5-dev-ci.rst
+++ b/news/hdf5-dev-ci.rst
@@ -1,0 +1,29 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* The CI system now includes testing h5py against the HDF5 `develop` branch.


### PR DESCRIPTION
This adds the develop branch of HDF5 to travis (with `allow_failures`). We could add more branches, but I'm guessing what we really need is some way of notifying the HDF5 group on failure of these and similar tests (do we know what CI system they are using?).
