### PR TITLE
Set environment variables for ccache under pip

### DIFF
--- a/setup_build.py
+++ b/setup_build.py
@@ -156,6 +156,13 @@ class h5py_build_ext(build_ext):
         from Cython.Build import cythonize
         import numpy
 
+        # This allows ccache to recognise the files when pip builds in a temp
+        # directory. It speeds up repeatedly running tests through tox with
+        # ccache configured (CC="ccache gcc"). It should have no effect if
+        # ccache is not in use.
+        os.environ['CCACHE_BASEDIR'] = op.dirname(op.abspath(__file__))
+        os.environ['CCACHE_NOHASHDIR'] = '1'
+
         # Provides all of our build options
         config = self.distribution.get_command_obj('configure')
         config.run()


### PR DESCRIPTION
I'm not 100% sure this can't break anything - I'd like someone else who's familiar with ccache to think about it.

Tox creates an sdist of h5py, and then uses `pip` to install that into test environments. Pip unpacks the sdist into a temporary directory to build it. This messes up ccache with the default options, because the path forms part of its cache key. Each build is done from a new temporary directory, so the path is different, and ccache ignores its cache.

`CCACHE_BASEDIR` tells ccache to treat absolute paths with this prefix as relative paths without it, so files in the build directory will have matching paths wherever that is. This can't be set by the user before calling tox/pip, because you don't know where the build directory will be. `CCACHE_NOHASHDIR` tells it to also ignore the CWD, which pip sets to the build directory.

On my system, rerunning `tox -e py37-test-deps` goes from ~2m 15s without ccache to ~35s once the cache is populated. Set `CC="ccache gcc"` to use ccache.