### PR TITLE
Remove deprecated Dataset.value attribute

### DIFF
--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -795,14 +795,6 @@ class Dataset(HLObject):
             )
         return r
 
-    def __dir__(self):
-        names = set(super().__dir__())
-        # ds.value is deprecated, and we want to ensure that Jedi doesn't try
-        # to call the property (https://github.com/h5py/h5py/issues/1312), so
-        # this hides it from tab completions.
-        names.discard('value')
-        return sorted(names)
-
     if hasattr(h5d.DatasetID, "refresh"):
         @with_phil
         def refresh(self):

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -13,7 +13,6 @@
 
 import posixpath as pp
 import sys
-from warnings import warn
 
 from threading import local
 
@@ -27,7 +26,6 @@ from . import selections2 as sel2
 from .datatype import Datatype
 from .compat import filename_decode
 from .vds import VDSmap, vds_support
-from ..h5py_warnings import H5pyDeprecationWarning
 
 _LEGACY_GZIP_COMPRESSION_VALS = frozenset(range(10))
 MPI = h5.get_config().mpi
@@ -302,14 +300,6 @@ class Dataset(HLObject):
     def dtype(self):
         """Numpy dtype representing the datatype"""
         return self.id.dtype
-
-    @property
-    @with_phil
-    def value(self):
-        """  Alias for dataset[()] """
-        warn("dataset.value has been deprecated. "
-            "Use dataset[()] instead.", H5pyDeprecationWarning, stacklevel=2)
-        return self[()]
 
     @property
     @with_phil

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -13,7 +13,6 @@
 
 import sys
 import os
-from warnings import warn
 
 from .compat import filename_decode, filename_encode
 
@@ -21,7 +20,6 @@ from .base import phil, with_phil
 from .group import Group
 from .. import h5, h5f, h5p, h5i, h5fd, _objects
 from .. import version
-from ..h5py_warnings import H5pyDeprecationWarning
 
 mpi = h5.get_config().mpi
 hdf5_version = version.hdf5_version_tuple[0:3]

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1267,16 +1267,6 @@ class TestLowOpen(BaseDataset):
         self.assertIsInstance(dsid, h5py.h5d.DatasetID)
 
 
-def test_hide_value_from_jedi():
-    from io import BytesIO
-    buf = BytesIO()
-    with h5py.File(buf, 'w') as fout:
-        fout['test'] = [1, 2, 3]
-        with pytest.warns(UserWarning):
-            assert hasattr(fout['test'], 'value')
-        assert 'value' not in dir(fout['test'])
-
-
 @ut.skipUnless(h5py.version.hdf5_version_tuple >= (1, 10, 5),
                "chunk info requires  HDF5 >= 1.10.5")
 def test_get_chunk_details():

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -21,7 +21,6 @@ from sys import platform
 
 from .common import ut, TestCase, UNICODE_FILENAMES, closed_tempfile
 from h5py import File
-from h5py.h5py_warnings import H5pyDeprecationWarning
 import h5py
 
 import pathlib

--- a/news/rm-dataset-value.rst
+++ b/news/rm-dataset-value.rst
@@ -1,0 +1,30 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* Remove deprecated ``Dataset.value`` property.
+  Use ``ds[()]`` to read all data from any dataset.
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
This has been deprecated for years (bae29c53af3922d46243d5a222ab5bda0df0cb22), but the warning wasn't working, even if you set the warning filters to show DeprecationWarning, until it was fixed in 2.9 (#1047).