### PR TITLE
Clean up unnecessary fallback imports

### DIFF
--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -13,11 +13,7 @@
 
 import posixpath
 import os
-try:
-    from collections.abc import (Mapping, MutableMapping, KeysView,
-                                 ValuesView, ItemsView)
-except ImportError:
-    from collections import (Mapping, MutableMapping, KeysView,
+from collections.abc import (Mapping, MutableMapping, KeysView,
                              ValuesView, ItemsView)
 
 from .compat import fspath, filename_encode

--- a/h5py/tests/test_attrs.py
+++ b/h5py/tests/test_attrs.py
@@ -17,10 +17,7 @@
 
 import numpy as np
 
-try:
-    from collections.abc import MutableMapping
-except ImportError:  # Python < 3.3
-    from collections import MutableMapping
+from collections.abc import MutableMapping
 
 from .common import TestCase, ut
 


### PR DESCRIPTION
`collections.abc` should work on all supported Python versions now.