### PR TITLE
Integrate check-manifest checker into pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,8 @@ repos:
     hooks:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
+
+-   repo: https://github.com/mgedmin/check-manifest
+    rev: "0.39"
+    hooks:
+    -   id: check-manifest

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -19,6 +19,7 @@ recursive-include h5py *.h *.pyx *.pxd *.pxi *.py *.txt
 exclude h5py/config.pxi
 exclude h5py/defs.pxd
 exclude h5py/defs.pyx
+exclude h5py/_hdf5.pxd
 
 recursive-include licenses *
 recursive-include lzf *

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
     matrix:
     # system independent tests
       static-checks:
-        TOXENV: docs,check-manifest,checkreadme,pre-commit
+        TOXENV: docs,checkreadme,pre-commit
         python.version: '3.6'
       # -deps : test with default (latest) versions of dependencies
       # -mindeps : test with oldest supported version of (python) dependencies

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 # We want an envlist like
-# envlist = {py36,py37,pypy3}-{test}-{deps,mindeps}-{,mpi4py}-{,pre},nightly,docs,check-manifest,checkreadme
+# envlist = {py36,py37,pypy3}-{test}-{deps,mindeps}-{,mpi4py}-{,pre},nightly,docs,checkreadme,pre-commit
 # but we want to skip mpi and pre by default, so this envlist is below
-envlist = {py36,py37,pypy3}-{test}-{deps,mindeps},nightly,docs,apidocs,check-manifest,checkreadme
+envlist = {py36,py37,pypy3}-{test}-{deps,mindeps},nightly,docs,apidocs,checkreadme,pre-commit
 
 [testenv]
 deps =
@@ -59,14 +59,6 @@ deps=
     sphinx
 commands=
     sphinx-build -W -b html -d {envtmpdir}/doctrees .  _build/html
-
-[testenv:check-manifest]
-skip_install=True
-deps=check-manifest
-setenv =
-    CHECK_MANIFEST=true
-commands=
-    check-manifest
 
 [testenv:checkreadme]
 skip_install=True


### PR DESCRIPTION
This shouldn't make a whole lot of difference to the CI, but it's one more check a human can conveniently run with a single `tox -e pre-commit` command.

While playing with it, it flagged that the sdist was including the generated `_hdf5.pxd` file, so I've changed the manifest to exclude that.