### PR TITLE
Nicer API for specifying a filter and options

### DIFF
--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -101,6 +101,20 @@ def _normalize_external(external):
     # Check and rebuild each entry to be well-formed.
     return [_external_entry(entry) for entry in external]
 
+class FilterRefBase:
+    """Base class for referring to an HDF5 and describing its options
+
+    Your subclass must define filter_id, and may define a filter_options tuple.
+    """
+    filter_id = None
+    filter_options = ()
+
+class Gzip(FilterRefBase):
+    filter_id = h5z.FILTER_DEFLATE
+
+    def __init__(self, level=DEFAULT_GZIP):
+        self.filter_options = (level,)
+
 def fill_dcpl(plist, shape, dtype, chunks, compression, compression_opts,
               shuffle, fletcher32, maxshape, scaleoffset, external):
     """ Generate a dataset creation property list.
@@ -134,6 +148,9 @@ def fill_dcpl(plist, shape, dtype, chunks, compression, compression_opts,
     rq_tuple(maxshape, 'maxshape')
 
     if compression is not None:
+        if isinstance(compression, FilterRefBase):
+            compression_opts = compression.filter_options
+            compression = compression.filter_id
 
         if compression not in encode and not isinstance(compression, int):
             raise ValueError('Compression filter "%s" is unavailable' % compression)

--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -118,6 +118,9 @@ class FilterRefBase(Mapping):
             'compression_opts': self.filter_options
         }
 
+    def __hash__(self):
+        return hash((self.filter_id, self.filter_options))
+
     def __len__(self):
         return len(self._kwargs)
 

--- a/h5py/tests/test_filters.py
+++ b/h5py/tests/test_filters.py
@@ -61,6 +61,7 @@ class TestFilters(TestCase):
                                   )
 
 
+@ut.skipIf('gzip' not in h5py.filters.encode, "DEFLATE is not installed")
 def test_filter_ref_obj(writable_file):
     gzip8 = h5py.filters.Gzip(level=8)
     # **kwargs unpacking (compatible with earlier h5py versions)

--- a/h5py/tests/test_filters.py
+++ b/h5py/tests/test_filters.py
@@ -61,6 +61,22 @@ class TestFilters(TestCase):
                                   )
 
 
+def test_filter_ref_obj(writable_file):
+    gzip8 = h5py.filters.Gzip(level=8)
+    # **kwargs unpacking (compatible with earlier h5py versions)
+    assert dict(**gzip8) == {
+        'compression': h5py.h5z.FILTER_DEFLATE,
+        'compression_opts': (8,)
+    }
+
+    # Pass object as compression argument (new in h5py 3.0)
+    ds = writable_file.create_dataset(
+        'x', shape=(100,), dtype=np.uint32, compression=gzip8
+    )
+    assert ds.compression == 'gzip'
+    assert ds.compression_opts == 8
+
+
 @insubprocess
 def test_unregister_filter(request):
     if h5py.h5z.filter_avail(h5py.h5z.FILTER_LZF):


### PR DESCRIPTION
This is a rough draft of an idea I mentioned on #1315. The idea is that from the user perspective, something like this would be possible:

```python
f.create_dataset('foo', data=numpy.arange(100),
    compression=hdf5plugin.Blosc(level=9, shuffle='byte'))
```

For hdf5plugin, the code would look something like this:

```python
from h5py.filters import FilterRefBase

class Blosc(FilterRefBase):
    filter_id = 32001
    def __init__(self, level, shuffle='bit', compression='blosclz'):
        self.filter_options = (0, 0, 0, 0, level, shuffle, compression)
```