### PR TITLE
fix crash when accessing vlen of string #1336

### DIFF
--- a/h5py/_conv.pyx
+++ b/h5py/_conv.pyx
@@ -17,7 +17,7 @@ from .h5 import get_config
 from .h5r cimport Reference, RegionReference, hobj_ref_t, hdset_reg_ref_t
 from .h5t cimport H5PY_OBJ, typewrap, py_create, TypeID
 from . cimport numpy as np
-from libc.stdlib cimport realloc, malloc
+from libc.stdlib cimport realloc
 from .utils cimport emalloc, efree
 cfg = get_config()
 
@@ -678,10 +678,7 @@ cdef int conv_vlen2ndarray(void* ipt, void* opt, np.dtype elem_dtype,
     data = in_vlen0.ptr
     if outtype.get_size() > intype.get_size():
         data = realloc(data, outtype.get_size() * in_vlen0.len)
-
-    # if there is string in compound, a backbuf is required
-    back_buf = malloc(outtype.get_size() * in_vlen0.len)
-    H5Tconvert(intype.id, outtype.id, in_vlen0.len, data, back_buf, H5P_DEFAULT)
+    H5Tconvert(intype.id, outtype.id, in_vlen0.len, data, NULL, H5P_DEFAULT)
 
     Py_INCREF(<PyObject*>elem_dtype)
     ndarray = PyArray_NewFromDescr(&PyArray_Type, elem_dtype, 1,
@@ -693,7 +690,6 @@ cdef int conv_vlen2ndarray(void* ipt, void* opt, np.dtype elem_dtype,
     in_vlen0.ptr = NULL
     memcpy(buf_obj, &ndarray_obj, sizeof(ndarray_obj))
 
-    free(back_buf)
     return 0
 
 cdef herr_t ndarray2vlen(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata,

--- a/h5py/tests/test_h5f.py
+++ b/h5py/tests/test_h5f.py
@@ -10,7 +10,8 @@
 import tempfile
 import shutil
 import os
-from h5py import File
+import numpy as np
+from h5py import File, special_dtype
 
 from .common import TestCase
 
@@ -66,5 +67,28 @@ class TestCacheConfig(TestCase):
             with File(fn_h5, mode='x') as f:
                 conf = f._id.get_mdc_config()
                 f._id.set_mdc_config(conf)
+        finally:
+            shutil.rmtree(dn_tmp)
+
+
+class TestVlenData(TestCase):
+    def test_vlen_strings(self):
+        # Create file with dataset containing vlen arrays of vlen strings
+        dn_tmp = tempfile.mkdtemp('h5py.lowtest.test_h5f.TestVlenStrings.test_vlen_strings')
+        fn_h5 = os.path.join(dn_tmp, 'test.h5')
+        try:
+            with File(fn_h5, mode='w') as h:
+                vlen_str = special_dtype(vlen=str)
+                vlen_vlen_str = special_dtype(vlen=vlen_str)
+
+                ds = h.create_dataset('/com', (2,), dtype=vlen_vlen_str)
+                ds[0] = (np.array(["a", "b", "c"], dtype=vlen_vlen_str))
+                ds[1] = (np.array(["d", "e", "f","g"], dtype=vlen_vlen_str))
+
+            with File(fn_h5, "r") as h:
+                ds = h["com"]
+                assert ds[0].tolist() == ['a', 'b', 'c']
+                assert ds[1].tolist() == ['d', 'e', 'f', 'g']
+
         finally:
             shutil.rmtree(dn_tmp)

--- a/news/vlen-string.rst
+++ b/news/vlen-string.rst
@@ -1,0 +1,29 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* fix segment fault issue when accessing vlen of strings #1336
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
in conv_vlen2str, a variable bkg_obj0 is not used, but it tries to call Py_XDECREF on it
