### PR TITLE
Avoid equality comparison where array might be used

### DIFF
--- a/ci/upload_coverage.py
+++ b/ci/upload_coverage.py
@@ -8,8 +8,7 @@ from os import chdir, listdir, environ
 from pathlib import Path
 import platform
 from pprint import pprint
-import shlex
-from subprocess import run, PIPE
+from subprocess import run, PIPE, CalledProcessError
 import sys
 
 THIS_FILE = Path(__file__)
@@ -39,13 +38,13 @@ def run_with_python(args, **kwargs):
         msg("STDOUT:")
         sys.stdout.buffer.write(e.stdout)
         msg("STDERR:")
-        sys.stderr.buffer.write(e.stdout)
+        sys.stderr.buffer.write(e.stderr)
         raise
     else:
         msg("STDOUT:")
         sys.stdout.buffer.write(res.stdout)
         msg("STDERR:")
-        sys.stderr.buffer.write(res.stdout)
+        sys.stderr.buffer.write(res.stderr)
         return res
 
 

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -489,9 +489,11 @@ class Dataset(HLObject):
         """
         args = args if isinstance(args, tuple) else (args,)
         if is_empty_dataspace(self.id):
-            if not (args == tuple() or args == (Ellipsis,)):
-                raise ValueError("Empty datasets cannot be sliced")
-            return Empty(self.dtype)
+            # Check 'is Ellipsis' to avoid equality comparison with an array:
+            # array equality returns an array, not a boolean.
+            if args == () or (len(args) == 1 and args[0] is Ellipsis):
+                return Empty(self.dtype)
+            raise ValueError("Empty datasets cannot be sliced")
 
         # Sort field indices from the rest of the args.
         names = tuple(x for x in args if isinstance(x, str))
@@ -531,7 +533,8 @@ class Dataset(HLObject):
         # === Check for zero-sized datasets =====
 
         if numpy.product(self.shape, dtype=numpy.ulonglong) == 0:
-            # Avoid checking 'args ==' - causes problems if it contains an array
+            # Check 'is Ellipsis' to avoid equality comparison with an array:
+            # array equality returns an array, not a boolean.
             if args == () or (len(args) == 1 and args[0] is Ellipsis):
                 return numpy.empty(self.shape, dtype=new_dtype)
 

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -531,8 +531,8 @@ class Dataset(HLObject):
         # === Check for zero-sized datasets =====
 
         if numpy.product(self.shape, dtype=numpy.ulonglong) == 0:
-            # These are the only access methods NumPy allows for such objects
-            if args == (Ellipsis,) or args == tuple():
+            # Avoid checking 'args ==' - causes problems if it contains an array
+            if args == () or (len(args) == 1 and args[0] is Ellipsis):
                 return numpy.empty(self.shape, dtype=new_dtype)
 
         # === Scalar dataspaces =================

--- a/news/no-array-eq.rst
+++ b/news/no-array-eq.rst
@@ -1,0 +1,30 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* Removed an equality comparison with an empty array, which will cause problems
+  with future versions of numpy.
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
Running the tests, I see a warning like this:

```
tests/test_dataset_getitem.py::Test1DZeroFloat::test_mask
  /home/takluyver/miniconda3/envs/h5py-dev/lib/python3.7/site-packages/h5py/_hl/dataset.py:535: DeprecationWarning: The truth value of an empty array is ambiguous. Returning False, but in future this will result in an error. Use `array.size > 0` to check that an array is not empty.
    if args == (Ellipsis,) or args == tuple():
```

The deprecation was apparently [introduced in numpy 1.14](https://numpy.org/devdocs/release/1.14.0-notes.html#deprecations).

This change uses `is` rather than `==` to check for Ellipsis, which avoids getting into array comparison, so the warning goes away. It's slightly ugly, but I can't think of a neater way to fix it.