### PR TITLE
ENH: Ensure that sys.path has the current directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,11 @@ import sys
 import os
 import os.path as op
 
+# Newer packaging standards may recommend removing the current dir from the
+# path, add it back if needed.
+if '' not in sys.path:
+    sys.path.insert(0, '')
+
 import setup_build, setup_configure
 
 


### PR DESCRIPTION
I think I wrote this because there was something about pip not including the directory containing the setup.py to the path (I think there was a patch to setuptools or something which is why I didn't get around to submitting this). In any case, if that change were to happen, this readds that dir so we can import the configure and build files.