### PR TITLE
Cache some properties on Dataset

### DIFF
--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -418,3 +418,15 @@ class Empty(object):
 
     def __repr__(self):
         return "Empty(dtype={0!r})".format(self.dtype)
+
+
+def product(nums):
+    """Calculate a numeric product
+
+    For small amounts of data (e.g. shape tuples), this simple code is much
+    faster than calling numpy.prod().
+    """
+    prod = 1
+    for n in nums:
+        prod *= n
+    return prod

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -414,7 +414,7 @@ class Dataset(HLObject):
         return self._extent_type == h5s.NULL
 
     @with_phil
-    def __init__(self, bind, readonly=False):
+    def __init__(self, bind, *, readonly=False):
         """ Create a new Dataset object by binding to a low-level DatasetID.
         """
         if not isinstance(bind, h5d.DatasetID):

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -271,7 +271,7 @@ class Group(HLObject, MutableMappingHDF5):
         if otype == h5i.GROUP:
             return Group(oid)
         elif otype == h5i.DATASET:
-            return dataset.Dataset(oid)
+            return dataset.Dataset(oid, readonly=(self.file.mode == 'r'))
         elif otype == h5i.DATATYPE:
             return datatype.Datatype(oid)
         else:

--- a/h5py/_hl/selections.py
+++ b/h5py/_hl/selections.py
@@ -16,6 +16,7 @@
 
 import numpy as np
 
+from .base import product
 from .. import h5s, h5r
 
 
@@ -302,7 +303,7 @@ class SimpleSelection(Selection):
         tshape = tuple(tshape)
 
         chunks = tuple(x//y for x, y in zip(count, tshape))
-        nchunks = int(np.product(chunks))
+        nchunks = product(chunks)
 
         if nchunks == 1:
             yield self._id

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ VERSION = '2.10.0'
 NUMPY_DEP = 'numpy>=1.7'
 
 # these are required to use h5py
-RUN_REQUIRES = [NUMPY_DEP,]
+RUN_REQUIRES = [NUMPY_DEP, "cached-property"]
 
 # these are required to build h5py
 # RUN_REQUIRES is included as setup.py test needs RUN_REQUIRES for testing


### PR DESCRIPTION
In #1391, we noticed that repeated small reads from the same dataset are surprisingly slow. Profiling showed that quite a bit of time was wasted re-fetching and calculating things which don't change from read to read.

First, the headline figures:

- Simple `ds[0:10]` reads are about 2x faster (1.2 s -> 0.55 s)
- `read_direct()` about 25% faster (0.98 s -> 0.75 s)

Times are for 10k reads of 10 numbers each from a 1D integer dataset. [Details in this comment](https://github.com/h5py/h5py/issues/1391#issuecomment-542080099), but the timings given there are done with a different method.

The fastest I've got with Python code calling the low-level API directly is 0.22 s.

-----

For properties which can't change (like whether a dataset is empty), I've used a standard [@cached_property](https://github.com/pydanny/cached-property) decorator. They'll be calculated once on first access, then saved.

Dataset shape and size can change, either if the file is writeable (through `H5Dset_extent`) or if it's being read in SWMR mode (when `H5Drefresh` is called). I've taken a compromise position: 

* For SWMR mode the `ds.refresh()` call also clears the cache. This assumes that people keeping a `Dataset` object around will use its refresh method, not the low-level API.
* If the file is writeable, it doesn't use the cache at all, so it can't get outdated if you modify it with the low-level API.

The code could be simpler if we cached shape & size for writeable files as well - but it would mean that after manipulating a dataset with the low-level API you need to call `.refresh()` or get a new high-level Dataset object.