### PR TITLE
Allow get_vfd_handle() for any file driver

### DIFF
--- a/h5py/h5f.pyx
+++ b/h5py/h5f.pyx
@@ -386,17 +386,20 @@ cdef class FileID(GroupID):
 
 
     @with_phil
-    def get_vfd_handle(self):
-        """ () => INT
+    def get_vfd_handle(self, fapl=None):
+        """ (PropFAID) => INT
 
         Retrieve the file handle used by the virtual file driver.
 
-        This method is only functional when the the SEC2 driver is used.
+        This may not be supported for all file drivers, and the meaning of the
+        return value may depend on the file driver.
+
+        The 'family' and 'multi' drivers access multiple files, and a file
+        access property list (fapl) can be used to indicate which to access,
+        with H5Pset_family_offset or H5Pset_multi_type.
         """
-        if H5Pget_driver(H5Fget_access_plist(self.id)) != h5fd.SEC2:
-            raise NotImplementedError
         cdef int *handle
-        H5Fget_vfd_handle(self.id, H5Fget_access_plist(self.id), <void**>&handle)
+        H5Fget_vfd_handle(self.id, pdefault(fapl), <void**>&handle)
         return handle[0]
 
     IF HDF5_VERSION >= (1, 8, 9):

--- a/h5py/tests/test_h5f.py
+++ b/h5py/tests/test_h5f.py
@@ -20,8 +20,7 @@ class TestFileID(TestCase):
     def test_descriptor_core(self):
         with File('TestFileID.test_descriptor_core', driver='core',
                   backing_store=False, mode='x') as f:
-            with self.assertRaises(NotImplementedError):
-                f.id.get_vfd_handle()
+            assert f.id.get_vfd_handle() != 0
 
     def test_descriptor_sec2(self):
         dn_tmp = tempfile.mkdtemp('h5py.lowtest.test_h5f.TestFileID.test_descriptor_sec2')

--- a/h5py/tests/test_h5f.py
+++ b/h5py/tests/test_h5f.py
@@ -20,7 +20,7 @@ class TestFileID(TestCase):
     def test_descriptor_core(self):
         with File('TestFileID.test_descriptor_core', driver='core',
                   backing_store=False, mode='x') as f:
-            assert f.id.get_vfd_handle() != 0
+            assert isinstance(f.id.get_vfd_handle(), int)
 
     def test_descriptor_sec2(self):
         dn_tmp = tempfile.mkdtemp('h5py.lowtest.test_h5f.TestFileID.test_descriptor_sec2')

--- a/news/get-vfd-handle-any.rst
+++ b/news/get-vfd-handle-any.rst
@@ -1,0 +1,30 @@
+New features
+------------
+
+* The low-level :meth:`FileID.get_vfd_handle` method now works for any
+  file driver that supports it, not only the sec2 driver.
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
I guess at some point in the past, only sec2 supported calling this, but looking at the [docs](https://confluence.hdfgroup.org/display/HDF5/H5F_GET_VFD_HANDLE) and the source code now, multiple drivers support it.