### PR TITLE
Publish unversioned API docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
       script:
         - tox
         - pip install doctr
-        - doctr deploy --built-docs docs_api/_build/html
+        - doctr deploy . --built-docs docs_api/_build/html
 
     # MPI tests
     # TODO: We should test with newer versions of HDF5

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,13 +42,8 @@ matrix:
         - HDF5_DIR=$HDF5_CACHE_DIR/$HDF5_VERSION
       script:
         - tox
-        - if [[ -z "$TRAVIS_TAG" ]]; then
-            DOCTR_DEPLOY_DIR="$TRAVIS_BRANCH";
-          else
-            DOCTR_DEPLOY_DIR="v$TRAVIS_TAG";
-          fi
         - pip install doctr
-        - doctr deploy --build-tags --built-docs docs_api/_build/html $DOCTR_DEPLOY_DIR
+        - doctr deploy --built-docs docs_api/_build/html
 
     # MPI tests
     # TODO: We should test with newer versions of HDF5


### PR DESCRIPTION
See discussion on #1343

Publishing API docs at versioned URLs would be nice, but it would break existing links, and people might find old versions as the top results on search engines. This can probably all be avoided with careful use of html meta redirects and `rel="canonical"` links, but that's an extra maintenance burden. So the simple solution is to stick to publishing docs at unversioned URLs.