### PR TITLE
TST,CI: Add tests to coverage, with split on codecov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,2 @@
 [run]
-omit=*/tests/*
 parallel=true

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,3 +3,15 @@ coverage:
     project:
       default:
         threshold: 0.5%
+      tests:
+        flags: tests
+      main:
+        flags: main
+
+flags:
+  tests:
+    paths:
+      - h5py/tests/
+  main:
+    paths:
+      - !h5py/tests/


### PR DESCRIPTION
This is a test to see if we can have codecov report the coverage of the tests separately from the main code.
