### PR TITLE
Cython cleanup

### DIFF
--- a/h5py/_conv.pyx
+++ b/h5py/_conv.pyx
@@ -91,7 +91,7 @@ cdef herr_t generic_converter(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata,
                         bkg + (i*bkg_stride),           # backing buffer
                         cdata[0].priv)                  # conversion context
             else:
-                for i from nl>i>=0:
+                for i in range(nl-1, -1, -1):
                     op( buf + (i*sizes[0].src_size),
                         buf + (i*sizes[0].dst_size),
                         bkg + (i*bkg_stride),
@@ -608,7 +608,7 @@ cdef herr_t vlen2ndarray(hid_t src_id,
                     conv_vlen2ndarray(buf + (i*src_size), buf + (i*dst_size),
                                       dt, supertype, outtype)
             else:
-                for i from nl>i>=0:
+                for i in range(nl-1, -1, -1):
                     conv_vlen2ndarray(buf + (i*src_size), buf + (i*dst_size),
                                       dt, supertype, outtype)
         else:

--- a/h5py/_conv.pyx
+++ b/h5py/_conv.pyx
@@ -23,14 +23,12 @@ cfg = get_config()
 
 # Initialization of numpy
 cimport numpy as cnp
-import numpy as np
-from numpy cimport npy_intp, NPY_WRITEABLE, NPY_C_CONTIGUOUS, NPY_OWNDATA, NPY_OBJECT
+from numpy cimport npy_intp, NPY_WRITEABLE, NPY_C_CONTIGUOUS, NPY_OWNDATA
 cnp._import_array()
 
-from cpython.object cimport PyObject, PyTypeObject
+from cpython.object cimport PyObject
 from cpython.unicode cimport PyUnicode_DecodeUTF8
-from cpython.ref cimport Py_INCREF, Py_DECREF, Py_XDECREF, Py_XINCREF
-from cython.view cimport array as cvarray
+from cpython.ref cimport Py_INCREF, Py_XDECREF, Py_XINCREF
 
 cdef PyObject* Py_None = <PyObject*> None
 

--- a/h5py/_conv.pyx
+++ b/h5py/_conv.pyx
@@ -75,7 +75,7 @@ cdef herr_t generic_converter(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata,
         elif H5Tis_variable_str(dst_id):
             sizes.cset = H5Tget_cset(dst_id)
         if bkg_stride==0:
-            bkg_stride = sizes[0].dst_size;
+            bkg_stride = sizes[0].dst_size
         if buf_stride == 0:
             # No explicit stride seems to mean that the elements are packed
             # contiguously in the buffer.  In this case we must be careful
@@ -286,7 +286,7 @@ cdef int conv_fixed2vlen(void* ipt, void* opt, void* bkg, void* priv) except -1:
     memcpy(temp_string, buf_fixed, sizes[0].src_size)
     temp_string[sizes[0].src_size] = c'\0'
 
-    memcpy(buf_vlen, &temp_string, sizeof(temp_string));
+    memcpy(buf_vlen, &temp_string, sizeof(temp_string))
 
     return 0
 

--- a/h5py/_proxy.pyx
+++ b/h5py/_proxy.pyx
@@ -361,7 +361,7 @@ cdef htri_t needs_proxy(hid_t tid) except -1:
     elif cls == H5T_COMPOUND:
 
         n = H5Tget_nmembers(tid)
-        for i from 0<=i<n:
+        for i in range(n):
             supertype = H5Tget_member_type(tid, i)
             try:
                 result = needs_proxy(supertype)

--- a/h5py/_proxy.pyx
+++ b/h5py/_proxy.pyx
@@ -187,10 +187,11 @@ cdef hid_t make_reduced_type(hid_t mtype, hid_t dstype):
     cdef hid_t newtype, temptype
     cdef hsize_t newtype_size, offset
     cdef char* member_name = NULL
+    cdef int idx
 
     # Make a list of all names in the memory type.
     mtype_fields = []
-    for idx in xrange(H5Tget_nmembers(mtype)):
+    for idx in range(H5Tget_nmembers(mtype)):
         member_name = H5Tget_member_name(mtype, idx)
         try:
             mtype_fields.append(member_name)
@@ -204,7 +205,7 @@ cdef hid_t make_reduced_type(hid_t mtype, hid_t dstype):
     # First pass: add up the sizes of matching fields so we know how large a
     # type to make
     newtype_size = 0
-    for idx in xrange(H5Tget_nmembers(dstype)):
+    for idx in range(H5Tget_nmembers(dstype)):
         member_name = H5Tget_member_name(dstype, idx)
         try:
             if member_name not in mtype_fields:
@@ -223,7 +224,7 @@ cdef hid_t make_reduced_type(hid_t mtype, hid_t dstype):
 
     # Second pass: pick out the matching fields and pack them in the new type
     offset = 0
-    for idx in xrange(H5Tget_nmembers(dstype)):
+    for idx in range(H5Tget_nmembers(dstype)):
         member_name = H5Tget_member_name(dstype, idx)
         try:
             if member_name not in mtype_fields:

--- a/h5py/h5a.pyx
+++ b/h5py/h5a.pyx
@@ -22,7 +22,6 @@ from .utils cimport check_numpy_read, check_numpy_write, emalloc, efree
 from ._proxy cimport attr_rw
 
 #Python level imports
-from . import _objects
 from ._objects import phil, with_phil
 
 # Initialization

--- a/h5py/h5ac.pyx
+++ b/h5py/h5ac.pyx
@@ -11,8 +11,7 @@
 """
     Low-level HDF5 "H5AC" cache configuration interface.
 """
-from ._objects cimport pdefault
-from . import _objects
+
 
 cdef class CacheConfig:
     """Represents H5AC_cache_config_t objects

--- a/h5py/h5d.pyx
+++ b/h5py/h5d.pyx
@@ -17,7 +17,7 @@ include "config.pxi"
 
 from collections import namedtuple
 from ._objects cimport pdefault
-from numpy cimport ndarray, import_array, PyArray_DATA, NPY_WRITEABLE
+from numpy cimport ndarray, import_array, PyArray_DATA
 from cpython cimport array
 from .utils cimport  check_numpy_read, check_numpy_write, \
                      convert_tuple, convert_dims, emalloc, efree
@@ -26,7 +26,6 @@ from .h5s cimport SpaceID
 from .h5p cimport PropID, propwrap
 from ._proxy cimport dset_rw
 
-from . import _objects
 from ._objects import phil, with_phil
 
 # Initialization

--- a/h5py/h5f.pyx
+++ b/h5py/h5f.pyx
@@ -219,7 +219,7 @@ def get_obj_count(object where=OBJ_ALL, int types=H5F_OBJ_ALL):
     cdef hid_t where_id
     if isinstance(where, FileID):
         where_id = where.id
-    elif isinstance(where, int) or isinstance(where, long):
+    elif isinstance(where, int):
         where_id = where
     else:
         raise TypeError("Location must be a FileID or OBJ_ALL.")

--- a/h5py/h5f.pyx
+++ b/h5py/h5f.pyx
@@ -267,7 +267,7 @@ def get_obj_ids(object where=OBJ_ALL, int types=H5F_OBJ_ALL):
 
         if count > 0: # HDF5 complains that obj_list is NULL, even if count==0
             H5Fget_obj_ids(where_id, types, count, obj_list)
-            for i from 0<=i<count:
+            for i in range(count):
                 py_obj_list.append(wrap_identifier(obj_list[i]))
                 # The HDF5 function returns a borrowed reference for each hid_t.
                 H5Iinc_ref(obj_list[i])

--- a/h5py/h5f.pyx
+++ b/h5py/h5f.pyx
@@ -19,7 +19,6 @@ from cpython.buffer cimport PyObject_CheckBuffer, \
                             PyBUF_SIMPLE
 from ._objects cimport pdefault
 from .h5p cimport propwrap, PropFAID, PropFCID
-from .h5t cimport typewrap
 from .h5i cimport wrap_identifier
 from .h5ac cimport CacheConfig
 from .utils cimport emalloc, efree
@@ -27,7 +26,6 @@ from .utils cimport emalloc, efree
 # Python level imports
 from . import _objects
 from ._objects import phil, with_phil
-from . import h5fd
 
 from cpython.bytes cimport PyBytes_FromStringAndSize, PyBytes_AsString
 

--- a/h5py/h5g.pyx
+++ b/h5py/h5g.pyx
@@ -23,7 +23,6 @@ from . cimport _hdf5 # to implement container testing for 1.6
 from ._errors cimport set_error_handler, err_cookie
 
 # Python level imports
-from . import _objects
 from ._objects import phil, with_phil
 
 # === Public constants and data structures ====================================

--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -587,7 +587,7 @@ cdef class PropDCID(PropOCID):
                 nelements = len(values)
                 cd_values = <unsigned int*>emalloc(sizeof(unsigned int)*nelements)
 
-                for i from 0<=i<nelements:
+                for i in range(nelements):
                     cd_values[i] = int(values[i])
 
             H5Pset_filter(self.id, <H5Z_filter_t>filter_code, flags, nelements, cd_values)
@@ -643,7 +643,7 @@ cdef class PropDCID(PropOCID):
         name[256] = c'\0'  # in case it's > 256 chars
 
         vlist = []
-        for i from 0<=i<nelements:
+        for i in range(nelements):
             vlist.append(cd_values[i])
 
         return (filter_code, flags, tuple(vlist), name)
@@ -657,9 +657,9 @@ cdef class PropDCID(PropOCID):
         property list.  Used because the HDF5 function H5Pget_filter_by_id
         is broken.
         """
-        cdef int nfilters
+        cdef int i, nfilters
         nfilters = self.get_nfilters()
-        for i from 0<=i<nfilters:
+        for i in range(nfilters):
             if self.get_filter(i)[0] == filter_code:
                 return True
         return False
@@ -697,7 +697,7 @@ cdef class PropDCID(PropOCID):
         name[256] = c'\0'  # In case HDF5 doesn't terminate it properly
 
         vlist = []
-        for i from 0<=i<nelements:
+        for i in range(nelements):
             vlist.append(cd_values[i])
 
         return (flags, tuple(vlist), name)

--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -28,7 +28,6 @@ from .h5s cimport SpaceID
 from .h5ac cimport CacheConfig
 
 # Python level imports
-from . import _objects
 from ._objects import phil, with_phil
 
 if MPI:

--- a/h5py/h5r.pyx
+++ b/h5py/h5r.pyx
@@ -170,7 +170,7 @@ cdef class Reference:
 
     def __nonzero__(self):
         cdef int i
-        for i from 0<=i<self.typesize:
+        for i in range(self.typesize):
             if (<unsigned char*>&self.ref)[i] != 0: return True
         return False
 

--- a/h5py/h5s.pyx
+++ b/h5py/h5s.pyx
@@ -20,7 +20,6 @@ from .utils cimport  require_tuple, convert_dims, convert_tuple, \
 cimport numpy as cnp
 
 #Python level imports
-from . import _objects
 from ._objects import phil, with_phil
 
 cdef object lockid(hid_t id_):

--- a/h5py/h5s.pyx
+++ b/h5py/h5s.pyx
@@ -228,7 +228,7 @@ cdef class SpaceID(ObjectID):
                 # The HDF5 docs say passing in NULL resets the offset to 0.
                 # Instead it raises an exception.  Imagine my surprise. We'll
                 # do this manually.
-                for i from 0<=i<rank:
+                for i in range(rank):
                     dims[i] = 0
 
             H5Soffset_simple(self.id, dims)

--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -1299,7 +1299,7 @@ cdef class TypeEnumID(TypeCompositeID):
         nmembers = self.get_nmembers()
         members = {}
 
-        for idx in xrange(nmembers):
+        for idx in range(nmembers):
             name = self.get_member_name(idx)
             val = self.get_member_value(idx)
             members[name] = val

--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -1156,7 +1156,7 @@ cdef class TypeCompoundID(TypeCompositeID):
             TypeID tmp_type
             list field_names
             list field_types
-            int nfields
+            int i, nfields
         field_names = []
         field_types = []
         field_offsets = []
@@ -1164,7 +1164,7 @@ cdef class TypeCompoundID(TypeCompositeID):
 
         # First step: read field names and their Numpy dtypes into
         # two separate arrays.
-        for i from 0 <= i < nfields:
+        for i in range(nfields):
             tmp_type = self.get_member_type(i)
             name = self.get_member_name(i)
             field_names.append(name)

--- a/h5py/utils.pyx
+++ b/h5py/utils.pyx
@@ -97,7 +97,7 @@ cdef int convert_tuple(object tpl, hsize_t *dims, hsize_t rank) except -1:
         raise ValueError("Tuple length incompatible with array")
 
     try:
-        for i from 0<=i<rank:
+        for i in range(rank):
             dims[i] = tpl[i]
     except TypeError:
         raise TypeError("Can't convert element %d (%s) to hsize_t" % (i, tpl[i]))
@@ -111,7 +111,7 @@ cdef object convert_dims(hsize_t* dims, hsize_t rank):
     cdef int i
     dims_list = []
 
-    for i from 0<=i<rank:
+    for i in range(rank):
         dims_list.append(int(dims[i]))
 
     return tuple(dims_list)
@@ -137,7 +137,7 @@ cdef object create_numpy_hsize(int rank, hsize_t* dims):
     dims_npy = <npy_intp*>emalloc(sizeof(npy_intp)*rank)
 
     try:
-        for i from 0<=i<rank:
+        for i in range(rank):
             dims_npy[i] = dims[i]
         arr = PyArray_SimpleNew(rank, dims_npy, typecode)
     finally:

--- a/h5py/utils.pyx
+++ b/h5py/utils.pyx
@@ -12,8 +12,7 @@
 
 from numpy cimport ndarray, import_array,\
                    NPY_UINT16, NPY_UINT32, NPY_UINT64,  npy_intp,\
-                   PyArray_SimpleNew, PyArray_ContiguousFromAny,\
-                   PyArray_FROM_OTF, PyArray_DIM,\
+                   PyArray_SimpleNew, PyArray_FROM_OTF,\
                    NPY_CONTIGUOUS, NPY_NOTSWAPPED, NPY_FORCECAST
 
 # Initialization


### PR DESCRIPTION
This shouldn't change functionality at all, but it gets rid of various warnings in Pycharm.

It was prompted by the fact that Pycharm doesn't recognise the `for i from 0<=i<n` syntax - @kif started clearing this up in other PRs, and this removes all the remaining instances. Cython [automatically optimises](https://cython.readthedocs.io/en/latest/src/userguide/pyrex_differences.html#automatic-range-conversion) statements like `for i in range(...)` to C for-loops wherever possible. I've checked several of these with `cython -a` to see that they're benefitting from that.

I manually checked each import I was removing, since sometimes PyCharm erroneously highlights them as unused.