### PR TITLE
TST,CI: Run rever check on CI to reduce release friction

### DIFF
--- a/.authors.yml
+++ b/.authors.yml
@@ -611,3 +611,21 @@
   num_commits: 1
   first_commit: 2017-03-22 04:40:26
   github: felixonmars
+- name: Julia Garriga Ferrer
+  email: julia.garriga@esrf.fr
+  aliases:
+    - juliagarriga
+  alternate_emails:
+    - juliiaa28@gmail.com
+- name: Henri Payno
+  email: henri.payno@esrf.fr
+  aliases:
+    - payno
+  alternate_emails:
+    - payno@linazimov.esrf.fr
+    - payno@users.noreply.github.com
+    - henri.payno@gmail.com
+- name: Jerome Kieffer
+  email: kieffer@esrf.fr
+  alternate_emails:
+    - jerome.kieffer@terre-adelie.org

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
     matrix:
     # system independent tests
       static-checks:
-        TOXENV: docs,checkreadme,pre-commit
+        TOXENV: docs,checkreadme,pre-commit,rever
         python.version: '3.6'
       # -deps : test with default (latest) versions of dependencies
       # -mindeps : test with oldest supported version of (python) dependencies

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # We want an envlist like
 # envlist = {py36,py37,pypy3}-{test}-{deps,mindeps}-{,mpi4py}-{,pre},nightly,docs,checkreadme,pre-commit
 # but we want to skip mpi and pre by default, so this envlist is below
-envlist = {py36,py37,pypy3}-{test}-{deps,mindeps},nightly,docs,apidocs,checkreadme,pre-commit
+envlist = {py36,py37,pypy3}-{test}-{deps,mindeps},nightly,docs,apidocs,checkreadme,pre-commit,rever
 
 [testenv]
 deps =
@@ -72,3 +72,13 @@ deps=pre-commit
 passenv = HOMEPATH SSH_AUTH_SOCK
 commands=
     pre-commit run --all-files
+
+[testenv:rever]
+skip_install=True
+deps=
+    re-ver
+    xonsh
+    lazyasd
+    ruamel.yaml
+commands=
+    rever check --activities authors,version_bump,changelog


### PR DESCRIPTION
This adds running `rever check` to the list of things we run on the CI. It looks like the later tests try to modify this repo, so I'm not including them in the check. I'm not sure if there's some automated way of updating the .authors.yml, so feel free to fix it if necessary. I was looking for some way of checking whether the news files would combine fine and that the rst was valid, and checking whether a news file had been added, but I couldn't find an option to do that.

@scopatz Any suggestions about tasks that should be run, and if there's a way to check the news files/changelog rst output?
