### PR TITLE
Faster read using Cython code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ h5py/_conv.c
 h5py/_proxy.c
 h5py/_objects.c
 h5py/_errors.c
+h5py/_reader.c
 h5py/config.pxi
 h5py/_hdf5.*
 h5py/*.dll

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -19,7 +19,7 @@ from threading import local
 
 import numpy
 
-from .. import h5, h5s, h5t, h5r, h5d, h5p, h5fd, h5ds
+from .. import h5, h5s, h5t, h5r, h5d, h5p, h5fd, h5ds, _reader
 from .base import HLObject, phil, with_phil, Empty
 from . import filters
 from . import selections as sel
@@ -316,6 +316,20 @@ class Dataset(HLObject):
         return size
 
     @property
+    def _fast_reader(self):
+        """Numpy-style attribute giving the total dataset size"""
+        if '_fast_reader' in self._cache_props:
+            return self._cache_props['_fast_reader']
+
+        rdr = _reader.Reader(self.id)
+
+        # If the file is read-only, cache the reader to speed up future uses.
+        # This cache is invalidated by .refresh() when using SWMR.
+        if self._readonly:
+            self._cache_props['_fast_reader'] = rdr
+        return rdr
+
+    @property
     @with_phil
     def dtype(self):
         """Numpy dtype representing the datatype"""
@@ -496,6 +510,15 @@ class Dataset(HLObject):
         for i in range(shape[0]):
             yield self[i]
 
+    @cached_property
+    def _fast_read_ok(self):
+        """Is this dataset suitable for simple reading"""
+        return (
+            self._extent_type == h5s.SIMPLE
+            and isinstance(self.id.get_type(), (h5t.TypeIntegerID, h5t.TypeFloatID))
+            and h5t.py_create(self.dtype) == self.id.get_type()  # No float promotion
+        )
+
     @with_phil
     def __getitem__(self, args, new_dtype=None):
         """ Read a slice from the HDF5 dataset.
@@ -509,6 +532,13 @@ class Dataset(HLObject):
         * Boolean "mask" array indexing
         """
         args = args if isinstance(args, tuple) else (args,)
+
+        if self._fast_read_ok and (new_dtype is None) and (self._local.astype is None):
+            try:
+                return self._fast_reader.read(args)
+            except TypeError:
+                pass  # Fall back to Python read pathway below
+
         if self._is_empty:
             # Check 'is Ellipsis' to avoid equality comparison with an array:
             # array equality returns an array, not a boolean.

--- a/h5py/_reader.pyx
+++ b/h5py/_reader.pyx
@@ -64,6 +64,9 @@ cdef class Reader:
                 dim_ix += self.rank - nargs  # Skip ahead to the remaining dimensions
                 continue
 
+            if dim_ix >= self.rank:
+                raise ValueError(f"{nargs} indexing arguments for {self.rank} dimensions")
+
             # Length of the relevant dimension
             l = self.dims[dim_ix]
 
@@ -120,8 +123,6 @@ cdef class Reader:
                 self.stride[dim_ix] = 1
                 self.count[dim_ix] = self.dims[dim_ix]
                 self.scalar[dim_ix] = False
-        elif nargs > self.rank:
-            raise ValueError(f"{nargs} indexing arguments for {self.rank} dimensions")
 
         H5Sselect_hyperslab(self.space, H5S_SELECT_SET, self.start, self.stride, self.count, NULL)
         return True

--- a/h5py/_reader.pyx
+++ b/h5py/_reader.pyx
@@ -1,0 +1,162 @@
+# cython: language_level=3
+from numpy cimport npy_intp, PyArray_SimpleNew, PyArray_DATA, import_array
+from cpython cimport PyIndex_Check
+
+from .defs cimport *
+from .h5d cimport DatasetID
+from .h5t cimport TypeID, typewrap
+from .utils cimport emalloc, efree
+
+import_array()
+
+cdef class Reader:
+    cdef hid_t dataset, space
+    cdef TypeID h5_type
+    cdef int rank, np_typenum
+    cdef hsize_t* dims
+    cdef hsize_t* start
+    cdef hsize_t* stride
+    cdef hsize_t* count
+    cdef bint* scalar
+
+    def __cinit__(self, DatasetID dsid):
+        self.dataset = dsid.id
+        self.space = H5Dget_space(self.dataset)
+        self.rank = H5Sget_simple_extent_ndims(self.space)
+
+        self.h5_type = typewrap(H5Dget_type(self.dataset))
+        dtype = self.h5_type.py_dtype()
+        self.np_typenum = dtype.num
+
+        self.dims = <hsize_t*>emalloc(sizeof(hsize_t) * self.rank)
+        self.start = <hsize_t*>emalloc(sizeof(hsize_t) * self.rank)
+        self.stride = <hsize_t*>emalloc(sizeof(hsize_t) * self.rank)
+        self.count = <hsize_t*>emalloc(sizeof(hsize_t) * self.rank)
+        self.scalar = <bint*>emalloc(sizeof(bint) * self.rank)
+
+        H5Sget_simple_extent_dims(self.space, self.dims, NULL)
+
+    def __dealloc__(self):
+        efree(self.dims)
+        efree(self.start)
+        efree(self.stride)
+        efree(self.count)
+        efree(self.scalar)
+
+    cdef bint apply_args(self, tuple args):
+        cdef:
+            int nargs, ellipsis_ix
+            bint seen_ellipsis
+            int dim_ix = 0
+            hsize_t l
+
+        nargs = len(args)
+
+        for a in args:
+            if a is Ellipsis:
+                # [...] - Ellipsis (fill any unspecified dimensions here)
+                if seen_ellipsis:
+                    raise ValueError("Only one ellipsis may be used.")
+                seen_ellipsis = True
+
+                ellipsis_ix = dim_ix
+                nargs -= 1  # Don't count the ... itself
+                dim_ix += self.rank - nargs  # Skip ahead to the remaining dimensions
+                continue
+
+            # Length of the relevant dimension
+            l = self.dims[dim_ix]
+
+            if isinstance(a, slice):
+                # [0:10] - slicing
+                start, stop, step = a.indices(l)
+                # Now if step > 0, then start and stop are in [0, length];
+                # if step < 0, they are in [-1, length - 1] (Python 2.6b2 and later;
+                # Python issue 3004).
+
+                if step < 1:
+                    raise ValueError("Step must be >= 1 (got %d)" % step)
+                if stop < start:
+                    # list/tuple and numpy consider stop < start to be an empty selection
+                    start, count, step = 0, 0, 1
+                else:
+                    count = 1 + (stop - start - 1) // step
+
+                self.start[dim_ix] = start
+                self.stride[dim_ix] = step
+                self.count[dim_ix] = count
+                self.scalar[dim_ix] = False
+
+            elif PyIndex_Check(a):
+                # [0] - simple integer indices
+                if a < 0:
+                    a += l
+
+                if not 0 <= a < l:
+                    if l == 0:
+                        msg = f"Index ({a}) out of range for empty dimension"
+                    else:
+                        msg = f"Index ({a}) out of range for (0-{l-1})"
+                    raise IndexError(msg)
+
+                self.start[dim_ix] = a
+                self.stride[dim_ix] = 1
+                self.count[dim_ix] = 1
+                self.scalar[dim_ix] = True
+            else:
+                return False
+
+            dim_ix += 1
+
+        if nargs == 0:
+            # [()] or [...] -> select all
+            H5Sselect_all(self.space)
+            return True
+        elif nargs < self.rank:
+            # Fill in ellipsis or trailing dimensions
+            ellipsis_end = ellipsis_ix + (self.rank - nargs)
+            for dim_ix in range(ellipsis_ix, ellipsis_end):
+                self.start[dim_ix] = 0
+                self.stride[dim_ix] = 1
+                self.count[dim_ix] = self.dims[dim_ix]
+                self.scalar[dim_ix] = False
+        elif nargs > self.rank:
+            raise ValueError(f"{nargs} indexing arguments for {self.rank} dimensions")
+
+        H5Sselect_hyperslab(self.space, H5S_SELECT_SET, self.start, self.stride, self.count, NULL)
+        return True
+
+    cdef make_array(self):
+        cdef int i, arr_rank = 0
+        cdef npy_intp* arr_shape
+
+        arr_shape = <npy_intp*>emalloc(sizeof(npy_intp) * self.rank)
+        try:
+            # Copy any non-scalar selection dimensions for the array shape
+            for i in range(self.rank):
+                if not self.scalar[i]:
+                    arr_shape[arr_rank] = self.count[i]
+                    arr_rank += 1
+
+            arr = PyArray_SimpleNew(arr_rank, arr_shape, self.np_typenum)
+        finally:
+            efree(arr_shape)
+
+        return arr
+
+    def read(self, tuple args):
+        cdef void* buf
+        cdef hid_t mspace
+        cdef int i
+
+        if not self.apply_args(args):
+            raise TypeError("Unsuitable arguments for simple read")
+
+        arr = self.make_array()
+        buf = PyArray_DATA(arr)
+
+        mspace = H5Screate_simple(self.rank, self.count, NULL)
+
+        H5Dread(self.dataset, self.h5_type.id, mspace, self.space, H5P_DEFAULT, buf)
+
+        return arr

--- a/h5py/tests/test_dataset_getitem.py
+++ b/h5py/tests/test_dataset_getitem.py
@@ -307,10 +307,9 @@ class Test1DZeroFloat(TestCase):
     def test_slice_stop_less_than_start(self):
         self.assertNumpyBehavior(self.dset, self.data, np.s_[7:5])
 
-    # FIXME: NumPy raises IndexError
     def test_index(self):
         """ index -> out of range """
-        with self.assertRaises(ValueError):
+        with self.assertRaises(IndexError):
             self.dset[0]
 
     def test_indexlist(self):
@@ -394,9 +393,8 @@ class Test1DFloat(TestCase):
         with self.assertRaises(TypeError):
             self.dset[{}]
 
-    # FIXME: NumPy raises IndexError
     def test_index_outofrange(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(IndexError):
             self.dset[100]
 
     def test_indexlist_simple(self):

--- a/h5py/tests/test_h5t.py
+++ b/h5py/tests/test_h5t.py
@@ -177,12 +177,12 @@ class TestTypeFloatID(TestCase):
 
         # ebias promotion to float32
         values = f[dataset][:]
-        self.assertTrue(np.all(values == wdata))
+        np.testing.assert_array_equal(values, wdata)
         self.assertEqual(values.dtype, np.dtype('<f4'))
 
         # esize promotion to float32
         values = f[dataset2][:]
-        self.assertTrue(np.all(values == wdata2))
+        np.testing.assert_array_equal(values, wdata2)
         self.assertEqual(values.dtype, np.dtype('<f4'))
 
         # regular half floats

--- a/news/cython-reader.rst
+++ b/news/cython-reader.rst
@@ -1,0 +1,32 @@
+New features
+------------
+
+* Reading typical numeric data now has less overhead, as it can use a fast code
+  path implemented mostly in Cython. Making many small reads from the same
+  dataset can be as much as 10 times faster, but there are many factors that
+  can affect performance.
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>

--- a/setup_build.py
+++ b/setup_build.py
@@ -22,7 +22,7 @@ def localpath(*args):
 
 
 MODULES = ['defs', '_errors', '_objects', '_proxy', 'h5fd', 'h5z',
-            'h5', 'h5i', 'h5r', 'utils',
+            'h5', 'h5i', 'h5r', 'utils', '_reader',
             '_conv', 'h5t', 'h5s',
             'h5p',
             'h5d', 'h5a', 'h5f', 'h5g',


### PR DESCRIPTION
My latest experiment with small read performance. This has been much more successful - I can make many small reads from the same dataset about 10x faster than with the high-level API.

This is how to try it out:

```python
from h5py._reader import Reader

rdr = Reader(ds.id)
arr = rdr.read((slice(0, 10),))
```

10k small reads takes about 50-60 ms reusing the `Reader` object and about 225 ms recreating it each time, versus about 600 ms with existing high-level APIs. A plain C example can do the reads in about 10 ms, so we're within an order of magnitude.

(**Update**: When the high-level slicing API uses a cached Reader object, the same reads take about 70 ms. So there's a bit of overhead involved for the nice API, but it's still much faster than before.)

My thinking is that `Dataset.__getitem__()` would automatically used a cached `Reader` object if certain conditions were met. It would be cached like shape & size - only for readonly files, and invalidated by a SWMR refresh. At present, it works for:

- Datasets with at least 1 dimension
- Data types exactly matching numpy builtin types
- Selections using only integers, slices and Ellipsis

This is just a prototype, so we could make this class more flexible. But the aim is to be fast for common cases - HDF5's strength is in storing arrays of numbers, so I think it's fine to have some limitations and let other cases (like scalar data spaces or vlen strings) be handled by slower code.