### PR TITLE
Abbreviate intro to low-level API docs

### DIFF
--- a/docs_api/index.rst
+++ b/docs_api/index.rst
@@ -1,6 +1,6 @@
 
-Low-Level API Reference
-=======================
+h5py Low-Level API Reference
+============================
 
 
 This documentation contains the auto-generated API information for the
@@ -8,14 +8,10 @@ HDF5 for Python "low-level" interface, a collection of Cython modules
 which form the interface to the HDF5 C library.  It's hosted separately from
 our main documentation as it requires autodoc.
 
-These docs are updated less frequently than the spiffy ReadTheDocs-hosted
-main documentation; this means roughly once per minor (X.Y) release.
+.. note::
 
-This may not be what you're looking for!
-----------------------------------------
-
-**The main docs for h5py are at** https://docs.h5py.org.  **These are
-the docs specifically for the h5py low-level interface.**
+   The main docs for h5py are at https://docs.h5py.org.
+   The docs here are specifically for the h5py low-level interface.
 
 Contents
 --------


### PR DESCRIPTION
The note about them being updated infrequently is no longer needed, and a shorter intro means the more of the list of modules is visible.

Before:
![Screenshot from 2019-11-01 08-38-56](https://user-images.githubusercontent.com/327925/68012917-5f390b00-fc83-11e9-816e-53f9364fcd12.png)

After:
![Screenshot from 2019-11-01 08-39-05](https://user-images.githubusercontent.com/327925/68012925-63fdbf00-fc83-11e9-8b22-7e0ff6eb2357.png)
