### PR TITLE
Unregister converters

### DIFF
--- a/.authors.yml
+++ b/.authors.yml
@@ -611,3 +611,5 @@
   num_commits: 1
   first_commit: 2017-03-22 04:40:26
   github: felixonmars
+- name: Pierlauro Sciarelli
+  email: foss@pstux.dev

--- a/h5py/__init__.py
+++ b/h5py/__init__.py
@@ -13,6 +13,7 @@
 """
 
 from warnings import warn as _warn
+import atexit
 
 
 # --- Library setup -----------------------------------------------------------
@@ -41,8 +42,10 @@ if version.hdf5_version_tuple != version.hdf5_built_version_tuple:
 
 _errors.silence_errors()
 
-from ._conv import register_converters as _register_converters
+from ._conv import register_converters as _register_converters, \
+                   unregister_converters as _unregister_converters
 _register_converters()
+atexit.register(_unregister_converters)
 
 from .h5z import _register_lzf
 _register_lzf()

--- a/news/unregister.rst
+++ b/news/unregister.rst
@@ -1,0 +1,11 @@
+New features
+------------
+
+* This prevents seg-fault at exit where Python code may be called after
+  the interpreter is already half way destroyed, usually in threaded environment.
+
+Development
+-----------
+
+* This allows profiling and code coverage tools to work also
+  on cython code whih is great for developers.


### PR DESCRIPTION
This prevents seg-fault at exit where Python code may be called after
the interpreter is already half way destroyed, usually in threaded environment.

It is a simpler PR extracted from the "nogil" part I am working on ...