### PR TITLE
Attempt to fix performance problems reading/writing with integer indexing

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -26,3 +26,32 @@ class TimeSuite:
         ds = self.f['a']
         for i in range(10000):
             arr = ds[i * 10:(i + 1) * 10]
+
+class WritingTimeSuite:
+    """Based on example in GitHub issue 492:
+    https://github.com/h5py/h5py/issues/492
+    """
+    def setup(self):
+        self._td = TemporaryDirectory()
+        path = osp.join(self._td.name, 'test.h5')
+        self.f = h5py.File(path, 'w')
+        self.shape = shape = (128, 1024, 512)
+        self.f.create_dataset(
+            'a', shape=shape, dtype=np.float32, chunks=(1, shape[1], 64)
+        )
+
+    def teardown(self):
+        self.f.close()
+        self._td.cleanup()
+
+    def time_write_index_last_axis(self):
+        ds = self.f['a']
+        data = np.zeros(self.shape[:2])
+        for i in range(self.shape[2]):
+            ds[..., i] = data
+
+    def time_write_slice_last_axis(self):
+        ds = self.f['a']
+        data = np.zeros(self.shape[:2])
+        for i in range(self.shape[2]):
+            ds[..., i:i+1] = data[..., np.newaxis]

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -603,22 +603,16 @@ class Dataset(HLObject):
         selection = sel.select(self.shape, args, dsid=self.id)
 
         if selection.nselect == 0:
-            return numpy.ndarray(selection.mshape, dtype=new_dtype)
+            return numpy.ndarray(selection.array_shape, dtype=new_dtype)
 
         # Up-converting to (1,) so that numpy.ndarray correctly creates
         # np.void rows in case of multi-field dtype. (issue 135)
-        single_element = selection.mshape == ()
-        mshape = (1,) if single_element else selection.mshape
-        arr = numpy.ndarray(mshape, new_dtype, order='C')
-
-        # HDF5 has a bug where if the memory shape has a different rank
-        # than the dataset, the read is very slow
-        if len(mshape) < len(self.shape):
-            # pad with ones
-            mshape = (1,)*(len(self.shape)-len(mshape)) + mshape
+        single_element = selection.array_shape == ()
+        arr_shape = (1,) if single_element else selection.array_shape
+        arr = numpy.ndarray(arr_shape, new_dtype, order='C')
 
         # Perform the actual read
-        mspace = h5s.create_simple(mshape)
+        mspace = h5s.create_simple(selection.mshape)
         fspace = selection.id
         self.id.read(mspace, fspace, arr, mtype, dxpl=self._dxpl)
 
@@ -750,14 +744,14 @@ class Dataset(HLObject):
         # memory. In any case, if we cannot afford to create an intermediate
         # array of the same size as the dataset chunk size, the user program has
         # little hope to go much further. Solves h5py isue #1067
-        if mshape == () and selection.mshape != ():
+        if mshape == () and selection.array_shape != ():
             if self.dtype.subdtype is not None:
                 raise TypeError("Scalar broadcasting is not supported for array dtypes")
-            if self.chunks and (numpy.prod(self.chunks, dtype=numpy.float) >= \
-                                numpy.prod(selection.mshape, dtype=numpy.float)):
-                val2 = numpy.empty(selection.mshape, dtype=val.dtype)
+            if self.chunks and (numpy.prod(self.chunks, dtype=numpy.float) >=
+                                numpy.prod(selection.array_shape, dtype=numpy.float)):
+                val2 = numpy.empty(selection.array_shape, dtype=val.dtype)
             else:
-                val2 = numpy.empty(selection.mshape[-1], dtype=val.dtype)
+                val2 = numpy.empty(selection.array_shape[-1], dtype=val.dtype)
             val2[...] = val
             val = val2
             mshape = val.shape

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -757,13 +757,7 @@ class Dataset(HLObject):
             mshape = val.shape
 
         # Perform the write, with broadcasting
-        # Be careful to pad memory shape with ones to avoid HDF5 chunking
-        # glitch, which kicks in for mismatched memory/file selections
-        if len(mshape) < len(self.shape):
-            mshape_pad = (1,)*(len(self.shape)-len(mshape)) + mshape
-        else:
-            mshape_pad = mshape
-        mspace = h5s.create_simple(mshape_pad, (h5s.UNLIMITED,)*len(mshape_pad))
+        mspace = h5s.create_simple(selection.expand_shape(mshape))
         for fspace in selection.broadcast(mshape):
             self.id.write(mspace, fspace, val, mtype, dxpl=self._dxpl)
 

--- a/h5py/_hl/vds.py
+++ b/h5py/_hl/vds.py
@@ -97,7 +97,7 @@ class VirtualSource(object):
 
     @property
     def shape(self):
-        return self.sel.mshape
+        return self.sel.array_shape
 
     def __getitem__(self, key):
         tmp = copy(self)

--- a/news/select-mshape.rst
+++ b/news/select-mshape.rst
@@ -1,0 +1,30 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* Fix pathologically slow reading/writing in certain conditions with integer
+  indexing (:issue:`492`).
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
See e.g. #492

When you use an integer index for an inner dimension, I think h5py is constructing a mismatched shape, because it always adds the padding dimensions at the beginning of the shape. In the example from #492:

- Dataset shape: (128, 2048, 512)
- Indexing: `dset[..., i]`
- Selection shape (HDF5): (128, 2048, 1)
- Selection shape (Python): (128, 2048)
- Padded selection shape (`mshape_pad`): (1, 128, 2048)

I guess that trying to convert from (128, 2048, 1) to (1, 128, 2048) triggers some pathological behaviour in HDF5. From the comments, it looked like padding the shape was an attempt to work around that, but always adding the dimensions at the start of the shape isn't always right. We also found a case where reading with an integer index was ~60x slower than with a slice - but this is partly avoided on master by my fast-path reader (#1428).

This PR tries to better match the array dimensions to dataset dimensions for mspace.

- For `__getitem__`, we preserve a copy of the selected shape without dropping dimensions with a scalar selection. The only hard bit is naming: I've gone for `mshape` for the shape preserving all dimensions, and `array_shape` for the shape with scalar dimensions dropped.
- For `__setitem__`, we can't just use the selection shape, because we may be broadcasting a smaller array. So the `selection.expand_shape()` method, refactored out of `selection.broadcast()`, matches the array dimensions up to the selection dimensions.

Testing the example in #492, this does seem to make writing with `[..., i]` as fast as `[..., i:i+1]`.

Struggling to understand the `broadcast()` method, I realised that the `target_shape` parameter actually describes the shape of the *source* data which is to be broadcast to the selection. So I've also renamed that.