### PR TITLE
fix for #1448

### DIFF
--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -315,7 +315,7 @@ class File(Group):
             Library version bounds.  Supported values: 'earliest', 'v108',
             'v110', 'v112'  and 'latest'. The 'v108', 'v110' and 'v112'
             options can only be specified with the HDF5 1.10.2 library or later.
-        userblock
+        userblock_size
             Desired size of user block.  Only allowed when creating a new
             file (mode w, w- or x).
         swmr


### PR DESCRIPTION
Match docstring to argument name userblock_size.