### PR TITLE
Protect Dataset.__getitem__ with phil lock

### DIFF
--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -603,6 +603,7 @@ class Dataset(HLObject):
         """
         return ChunkIterator(self, sel)
 
+    @with_phil
     def __getitem__(self, args, new_dtype=None):
         """ Read a slice from the HDF5 dataset.
 


### PR DESCRIPTION
See discussion on #1453, where we realised that the fast read pathway never acquires the lock. This doesn't seem to be an issue on more recent HDF5 (presumably because it has its own lock), but it came up with an older version. I've repeated the crashing scenario with this change, and it works.

All the other high-level methods use the `phil` lock, including `__setitem__`, so it seems reasonable to add it to `__geitem__` as well. The (private) `Reader` machinery assumes that its caller has acquired the lock.