### PR TITLE
Simplify low-level error handling

### DIFF
--- a/api_gen.py
+++ b/api_gen.py
@@ -39,18 +39,16 @@ class Line(object):
                     function. Any Python callbacks it could trigger must
                     acquire the GIL (e.g. using 'with gil' in Cython).
         mpi:        Bool indicating if MPI required
-        error:      Bool indicating if special error handling required
         version:    None or a minimum-version tuple
         code:       String with function return type
         fname:      String with function name
         sig:        String with raw function signature
         args:       String with sequence of arguments to call function
 
-        Example:    MPI ERROR 1.8.12 int foo(char* a, size_t b)
+        Example:    MPI 1.8.12 int foo(char* a, size_t b)
 
         .nogil:     ""
         .mpi:       True
-        .error:     True
         .version:   (1, 8, 12)
         .code:      "int"
         .fname:     "foo"
@@ -59,7 +57,6 @@ class Line(object):
     """
 
     PATTERN = re.compile("""(?P<mpi>(MPI)[ ]+)?
-                            (?P<error>(ERROR)[ ]+)?
                             (?P<min_version>([0-9]+\.[0-9]+\.[0-9]+))?
                             (-(?P<max_version>([0-9]+\.[0-9]+\.[0-9]+)))?
                             ([ ]+)?
@@ -90,7 +87,6 @@ class Line(object):
         parts = m.groupdict()
         self.nogil = "nogil" if parts['nogil'] else ""
         self.mpi = parts['mpi'] is not None
-        self.error = parts['error'] is not None
         self.min_version = parts['min_version']
         if self.min_version is not None:
             self.min_version = tuple(int(x) for x in self.min_version.split('.'))
@@ -160,6 +156,7 @@ from .api_types_hdf5 cimport *
 from . cimport _hdf5
 
 from ._errors cimport set_exception, set_default_error_handler
+
 """
 
 
@@ -250,7 +247,7 @@ cdef {0.code} {0.fname}({0.sig}) except {0.err_value}:
     if r{0.err_condition}:
         if set_exception():
             return {0.err_value}
-        elif {0.error}:
+        else:
             raise RuntimeError("Unspecified error in {0.fname} (return value {0.err_condition})")
     return r
 
@@ -264,7 +261,7 @@ cdef {0.code} {0.fname}({0.sig}) except {0.err_value}:
     if r{0.err_condition}:
         if set_exception():
             return {0.err_value}
-        elif {0.error}:
+        else:
             raise RuntimeError("Unspecified error in {0.fname} (return value {0.err_condition})")
     return r
 

--- a/h5py/_errors.pyx
+++ b/h5py/_errors.pyx
@@ -10,7 +10,6 @@
 # Python-style minor error classes.  If the minor error code matches an entry
 # in this dict, the generated exception will be used.
 
-from ._hl.compat import filename_encode, filename_decode
 from cpython cimport PyErr_Occurred
 
 _minor_table = {
@@ -135,10 +134,7 @@ cdef int set_exception() except -1:
     if desc_bottom is NULL:
         raise RuntimeError("Failed to extract bottom-level error description")
 
-    msg = filename_encode(u"{0} ({1})".format(
-        filename_decode(desc).capitalize(),
-        filename_decode(desc_bottom)
-    ))
+    msg = b"%b (%b)" % (bytes(desc).capitalize(), bytes(desc_bottom))
 
     # Finally, set the exception.  We do this with the Python C function
     # so that the traceback doesn't point here.

--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -573,15 +573,15 @@ hdf5_hl:
 
   # === H5DS - Dimension Scales API =============================================
 
-  ERROR herr_t  H5DSattach_scale(hid_t did, hid_t dsid, unsigned int idx)
-  ERROR herr_t  H5DSdetach_scale(hid_t did, hid_t dsid, unsigned int idx)
-  ERROR htri_t  H5DSis_attached(hid_t did, hid_t dsid, unsigned int idx)
-  ERROR herr_t  H5DSset_scale(hid_t dsid, char *dimname)
-  ERROR int     H5DSget_num_scales(hid_t did, unsigned int dim)
+  herr_t  H5DSattach_scale(hid_t did, hid_t dsid, unsigned int idx)
+  herr_t  H5DSdetach_scale(hid_t did, hid_t dsid, unsigned int idx)
+  htri_t  H5DSis_attached(hid_t did, hid_t dsid, unsigned int idx)
+  herr_t  H5DSset_scale(hid_t dsid, char *dimname)
+  int     H5DSget_num_scales(hid_t did, unsigned int dim)
 
-  ERROR herr_t  H5DSset_label(hid_t did, unsigned int idx, char *label)
-  ERROR ssize_t H5DSget_label(hid_t did, unsigned int idx, char *label, size_t size)
+  herr_t  H5DSset_label(hid_t did, unsigned int idx, char *label)
+  ssize_t H5DSget_label(hid_t did, unsigned int idx, char *label, size_t size)
 
-  ERROR ssize_t H5DSget_scale_name(hid_t did, char *name, size_t size)
-  ERROR htri_t  H5DSis_scale(hid_t did)
-  ERROR herr_t  H5DSiterate_scales(hid_t did, unsigned int dim, int *idx, H5DS_iterate_t visitor, void *visitor_data)
+  ssize_t H5DSget_scale_name(hid_t did, char *name, size_t size)
+  htri_t  H5DSis_scale(hid_t did)
+  herr_t  H5DSiterate_scales(hid_t did, unsigned int dim, int *idx, H5DS_iterate_t visitor, void *visitor_data)


### PR DESCRIPTION
This makes several related changes to how errors are handled in the lowest level wrappers around HDF5 functions.

1. Don't use `except *` in the 'extern' declarations of raw HDF5 functions. Removing this avoids Cython checking `PyErr_Occurred()` before our generated error-checking. Consequently, if HDF5 indicates an error, I've added a check for an existing Python error before trying to create a new exception.
2. Use specific error values on the generated wrapper functions, e.g. `except <hid_t>-1` rather than `except *`. This means Cython checks the return value of the function rather than checking `PyErr_Occurred` in all cases. A comment suggests that this was previously not possible, but it works now.
3. Be prepared to handle an error return value with no HDF5 error information in all wrapper functions, rather than only those with a special `ERROR` flag. I believe this has no performance penalty normally, as the branch is only taken if attempting to retrieve HDF5 error information fails.
4. Avoid converting bytes to unicode and back again while processing error messages.

1 & 2 may reduce the overhead of calling HDF5 functions slightly, but I'm mainly trying to make the lowest level bindings simpler and clearer.
