### PR TITLE
Fix lzf filter build with HDF5 1.10.x

### DIFF
--- a/lzf/lzf_filter.c
+++ b/lzf/lzf_filter.c
@@ -43,18 +43,22 @@
 #endif
 
 /*  Deal with the multiple definitions for H5Z_class_t.
-    Note: Only HDF5 1.6 and 1.8 are supported.
+    Note: HDF5 >=1.6 are supported.
 
     (1) The old class should always be used for HDF5 1.6
     (2) The new class should always be used for HDF5 1.8 < 1.8.3
-    (3) The old class should be used for HDF5 1.8 >= 1.8.3 only if the
+    (3) The old class should be used for HDF5 >= 1.8.3 only if the
         macro H5_USE_16_API is set
 */
 
-#if H5_VERS_MAJOR == 1 && H5_VERS_MINOR == 8 && (H5_VERS_RELEASE < 3 || !H5_USE_16_API)
-#define H5PY_H5Z_NEWCLS 1
-#else
+#if H5_VERS_MAJOR == 1 && H5_VERS_MINOR == 6
 #define H5PY_H5Z_NEWCLS 0
+#elif H5_VERS_MAJOR == 1 && H5_VERS_MINOR == 8 && H5_VERS_RELEASE < 3
+#define H5PY_H5Z_NEWCLS 1
+#elif H5_USE_16_API
+#define H5PY_H5Z_NEWCLS 0
+#else /* Default: use new class */
+#define H5PY_H5Z_NEWCLS 1
 #endif
 
 size_t lzf_filter(unsigned flags, size_t cd_nelmts,

--- a/news/lzf-filter-build.rst
+++ b/news/lzf-filter-build.rst
@@ -1,0 +1,4 @@
+Building h5py
+-------------
+
+* Make the lzf filter build with HDF5 1.10  #1219


### PR DESCRIPTION
<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- Add a release note in the news/ folder (copy TEMPLATE.rst)

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->


This PR updates the C macro handling of the `lzf` filter to make it compatible with hdf5 1.10.x.
I tested with hdf5 1.10.5 and 1.8.21 (I haven't tested 1.6 or 1.8.x <1.8.3.... but they should still be supported).

This is one little step towards eventually removing the `H5_USE_16_API` HDF5 1.6 compatibility flag.