### PR TITLE
FIX: remove `base.MappingHDF5` from `dims.DimensionManager`

### DIFF
--- a/h5py/_hl/dims.py
+++ b/h5py/_hl/dims.py
@@ -136,7 +136,7 @@ class DimensionProxy(base.CommonStateObject):
                % (self.label, self._dimension, id(self._id)))
 
 
-class DimensionManager(base.MappingHDF5, base.CommonStateObject):
+class DimensionManager(base.CommonStateObject):
 
     """
         Represents a collection of dimension associated with a dataset.

--- a/news/dims-collection.rst
+++ b/news/dims-collection.rst
@@ -1,0 +1,29 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* Remove `base.MappingHDF5` from `dims.DimensionManager` class definition to handle as collection only, resolves https://github.com/h5py/h5py/issues/744.
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
- remove `base.MappingHDF5` from `dims.DimensionManager` to not add unneeded Mapping properties
- resolves https://github.com/h5py/h5py/issues/744

Update: Description changed and force-pushed 

<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- Add a release note in the news/ folder (copy TEMPLATE.rst)

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->
