### PR TITLE
Use versionadded directive for new chunk query functions

### DIFF
--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -118,6 +118,11 @@ hdf5:
   1.10.2    herr_t H5DOread_chunk(hid_t dset_id, hid_t dxpl_id, const hsize_t *offset, uint32_t *filters, void *buf) nogil
   1.10.3    herr_t H5Dread_chunk(hid_t dset_id, hid_t dxpl_id, const hsize_t *offset, uint32_t *filters, void *buf) nogil
 
+  # Chunk query functions
+  1.10.5    herr_t H5Dget_num_chunks(hid_t dset_id, hid_t fspace_id, hsize_t *nchunks)
+  1.10.5    herr_t H5Dget_chunk_info(hid_t dset_id, hid_t fspace_id, hsize_t chk_idx, hsize_t *offset, unsigned *filter_mask, haddr_t *addr, hsize_t *size)
+  1.10.5    herr_t H5Dget_chunk_info_by_coord(hid_t dset_id, const hsize_t *offset, unsigned *filter_mask, haddr_t *addr, hsize_t *size)
+
 
   # === H5E - Minimal error-handling interface ================================
 
@@ -162,12 +167,6 @@ hdf5:
 
   # SWMR functions
   1.9.178   herr_t H5Fstart_swmr_write(hid_t file_id)
-
-  # Chunk query functions
-  1.10.5    herr_t H5Dget_num_chunks(hid_t dset_id, hid_t fspace_id, hsize_t *nchunks)
-  1.10.5    herr_t H5Dget_chunk_info(hid_t dset_id, hid_t fspace_id, hsize_t chk_idx, hsize_t *offset, unsigned *filter_mask, haddr_t *addr, hsize_t *size)
-  1.10.5    herr_t H5Dget_chunk_info_by_coord(hid_t dset_id, const hsize_t *offset, unsigned *filter_mask, haddr_t *addr, hsize_t *size)
-
 
   # === H5FD - Virtual File Layer =========================================================
 

--- a/h5py/h5d.pyx
+++ b/h5py/h5d.pyx
@@ -515,7 +515,9 @@ cdef class DatasetID(ObjectID):
             specified dataspace. Currently, this function only gets the number
             of all written chunks, regardless of the dataspace.
 
-            Feature requires: 1.10.5 HDF5
+            Feature requires: HDF5 1.10.5
+
+            .. versionadded:: 3.0
             """
             cdef hsize_t num_chunks
 
@@ -530,7 +532,9 @@ cdef class DatasetID(ObjectID):
 
             Retrieve storage information about a chunk specified by its index.
 
-            Feature requires: 1.10.5 HDF5
+            Feature requires: HDF5 1.10.5
+
+            .. versionadded:: 3.0
             """
             cdef haddr_t byte_offset
             cdef hsize_t size
@@ -567,7 +571,9 @@ cdef class DatasetID(ObjectID):
             Retrieve information about a chunk specified by the array
             address of the chunk’s first element in each dimension.
 
-            Feature requires: 1.10.5 HDF5
+            Feature requires: HDF5 1.10.5
+
+            .. versionadded:: 3.0
             """
             cdef haddr_t byte_offset
             cdef hsize_t size


### PR DESCRIPTION
Closes #1449

Also moved the listing of the HDF5 functions into the correct section (H5F -> H5D).

This change doesn't need a news entry.