### PR TITLE
Support split files

### DIFF
--- a/docs/high/file.rst
+++ b/docs/high/file.rst
@@ -85,6 +85,15 @@ of supported drivers and their options:
         Store the data in a Python file-like object; see below.
         This is the default if a file-like object is passed to :class:`File`.
 
+    'split'
+        Splits the meta data and raw data into separate files. Keywords:
+
+        meta_ext:
+          Metadata filename extension. Default is '-m.h5'.
+
+        raw_ext:
+          Raw data filename extension. Default is '-r.h5'.
+
 .. _file_fileobj:
 
 Python file-like objects

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -52,13 +52,6 @@ def _set_fapl_mpio(plist, **kwargs):
 def _set_fapl_fileobj(plist, **kwargs):
     plist.set_fileobj_driver(h5fd.fileobj_driver, kwargs.get('fileobj'))
 
-def _set_fapl_split(plist, **kwargs):
-    kwargs.setdefault('meta_ext', b'-m.h5')
-    kwargs.setdefault('meta_plist_id', h5p.DEFAULT)
-    kwargs.setdefault('raw_ext', b'-r.h5')
-    kwargs.setdefault('raw_plist_id', h5p.DEFAULT)
-    plist.set_fapl_split(**kwargs)
-
 
 _drivers = {
     'sec2': lambda plist, **kwargs: plist.set_fapl_sec2(**kwargs),
@@ -70,7 +63,7 @@ _drivers = {
     ),
     'mpio': _set_fapl_mpio,
     'fileobj': _set_fapl_fileobj,
-    'split': _set_fapl_split,
+    'split': lambda plist, **kwargs: plist.set_fapl_split(**kwargs),
 }
 
 

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -52,6 +52,13 @@ def _set_fapl_mpio(plist, **kwargs):
 def _set_fapl_fileobj(plist, **kwargs):
     plist.set_fileobj_driver(h5fd.fileobj_driver, kwargs.get('fileobj'))
 
+def _set_fapl_split(plist, **kwargs):
+    kwargs.setdefault('meta_ext', b'-m.h5')
+    kwargs.setdefault('meta_plist_id', h5p.DEFAULT)
+    kwargs.setdefault('raw_ext', b'-r.h5')
+    kwargs.setdefault('raw_plist_id', h5p.DEFAULT)
+    plist.set_fapl_split(**kwargs)
+
 
 _drivers = {
     'sec2': lambda plist, **kwargs: plist.set_fapl_sec2(**kwargs),
@@ -63,6 +70,7 @@ _drivers = {
     ),
     'mpio': _set_fapl_mpio,
     'fileobj': _set_fapl_fileobj,
+    'split': _set_fapl_split,
 }
 
 

--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -307,6 +307,7 @@ hdf5:
   herr_t    H5Pget_cache(hid_t plist_id, int *mdc_nelmts, size_t *rdcc_nelmts, size_t *rdcc_nbytes, double *rdcc_w0)
   herr_t    H5Pset_fapl_sec2(hid_t fapl_id)
   herr_t    H5Pset_fapl_stdio(hid_t fapl_id)
+  herr_t    H5Pset_fapl_split(hid_t fapl_id, const char *meta_ext, hid_t meta_plist_id, const char *raw_ext, hid_t raw_plist_id)
   herr_t    H5Pset_driver(hid_t plist_id, hid_t driver_id, void *driver_info)
   hid_t     H5Pget_driver(hid_t fapl_id)
   void*     H5Pget_driver_info(hid_t plist_id)

--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -114,7 +114,10 @@ OBJECT_CREATE = lockcls(H5P_OBJECT_CREATE)
 CRT_ORDER_TRACKED = H5P_CRT_ORDER_TRACKED
 CRT_ORDER_INDEXED = H5P_CRT_ORDER_INDEXED
 
-DEFAULT = H5P_DEFAULT
+DEFAULT = None   # In the HDF5 header files this is actually 0, which is an
+                 # invalid identifier.  The new strategy for default options
+                 # is to make them all None, to better match the Python style
+                 # for keyword arguments.
 
 
 # === Property list functional API ============================================
@@ -1078,7 +1081,6 @@ cdef class PropFAID(PropInstanceID):
         - h5fd.MULTI
         - h5fd.SEC2
         - h5fd.STDIO
-        - h5fd.SPLIT
         """
         return H5Pget_driver(self.id)
 

--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -1038,12 +1038,12 @@ cdef class PropFAID(PropInstanceID):
         H5Pset_fapl_stdio(self.id)
 
     @with_phil
-    def set_fapl_split(self, const char* meta_ext, hid_t meta_plist_id, const char*raw_ext, hid_t raw_plist_id):
+    def set_fapl_split(self, const char* meta_ext="-m.h5", PropID meta_plist_id=None, const char* raw_ext="-r.h5", PropID raw_plist_id=None):
         """()
 
         Select the "split" driver (h5fd.SPLIT)
         """
-        H5Pset_fapl_split(self.id, meta_ext, meta_plist_id, raw_ext, raw_plist_id)
+        H5Pset_fapl_split(self.id, meta_ext, pdefault(meta_plist_id), raw_ext, pdefault(raw_plist_id))
 
 
     @with_phil

--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -114,10 +114,7 @@ OBJECT_CREATE = lockcls(H5P_OBJECT_CREATE)
 CRT_ORDER_TRACKED = H5P_CRT_ORDER_TRACKED
 CRT_ORDER_INDEXED = H5P_CRT_ORDER_INDEXED
 
-DEFAULT = None   # In the HDF5 header files this is actually 0, which is an
-                 # invalid identifier.  The new strategy for default options
-                 # is to make them all None, to better match the Python style
-                 # for keyword arguments.
+DEFAULT = H5P_DEFAULT
 
 
 # === Property list functional API ============================================
@@ -1037,6 +1034,14 @@ cdef class PropFAID(PropInstanceID):
         """
         H5Pset_fapl_stdio(self.id)
 
+    @with_phil
+    def set_fapl_split(self, const char* meta_ext, hid_t meta_plist_id, const char*raw_ext, hid_t raw_plist_id):
+        """()
+
+        Select the "split" driver (h5fd.SPLIT)
+        """
+        H5Pset_fapl_split(self.id, meta_ext, meta_plist_id, raw_ext, raw_plist_id)
+
 
     @with_phil
     def set_driver(self, hid_t driver_id):
@@ -1073,6 +1078,7 @@ cdef class PropFAID(PropInstanceID):
         - h5fd.MULTI
         - h5fd.SEC2
         - h5fd.STDIO
+        - h5fd.SPLIT
         """
         return H5Pget_driver(self.id)
 

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -253,6 +253,7 @@ class TestDrivers(TestCase):
         self.assertTrue(os.path.exists(fname + '-m.h5'))
         fid = File(fname, 'r', driver='split')
         self.assertTrue(fid)
+        fid.close()
 
     # TODO: family driver tests
 

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -245,6 +245,15 @@ class TestDrivers(TestCase):
         self.assertTrue(fid)
         fid.close()
 
+    def test_split(self):
+        """ Split stores metadata in a separate file """
+        fname = self.mktemp()
+        fid = File(fname, 'w', driver='split')
+        fid.close()
+        self.assertTrue(os.path.exists(fname + '-m.h5'))
+        fid = File(fname, 'r', driver='split')
+        self.assertTrue(fid)
+
     # TODO: family driver tests
 
 

--- a/news/split-files.rst
+++ b/news/split-files.rst
@@ -1,0 +1,29 @@
+New features
+------------
+
+* Introduced support for split files.
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* H5Pset_fapl_split
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
Adds support for split HDF5 files.

I revived this old pull request: https://github.com/h5py/h5py/pull/718

<!--
Thanks for contributing to h5py!

Before opening a pull request, please:


- Add a release note in the news/ folder (copy TEMPLATE.rst)

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->
