### PR TITLE
Missing dep msg

### DIFF
--- a/news/missing_dep_msg.rst
+++ b/news/missing_dep_msg.rst
@@ -1,0 +1,19 @@
+New features
+------------
+
+Deprecations
+------------
+
+Exposing HDF5 functions
+-----------------------
+
+Bug fixes
+---------
+
+Building h5py
+-------------
+- If HDF5 is not loaded, an additional message is displayed to check HDF5 installation
+Development
+-----------
+
+* <news item>

--- a/setup_configure.py
+++ b/setup_configure.py
@@ -234,14 +234,17 @@ def autodetect_version(hdf5_dir=None):
     if path is None:
         path = default_path
 
-    print("Loading library to get version:", path)
-
-    lib = ctypes.cdll.LoadLibrary(path)
-
     major = ctypes.c_uint()
     minor = ctypes.c_uint()
     release = ctypes.c_uint()
 
-    lib.H5get_libversion(byref(major), byref(minor), byref(release))
+    print("Loading library to get version:", path)
+
+    try:
+        lib = ctypes.cdll.LoadLibrary(path)
+        lib.H5get_libversion(byref(major), byref(minor), byref(release))
+    except:
+        print("error: Unable to load dependency HDF5, make sure HDF5 is installed properly")
+        raise
 
     return "{0}.{1}.{2}".format(int(major.value), int(minor.value), int(release.value))


### PR DESCRIPTION
- Run simple static checks with `tox -e pre-commit`
```
(venv) test@f286f454f7ce:~/code/h5py$ tox -e pre-commit
pre-commit installed: aspy.yaml==1.3.0,cfgv==2.0.1,h5py==2.10.0,identify==1.4.8,importlib-metadata==1.3.0,importlib-resources==1.0.2,more-itertools==8.0.2,nodeenv==1.3.3,pre-commit==1.20.0,PyYAML==5.2,six==1.13.0,toml==0.10.0,virtualenv==16.7.9,zipp==0.6.0
pre-commit run-test-pre: PYTHONHASHSEED='1580159698'
pre-commit run-test: commands[0] | pre-commit run --all-files
Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Passed
check-manifest...........................................................Passed
__________________________________________________________________ summary ___________________________________________________________________
  pre-commit: commands succeeded
  congratulations :)

```
- Run the tests with e.g. `tox -e py37-test-deps`
```
(venv) test@f286f454f7ce:~/code/h5py$ tox -e py36-test-deps
GLOB sdist-make: /home/test/code/h5py/setup.py
py36-test-deps inst-nodeps: /home/test/code/h5py/.tox/.tmp/package/1/h5py-2.10.0.zip
py36-test-deps installed: attrs==19.3.0,cached-property==1.5.1,coverage==5.0,Cython==0.29.14,h5py==2.10.0,importlib-metadata==1.3.0,more-itertools==8.0.2,numpy==1.17.4,packaging==19.2,pluggy==0.13.1,py==1.8.0,pyparsing==2.4.5,pytest==5.3.2,pytest-cov==2.8.1,pytest-mpi==0.3,six==1.13.0,wcwidth==0.1.7,zipp==0.6.0
py36-test-deps run-test-pre: PYTHONHASHSEED='3867175640'
py36-test-deps run-test: commands[0] | python -c 'import sys; print('"'"'64 bit?'"'"', sys.maxsize > 2**32)'
64 bit? True
py36-test-deps run-test: commands[1] | python /home/test/code/h5py/ci/fix_paths.py
site packages dir: /home/test/code/h5py/.tox/py36-test-deps/lib/python3.6/site-packages
HDF5_DIR None
In installed h5py: ['h5g.cpython-36m-x86_64-linux-gnu.so', '_errors.cpython-36m-x86_64-linux-gnu.so', 'defs.cpython-36m-x86_64-linux-gnu.so', 'h5f.cpython-36m-x86_64-linux-gnu.so', '_objects.cpython-36m-x86_64-linux-gnu.so', 'tests', 'h5i.cpython-36m-x86_64-linux-gnu.so', 'h5t.cpython-36m-x86_64-linux-gnu.so', 'h5r.cpython-36m-x86_64-linux-gnu.so', '_conv.cpython-36m-x86_64-linux-gnu.so', 'h5z.cpython-36m-x86_64-linux-gnu.so', 'h5o.cpython-36m-x86_64-linux-gnu.so', '__pycache__', 'h5l.cpython-36m-x86_64-linux-gnu.so', 'h5s.cpython-36m-x86_64-linux-gnu.so', '_proxy.cpython-36m-x86_64-linux-gnu.so', 'h5ds.cpython-36m-x86_64-linux-gnu.so', 'ipy_completer.py', 'h5pl.cpython-36m-x86_64-linux-gnu.so', 'h5ac.cpython-36m-x86_64-linux-gnu.so', 'h5a.cpython-36m-x86_64-linux-gnu.so', 'utils.cpython-36m-x86_64-linux-gnu.so', '__init__.py', 'h5py_warnings.py', 'version.py', 'h5.cpython-36m-x86_64-linux-gnu.so', 'h5p.cpython-36m-x86_64-linux-gnu.so', '_hl', '_reader.cpython-36m-x86_64-linux-gnu.so', 'h5fd.cpython-36m-x86_64-linux-gnu.so', 'h5d.cpython-36m-x86_64-linux-gnu.so']
py36-test-deps run-test: commands[2] | python -m pytest --pyargs h5py --cov=h5py -rxXs --cov-config=/home/test/code/h5py/.coveragerc
============================================================ test session starts =============================================================
platform linux -- Python 3.6.9, pytest-5.3.2, py-1.8.0, pluggy-0.13.1
cachedir: .tox/py36-test-deps/.pytest_cache
rootdir: /home/test/code/h5py, inifile: pytest.ini
plugins: cov-2.8.1, mpi-0.3
collected 572 items                                                                                                                          

py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_attribute_create.py .....                                                   [  0%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_attrs.py ................s                                                  [  3%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_attrs_data.py ....................                                          [  7%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_base.py ..s..                                                               [  8%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_completions.py ..                                                           [  8%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_dataset.py ...........x.................................................... [ 19%]
........................x................................s.                                                                            [ 30%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_dataset_getitem.py .................................................x...... [ 39%]
..............................                                                                                                         [ 45%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_dataset_swmr.py ssss..........                                              [ 47%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_datatype.py ..                                                              [ 47%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_dimension_scales.py ....s................                                   [ 51%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_dims_dimensionproxy.py .                                                    [ 51%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_dtype.py ..................ssss                                             [ 55%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_errors.py ...                                                               [ 56%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_file.py ....................sssssss......sss.............sss                [ 65%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_file2.py .................                                                  [ 68%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_file_image.py ..                                                            [ 68%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_filters.py ....                                                             [ 69%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_group.py ................................................................ss [ 80%]
..................                                                                                                                     [ 83%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_h5.py .....                                                                 [ 84%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_h5d_direct_chunk.py .sss                                                    [ 85%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_h5f.py ......                                                               [ 86%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_h5p.py .sss.....                                                            [ 88%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_h5pl.py ssssss                                                              [ 89%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_h5t.py ...                                                                  [ 89%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_objects.py ...                                                              [ 90%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_selections.py ....                                                          [ 90%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_slicing.py ........................                                         [ 95%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_vds/test_highlevel_vds.py ......                                            [ 96%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_vds/test_lowlevel_vds.py ...s                                               [ 96%]
py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_vds/test_virtual_source.py ..................                               [100%]

----------- coverage: platform linux, python 3.6.9-final-0 -----------
Name                                                                 Stmts   Miss  Cover
----------------------------------------------------------------------------------------
py36-test-deps/lib/python3.6/site-packages/h5py/__init__.py             52     23    56%
py36-test-deps/lib/python3.6/site-packages/h5py/_hl/__init__.py          1      0   100%
py36-test-deps/lib/python3.6/site-packages/h5py/_hl/attrs.py           127     16    87%
py36-test-deps/lib/python3.6/site-packages/h5py/_hl/base.py            187     20    89%
py36-test-deps/lib/python3.6/site-packages/h5py/_hl/compat.py           18      8    56%
py36-test-deps/lib/python3.6/site-packages/h5py/_hl/dataset.py         528     76    86%
py36-test-deps/lib/python3.6/site-packages/h5py/_hl/datatype.py         20      1    95%
py36-test-deps/lib/python3.6/site-packages/h5py/_hl/dims.py             83      7    92%
py36-test-deps/lib/python3.6/site-packages/h5py/_hl/files.py           208     23    89%
py36-test-deps/lib/python3.6/site-packages/h5py/_hl/filters.py         193     16    92%
py36-test-deps/lib/python3.6/site-packages/h5py/_hl/group.py           237     10    96%
py36-test-deps/lib/python3.6/site-packages/h5py/_hl/selections.py      299     54    82%
py36-test-deps/lib/python3.6/site-packages/h5py/_hl/selections2.py      42      3    93%
py36-test-deps/lib/python3.6/site-packages/h5py/_hl/vds.py              55      2    96%
py36-test-deps/lib/python3.6/site-packages/h5py/h5py_warnings.py         6      0   100%
py36-test-deps/lib/python3.6/site-packages/h5py/ipy_completer.py       101    101     0%
py36-test-deps/lib/python3.6/site-packages/h5py/version.py              20      3    85%
----------------------------------------------------------------------------------------
TOTAL                                                                 2177    363    83%


========================================================== short test summary info ===========================================================
XFAIL py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_dataset.py::TestCreateData::test_create_bytestring
  reason: 
XFAIL py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_dataset.py::TestStrings::test_unicode_write_error
  reason: 
XFAIL py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_dataset_getitem.py::Test1DFloat::test_index_illegal
  reason: 
SKIPPED [1] .tox/py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_attrs.py:181: HDF5 1.10.6 required
SKIPPED [1] .tox/py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_base.py:71: Filesystem unicode support required
SKIPPED [1] /home/test/code/h5py/.tox/py36-test-deps/lib/python3.6/site-packages/_pytest/unittest.py:237: chunk info requires  HDF5 >= 1.10.5
SKIPPED [4] /home/test/code/h5py/.tox/py36-test-deps/lib/python3.6/site-packages/_pytest/unittest.py:90: SWMR is available. Skipping backwards compatible tests
SKIPPED [1] .tox/py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_dimension_scales.py:88: Reading non-existent label segfaults
SKIPPED [4] /home/test/code/h5py/.tox/py36-test-deps/lib/python3.6/site-packages/_pytest/unittest.py:90: tables is required
SKIPPED [7] /home/test/code/h5py/.tox/py36-test-deps/lib/python3.6/site-packages/_pytest/unittest.py:90: Requires HDF5 1.10.2 or later
SKIPPED [3] /home/test/code/h5py/.tox/py36-test-deps/lib/python3.6/site-packages/_pytest/unittest.py:90: Filesystem unicode support required
SKIPPED [2] .tox/py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_file.py: need --with-mpi option to run
SKIPPED [1] .tox/py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_file.py:669: need --with-mpi option to run
SKIPPED [1] .tox/py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_group.py:733: No unicode filename support
SKIPPED [1] .tox/py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_group.py:722: No unicode filename support
SKIPPED [3] /home/test/code/h5py/.tox/py36-test-deps/lib/python3.6/site-packages/_pytest/unittest.py:90: Direct Chunk Reading requires HDF5 >= 1.10.2
SKIPPED [1] .tox/py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_h5p.py:39: Requires HDF5 1.10.2 or later
SKIPPED [1] .tox/py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_h5p.py:48: Requires HDF5 1.11.4 or later
SKIPPED [1] .tox/py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_h5p.py:30: Requires HDF5 1.10.2 or later
SKIPPED [1] .tox/py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_h5pl.py:23: HDF5 1.10.1+ required
SKIPPED [1] .tox/py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_h5pl.py:31: HDF5 1.10.1+ required
SKIPPED [1] .tox/py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_h5pl.py:41: HDF5 1.10.1+ required
SKIPPED [1] .tox/py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_h5pl.py:51: HDF5 1.10.1+ required
SKIPPED [1] .tox/py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_h5pl.py:61: HDF5 1.10.1+ required
SKIPPED [1] .tox/py36-test-deps/lib/python3.6/site-packages/h5py/tests/test_h5pl.py:70: HDF5 1.10.1+ required
SKIPPED [1] /home/test/code/h5py/.tox/py36-test-deps/lib/python3.6/site-packages/_pytest/unittest.py:237: get_ / set_virtual_prefix requires HDF5 >= 1.10.2
================================================= 529 passed, 40 skipped, 3 xfailed in 5.26s =================================================
__________________________________________________________________ summary ___________________________________________________________________
  py36-test-deps: commands succeeded
  congratulations :)
```
- Add a release note in the news/ folder (copy TEMPLATE.rst)
Done!

This PR takes care of the issue discussed in #1461 and helps anyone installing 
h5py (directly or indirectly) become aware that HDF5 installation is a dependency (if it is not installed).