### PR TITLE
Fix object location for intersphinx

### DIFF
--- a/docs/high/attr.rst
+++ b/docs/high/attr.rst
@@ -1,3 +1,4 @@
+.. currentmodule:: h5py
 .. _attributes:
 
 

--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -1,3 +1,4 @@
+.. currentmodule:: h5py
 .. _dataset:
 
 

--- a/docs/high/file.rst
+++ b/docs/high/file.rst
@@ -1,3 +1,4 @@
+.. currentmodule:: h5py
 .. _file:
 
 

--- a/docs/high/group.rst
+++ b/docs/high/group.rst
@@ -1,3 +1,4 @@
+.. currentmodule:: h5py
 .. _group:
 
 

--- a/docs/special.rst
+++ b/docs/special.rst
@@ -1,3 +1,4 @@
+.. currentmodule:: h5py
 .. _special_types:
 
 Special types

--- a/docs/vds.rst
+++ b/docs/vds.rst
@@ -1,3 +1,4 @@
+.. currentmodule:: h5py
 .. _vds:
 
 Virtual Datasets (VDS)


### PR DESCRIPTION
Currently, people have to use ``:class:`Dataset` `` to link to `h5py.Dataset`, which isn’t the way it should be; it should read ``:class:`h5py.Dataset` `` (or ``:class:`~h5py.Dataset` `` if you want it to *read* as plain “Dataset”). If everything would link their stuff unnamespaced, there would be clashes all the time!

This fixes that, all attributes, classes and functions are now properly namespaced in `objects.inv`.