### PR TITLE
Fixes for empty region references

### DIFF
--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -656,7 +656,8 @@ class Dataset(HLObject):
             sid = h5r.get_region(args[0], self.id)
             mshape = sel.guess_shape(sid)
             if mshape is None:
-                return numpy.array((0,), dtype=new_dtype)
+                # 0D with no data (NULL or deselected SCALAR)
+                return Empty(new_dtype)
             out = numpy.empty(mshape, dtype=new_dtype)
             if out.size == 0:
                 return out

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -657,9 +657,10 @@ class Dataset(HLObject):
             mshape = sel.guess_shape(sid)
             if mshape is None:
                 return numpy.array((0,), dtype=new_dtype)
-            if numpy.product(mshape, dtype=numpy.ulonglong) == 0:
-                return numpy.array(mshape, dtype=new_dtype)
             out = numpy.empty(mshape, dtype=new_dtype)
+            if out.size == 0:
+                return out
+
             sid_out = h5s.create_simple(mshape)
             sid_out.select_all()
             self.id.read(sid_out, sid, out, mtype)

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1168,6 +1168,12 @@ class TestRegionRefs(BaseDataset):
         ref = self.dset.regionref[slic]
         self.assertArrayEqual(self.dset[ref], self.data[slic])
 
+    def test_empty_region(self):
+        ref = self.dset.regionref[:0]
+        out = self.dset[ref]
+        assert out.size == 0
+        # Ideally we should preserve shape (0, 100), but it seems this is lost.
+
     def test_ref_shape(self):
         """ Region reference shape and selection shape """
         slic = np.s_[25:35, 10:100:5]

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1174,6 +1174,20 @@ class TestRegionRefs(BaseDataset):
         assert out.size == 0
         # Ideally we should preserve shape (0, 100), but it seems this is lost.
 
+    def test_scalar_dataset(self):
+        ds = self.f.create_dataset("scalar", data=1.0, dtype='f4')
+        sid = h5py.h5s.create(h5py.h5s.SCALAR)
+
+        # Deselected
+        sid.select_none()
+        ref = h5py.h5r.create(ds.id, b'.', h5py.h5r.DATASET_REGION, sid)
+        assert ds[ref] == h5py.Empty(np.dtype('f4'))
+
+        # Selected
+        sid.select_all()
+        ref = h5py.h5r.create(ds.id, b'.', h5py.h5r.DATASET_REGION, sid)
+        assert ds[ref] == ds[()]
+
     def test_ref_shape(self):
         """ Region reference shape and selection shape """
         slic = np.s_[25:35, 10:100:5]

--- a/news/empty-regionrefs.rst
+++ b/news/empty-regionrefs.rst
@@ -1,0 +1,29 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* Fix reading data for region references pointing to an empty selection.
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
- When a region reference points to an empty dataset, or an empty selection on a scalar dataset, return the appropriate `Empty` instance rather than a 1D, length 1 array.
- When a region reference points to an empty selection on a normal (simple) dataset, return an empty array rather than an array with 1 value per dimension (!).
  - Ideally this would also get the right shape, but it always gives (0, 0). I don't know if this is something we can fix or a limitation of HDF5.