### PR TITLE
Allow dtype promotion in fast read pathway

### DIFF
--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -583,7 +583,6 @@ class Dataset(HLObject):
         return (
             self._extent_type == h5s.SIMPLE
             and isinstance(self.id.get_type(), (h5t.TypeIntegerID, h5t.TypeFloatID))
-            and h5t.py_create(self.dtype) == self.id.get_type()  # No float promotion
         )
 
     @with_phil


### PR DESCRIPTION
This is one step towards making the Cython reader usable for more cases; my aim is to reduce code duplication between this and `selections.py`.

Previously, the Cython reader was only used where the stored data type exactly matched a numpy dtype, so HDF5 didn't need to do any conversion. This change enables it when e.g. a custom float datatype has to be promoted to a numpy dtype. I don't think this is a common case, but it's fairly easy to fix. There is already a test `test_custom_float_promotion` which failed when I removed the check but didn't make the other code changes.

The Cython reader is still only used for numeric (integer & floating point) data, where we're reading to the default dtype for that dataset (not using `.astype()`).