### PR TITLE
Enable fancy indexing in Cython reader code

### DIFF
--- a/h5py/_reader.pyx
+++ b/h5py/_reader.pyx
@@ -134,7 +134,10 @@ cdef class Reader:
                 if array_ix != -1:
                     raise TypeError("Only one indexing vector or array is currently allowed for fancy indexing")
 
+                # Convert negative indices to positive
                 a[a < 0] += l
+
+                # Bounds check
                 if np.any((a < 0) | (a > l)):
                     if l == 0:
                         msg = "Fancy indexing out of range for empty dimension"

--- a/h5py/_reader.pyx
+++ b/h5py/_reader.pyx
@@ -69,6 +69,8 @@ cdef class Reader:
 
                 ellipsis_ix = dim_ix
                 nargs -= 1  # Don't count the ... itself
+                if nargs > self.rank:
+                    raise ValueError(f"{nargs} indexing arguments for {self.rank} dimensions")
                 dim_ix += self.rank - nargs  # Skip ahead to the remaining dimensions
                 continue
 

--- a/h5py/_reader.pyx
+++ b/h5py/_reader.pyx
@@ -125,8 +125,6 @@ cdef class Reader:
                     raise TypeError("Only 1D arrays allowed for fancy indexing")
                 if not np.issubdtype(a.dtype, np.integer):
                     raise TypeError("Indexing arrays must have integer dtypes")
-                if np.any(np.diff(a) <= 0):
-                    raise TypeError("Indexing elements must be in increasing order")
                 if array_ix != -1:
                     raise TypeError("Only one indexing vector or array is currently allowed for fancy indexing")
 
@@ -137,6 +135,9 @@ cdef class Reader:
                     else:
                         msg = f"Fancy indexing our of range for (0-{l-1})"
                     raise IndexError(msg)
+
+                if np.any(np.diff(a) <= 0):
+                    raise TypeError("Indexing elements must be in increasing order")
 
                 array_ix = dim_ix
                 array_arg = a

--- a/h5py/_reader.pyx
+++ b/h5py/_reader.pyx
@@ -1,4 +1,9 @@
 # cython: language_level=3
+"""Class to efficiently select and read data from an HDF5 dataset
+
+This is written in Cython to reduce overhead when reading small amounts of
+data. But it doesn't (yet) handle all cases that the Python machinery covers.
+"""
 from numpy cimport ndarray, npy_intp, PyArray_SimpleNew, PyArray_DATA, import_array
 from cpython cimport PyIndex_Check, PyNumber_Index
 
@@ -50,6 +55,7 @@ cdef class Reader:
         efree(self.scalar)
 
     cdef bint apply_args(self, tuple args) except 0:
+        """Apply indexing arguments to this reader object"""
         cdef:
             int nargs, ellipsis_ix, array_ix = -1
             bint seen_ellipsis = False
@@ -192,6 +198,11 @@ cdef class Reader:
             efree(tmp_count)
 
     cdef ndarray make_array(self):
+        """Create an array to read the selected data into.
+
+        .apply_args() should be called first, to set self.count and self.scalar.
+        Only works for simple numeric dtypes which can be defined with typenum.
+        """
         cdef int i, arr_rank = 0
         cdef npy_intp* arr_shape
 
@@ -210,6 +221,10 @@ cdef class Reader:
         return arr
 
     def read(self, tuple args):
+        """Index the dataset using args and read into a new numpy array
+
+        Only works for simple numeric dtypes.
+        """
         cdef void* buf
         cdef ndarray arr
         cdef hid_t mspace

--- a/h5py/tests/test_dataset_getitem.py
+++ b/h5py/tests/test_dataset_getitem.py
@@ -415,9 +415,8 @@ class Test1DFloat(TestCase):
     def test_indexlist_empty(self):
         self.assertNumpyBehavior(self.dset, self.data, np.s_[[]])
 
-    # FIXME: NumPy has IndexError
     def test_indexlist_outofrange(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(IndexError):
             self.dset[[100]]
 
     def test_indexlist_nonmonotonic(self):

--- a/h5py/tests/test_dataset_getitem.py
+++ b/h5py/tests/test_dataset_getitem.py
@@ -424,6 +424,13 @@ class Test1DFloat(TestCase):
         with self.assertRaises(TypeError):
             self.dset[[1,3,2]]
 
+    def test_indexlist_monotonic_negative(self):
+        # This should work: indices are logically increasing
+        self.assertNumpyBehavior(self.dset, self.data,  np.s_[[0, 2, -2]])
+
+        with self.assertRaises(TypeError):
+            self.dset[[-2, -3]]
+
     def test_indexlist_repeated(self):
         """ we forbid repeated index values """
         with self.assertRaises(TypeError):


### PR DESCRIPTION
This is another step towards replacing some of the Python selection code. This implements selection with a list or array of indices in the Cython reader pathway.

There shouldn't be much overhead for simple cases: we only check for array-like arguments after checking the options for simple indexing (integers, slices, ellipsis). So when you use those, the only new code that runs is a simple if to check if an array was found.

This also partly addresses #993 (partly because it only affects reads which can use this code).