### PR TITLE
Datatypes to be compatible with Attribute Managers

### DIFF
--- a/.authors.yml
+++ b/.authors.yml
@@ -636,6 +636,8 @@
     - sciarellip@gmail.com
 - name: Jordan Farquhar
   email: jordan.a.farquhar@gmail.com
+  aliases:
+    - jordan-farq
   num_commits: 1
   first_commit: 2020-02-05 02:54:41
   github: jordan-farq

--- a/.authors.yml
+++ b/.authors.yml
@@ -634,3 +634,8 @@
   alternate_emails:
     - pierlauro@users.noreply.github.com
     - sciarellip@gmail.com
+- name: Jordan Farquhar
+  email: jordan.a.farquhar@gmail.com
+  num_commits: 1
+  first_commit: 2020-02-05 02:54:41
+  github: jordan-farq

--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -491,6 +491,7 @@ hdf5:
   herr_t        H5Tclose(hid_t type_id)
   hid_t         H5Tget_native_type(hid_t type_id, H5T_direction_t direction)
   herr_t        H5Tcommit2(hid_t loc_id, char *name, hid_t dtype_id, hid_t lcpl_id, hid_t tcpl_id, hid_t tapl_id)
+  hid_t         H5Tget_create_plist(hid_t dtype_id)
 
   hid_t         H5Tdecode(unsigned char *buf)
   herr_t        H5Tencode(hid_t obj_id, unsigned char *buf, size_t *nalloc)

--- a/h5py/api_types_hdf5.pxd
+++ b/h5py/api_types_hdf5.pxd
@@ -459,6 +459,7 @@ cdef extern from "hdf5.h":
   hid_t H5P_LINK_CREATE
   hid_t H5P_LINK_ACCESS
   hid_t H5P_GROUP_CREATE
+  hid_t H5P_DATATYPE_CREATE
   hid_t H5P_CRT_ORDER_TRACKED
   hid_t H5P_CRT_ORDER_INDEXED
 

--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -72,6 +72,8 @@ cdef object propwrap(hid_t id_in):
             pcls = PropLAID
         elif H5Pequal(clsid, H5P_GROUP_CREATE):
             pcls = PropGCID
+        elif H5Pequal(clsid, H5P_DATATYPE_CREATE):
+            pcls = PropTCID
         elif H5Pequal(clsid, H5P_DATASET_ACCESS):
             pcls = PropDAID
         elif H5Pequal(clsid, H5P_OBJECT_CREATE):
@@ -1415,6 +1417,11 @@ cdef class PropLAID(PropInstanceID):
             H5Idec_ref(fid)
         return propwrap(fid)
 
+# Datatype creation
+cdef class PropTCID(PropOCID):
+    """ Datatype creation property list """
+
+    pass
 
 # Group creation
 cdef class PropGCID(PropOCID):

--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -20,6 +20,7 @@ include "config.pxi"
 from ._objects cimport pdefault
 cimport numpy as cnp
 from .h5r cimport Reference, RegionReference
+from .h5p cimport PropID, propwrap
 
 from .utils cimport  emalloc, efree, require_tuple, convert_dims,\
                      convert_tuple
@@ -537,6 +538,15 @@ cdef class TypeID(ObjectID):
             efree(buf)
 
         return pystr
+
+    @with_phil
+    def get_create_plist(self):
+        """ () => PropTCID
+
+            Create and return a new copy of the datatype creation property list
+            used when this datatype was created.
+        """
+        return propwrap(H5Tget_create_plist(self.id))
 
 
     def __reduce__(self):

--- a/h5py/tests/test_attrs.py
+++ b/h5py/tests/test_attrs.py
@@ -189,3 +189,14 @@ class TestTrackOrder(BaseAttrs):
         attrs = self.fill_attrs(track_order=False)  # name alphanumeric
         self.assertEqual(list(attrs),
                          sorted([str(i) for i in range(100)]))
+
+
+class TestDatatype(BaseAttrs):
+
+    def test_datatype(self):
+        self.f['foo'] = np.dtype('f')
+        dt = self.f['foo']
+        self.assertEqual(list(dt.attrs.keys()), [])
+        dt.attrs.create('a', 4.0)
+        self.assertEqual(list(dt.attrs.keys()), ['a'])
+        self.assertEqual(list(dt.attrs.values()), [4.0])

--- a/news/dtype-attrs-mgr.rst
+++ b/news/dtype-attrs-mgr.rst
@@ -1,0 +1,29 @@
+New features
+------------
+
+* Attribute Managers will now work as expected on HDF5 datatypes when they previously failed. Resolves issue https://github.com/h5py/h5py/issues/1476.
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* H5Tget_create_plist - https://support.hdfgroup.org/HDF5/doc/RM/RM_H5T.html#Datatype-GetCreatePlist
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
This PR adds the ability to use dictionary-style access to attributes on a datatype, which would previously fail. It corresponds to this issue: https://github.com/h5py/h5py/issues/1476

Added the C function `H5Tget_create_plist` into `api_functions.txt`, as well as the Python binding in `h5t.pyx`. 

There are no particularly interesting C functions for datatype properties as there are for other HDF5 interfaces (see https://support.hdfgroup.org/HDF5/doc/RM/RM_H5P.html), which is why the `PropTCID` class in `h5p.pyx` has no methods.

Finally, I added a test in `test_attrs.py` that explicitly tests the Attribute Manager class for compatibility with datatypes. Before my change, it would fail with `AttributeError: 'h5py.h5t.TypeFloatID' object has no attribute 'get_create_plist'`. It passes fine after the changes.

<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- Add a release note in the news/ folder (copy TEMPLATE.rst)

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->
