### PR TITLE
The fourth argument to require_tuple should be bytes

### DIFF
--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -422,7 +422,7 @@ cdef class PropDCID(PropOCID):
         cdef hsize_t* dims
         dims = NULL
 
-        require_tuple(chunksize, 0, -1, "chunksize")
+        require_tuple(chunksize, 0, -1, b"chunksize")
         rank = len(chunksize)
 
         dims = <hsize_t*>emalloc(sizeof(hsize_t)*rank)
@@ -576,7 +576,7 @@ cdef class PropDCID(PropOCID):
         cdef int i
         cd_values = NULL
 
-        require_tuple(values, 1, -1, "values")
+        require_tuple(values, 1, -1, b"values")
 
         try:
             if values is None or len(values) == 0:

--- a/h5py/h5s.pyx
+++ b/h5py/h5s.pyx
@@ -87,9 +87,9 @@ def create_simple(object dims_tpl, object max_dims_tpl=None):
     cdef hsize_t* dims = NULL
     cdef hsize_t* max_dims = NULL
 
-    require_tuple(dims_tpl, 0, -1, "dims_tpl")
+    require_tuple(dims_tpl, 0, -1, b"dims_tpl")
     rank = len(dims_tpl)
-    require_tuple(max_dims_tpl, 1, rank, "max_dims_tpl")
+    require_tuple(max_dims_tpl, 1, rank, b"max_dims_tpl")
 
     try:
         dims = <hsize_t*>emalloc(sizeof(hsize_t)*rank)
@@ -219,7 +219,7 @@ cdef class SpaceID(ObjectID):
 
             rank = H5Sget_simple_extent_ndims(self.id)
 
-            require_tuple(offset, 1, rank, "offset")
+            require_tuple(offset, 1, rank, b"offset")
             dims = <hssize_t*>emalloc(sizeof(hssize_t)*rank)
             if(offset is not None):
                 convert_tuple(offset, <hsize_t*>dims, rank)
@@ -318,9 +318,9 @@ cdef class SpaceID(ObjectID):
         cdef hsize_t* dims = NULL
         cdef hsize_t* max_dims = NULL
 
-        require_tuple(dims_tpl, 0, -1, "dims_tpl")
+        require_tuple(dims_tpl, 0, -1, b"dims_tpl")
         rank = len(dims_tpl)
-        require_tuple(max_dims_tpl, 1, rank, "max_dims_tpl")
+        require_tuple(max_dims_tpl, 1, rank, b"max_dims_tpl")
 
         try:
             dims = <hsize_t*>emalloc(sizeof(hsize_t)*rank)
@@ -556,10 +556,10 @@ cdef class SpaceID(ObjectID):
         # Dataspace rank.  All provided tuples must match this.
         rank = H5Sget_simple_extent_ndims(self.id)
 
-        require_tuple(start, 0, rank, "start")
-        require_tuple(count, 0, rank, "count")
-        require_tuple(stride, 1, rank, "stride")
-        require_tuple(block, 1, rank, "block")
+        require_tuple(start, 0, rank, b"start")
+        require_tuple(count, 0, rank, b"count")
+        require_tuple(stride, 1, rank, b"stride")
+        require_tuple(block, 1, rank, b"block")
 
         try:
             start_array = <hsize_t*>emalloc(sizeof(hsize_t)*rank)

--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -320,7 +320,7 @@ def array_create(TypeID base not None, object dims_tpl):
     cdef hsize_t rank
     cdef hsize_t *dims = NULL
 
-    require_tuple(dims_tpl, 0, -1, "dims_tpl")
+    require_tuple(dims_tpl, 0, -1, b"dims_tpl")
     rank = len(dims_tpl)
     dims = <hsize_t*>emalloc(sizeof(hsize_t)*rank)
 

--- a/news/fix-internal-errors.rst
+++ b/news/fix-internal-errors.rst
@@ -1,0 +1,22 @@
+New features
+------------
+
+
+Deprecations
+------------
+
+
+Exposing HDF5 functions
+-----------------------
+
+Bug fixes
+---------
+
+* Fix some errors for internal functions that were raising "TypeError:
+  expected bytes, str found" instead of the correct error.
+
+Building h5py
+-------------
+
+Development
+-----------


### PR DESCRIPTION
<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- Add a release note in the news/ folder (copy TEMPLATE.rst)

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->

For example, before this PR

```py
>>> s
<h5py.h5s.SpaceID object at 0x119372d18>
>>> s.select_hyperslab(0, 1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
  File "h5py/h5s.pyx", line 553, in h5py.h5s.SpaceID.select_hyperslab
  File "h5py/utils.pyx", line 181, in h5py.utils.require_tuple
TypeError: expected bytes, str found
```

and after

```py
>>> s.select_hyperslab(0, 1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
  File "h5py/h5s.pyx", line 559, in h5py.h5s.SpaceID.select_hyperslab
ValueError: start must be a tuple of size 1.
```

It isn't clear to me if the fix should be to replace all calls with bytes or to make the function use strings instead of bytes. Is there a reason bytes are preferred in Cython (I'm not too familiar with Cython)? 