### PR TITLE
Rethink field access in compound datatype as a dataset.fields() method

### DIFF
--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -454,6 +454,18 @@ Reference
                >>> with dset.astype('int16'):
                ...     out = dset[:]
 
+    .. method:: fields(names)
+
+        Get a wrapper to read a subset of fields from a compound data type::
+
+            >>> 2d_coords = dataset.fields(['x', 'y'])[:]
+
+        If names is a string, a single field is extracted, and the resulting
+        arrays will have that dtype. Otherwise, it should be an iterable,
+        and the read data will have a compound dtype.
+
+        .. versionadded:: 3.0
+
     .. method:: iter_chunks
 
        Iterate over chunks in a chunked dataset. The optional ``sel`` argument

--- a/h5py/_hl/attrs.py
+++ b/h5py/_hl/attrs.py
@@ -20,7 +20,6 @@ import uuid
 from .. import h5, h5s, h5t, h5a, h5p
 from . import base
 from .base import phil, with_phil, Empty, is_empty_dataspace
-from .dataset import readtime_dtype
 from .datatype import Datatype
 
 
@@ -59,7 +58,7 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
         if is_empty_dataspace(attr):
             return Empty(attr.dtype)
 
-        dtype = readtime_dtype(attr.dtype, [])
+        dtype = attr.dtype
         shape = attr.shape
 
         # Do this first, as we'll be fiddling with the dtype for top-level

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -338,7 +338,7 @@ class Dataset(HLObject):
         """
         return AstypeWrapper(self, dtype)
 
-    def fields(self, names, prior_dtype=None):
+    def fields(self, names, *, _prior_dtype=None):
         """Get a wrapper to read a subset of fields from a compound data type:
 
         >>> 2d_coords = dataset.fields(['x', 'y'])[:]
@@ -347,9 +347,9 @@ class Dataset(HLObject):
         arrays will have that dtype. Otherwise, it should be an iterable,
         and the read data will have a compound dtype.
         """
-        if prior_dtype is None:
-            prior_dtype = self.dtype
-        return FieldsWrapper(self, prior_dtype, names)
+        if _prior_dtype is None:
+            _prior_dtype = self.dtype
+        return FieldsWrapper(self, _prior_dtype, names)
 
     if MPI:
         @property
@@ -667,7 +667,7 @@ class Dataset(HLObject):
             if len(names) == 1:
                 names = names[0]  # Read with simpler dtype of this field
             args = tuple(x for x in args if not isinstance(x, str))
-            return self.fields(names, new_dtype)[args]
+            return self.fields(names, _prior_dtype=new_dtype)[args]
 
         if new_dtype is None:
             new_dtype = self.dtype

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1054,6 +1054,27 @@ class TestCompound(BaseDataset):
         self.assertTrue(np.all(outdata == testdata))
         self.assertEqual(outdata.dtype, testdata.dtype)
 
+    def test_fields(self):
+        dt = np.dtype([
+            ('x', np.float64),
+            ('y', np.float64),
+            ('z', np.float64),
+        ])
+
+        testdata = np.ndarray((16,), dtype=dt)
+        for key in dt.fields:
+            testdata[key] = np.random.random((16,)) * 100
+
+        self.f['test'] = testdata
+
+        # Extract multiple fields
+        np.testing.assert_array_equal(
+            self.f['test'].fields(['x', 'y'])[:], testdata[['x', 'y']]
+        )
+        # Extract single field
+        np.testing.assert_array_equal(
+            self.f['test'].fields('x')[:], testdata['x']
+        )
 
 class TestEnum(BaseDataset):
 


### PR DESCRIPTION
This is my idea to address #1480:

```python
# Old way - mix field names and indexing:
x = f['coords']['x', :10]

# New way:
x = f['coords'].fields('x')[:10]
```

The old way continues working with these changes. I'd favour deprecating and/or restricting it, because at present it allows names and indexing to be mixed arbitrarily (`ds['y', 0, 'x']`), which seems confusing.

The new API allows for one thing that's not possible with the current API: extracting a single field, but keeping it as a compound dtype (`.fields(['x'])`). I can't immediately see a case where this is useful, but it's possible in numpy - `arr[['x']]` is not the same as `arr['x']`.