### PR TITLE
ENH: use char* not array.array, clean up some warnings

### DIFF
--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1247,7 +1247,7 @@ class TestVlen(BaseDataset):
         self.assertArrayEqual(ds[1], np.arange(0))
         self.assertArrayEqual(ds[2], np.array([1, 2, 3]))
         self.assertArrayEqual(ds[1], np.arange(0))
-        ds[0:2] = np.array([np.arange(5), np.arange(4)])
+        ds[0:2] = np.array([np.arange(5), np.arange(4)], dtype=object)
         self.assertArrayEqual(ds[0], np.arange(5))
         self.assertArrayEqual(ds[1], np.arange(4))
         ds[0:2] = np.array([np.arange(3), np.arange(3)])
@@ -1276,7 +1276,7 @@ class TestVlen(BaseDataset):
         self.assertArrayEqual(ds[0], np.array([1, 1]))
         self.assertArrayEqual(ds[1], np.array([1]))
         self.assertArrayEqual(ds[2], np.array([1, 2, 3]))
-        ds[0:2] = np.array([[0.1, 1.1, 2.1, 3.1, 4], np.arange(4)])
+        ds[0:2] = np.array([[0.1, 1.1, 2.1, 3.1, 4], np.arange(4)], dtype=object)
         self.assertArrayEqual(ds[0], np.arange(5))
         self.assertArrayEqual(ds[1], np.arange(4))
         ds[0:2] = np.array([np.array([0.1, 1.2, 2.2]),
@@ -1289,7 +1289,7 @@ class TestVlen(BaseDataset):
         ds = self.f.create_dataset('vlen', (2, 2), dtype=dt)
         ds[0, 0] = np.arange(1)
         ds[:, :] = np.array([[np.arange(3), np.arange(2)],
-                            [np.arange(1), np.arange(2)]])
+                            [np.arange(1), np.arange(2)]], dtype=object)
         ds[:, :] = np.array([[np.arange(2), np.arange(2)],
                              [np.arange(2), np.arange(2)]])
 

--- a/h5py/tests/test_dtype.py
+++ b/h5py/tests/test_dtype.py
@@ -113,7 +113,7 @@ class TestVlen(TestCase):
 
         with h5py.File(fname, 'w') as f:
             df1 = f.create_dataset('test', (len(arr1),), dtype=dt1)
-            df1[:] = np.array(arr1)
+            df1[:] = np.array(arr1, dtype=object)
 
         with h5py.File(fname, 'r') as f:
             df2 = f['test']

--- a/news/cleanup.rst
+++ b/news/cleanup.rst
@@ -1,0 +1,9 @@
+Building h5py
+-------------
+
+* use bare ``char*`` instead of ``array.array`` in h5d.read_direct_chunk since
+  ``array.array`` is a private CPython C-API interface
+
+* define ``NPY_NO_DEPRECATED_API`` to quiet a warning
+
+* use ``dtype=object`` in tests with ragged arrays

--- a/setup_build.py
+++ b/setup_build.py
@@ -43,7 +43,9 @@ COMPILER_SETTINGS = {
    'libraries'      : ['hdf5', 'hdf5_hl'],
    'include_dirs'   : [localpath('lzf')],
    'library_dirs'   : [],
-   'define_macros'  : [('H5_USE_16_API', None)]
+   'define_macros'  : [('H5_USE_16_API', None),
+                       ('NPY_NO_DEPRECATED_API', 0),
+                      ]
 }
 
 if sys.platform.startswith('win'):


### PR DESCRIPTION
closes #1514 

Replace `array.array` with a `char*` and cleanup some NumPy warnings