### PR TITLE
Release the GIL in H5Idec_ref

### DIFF
--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -208,8 +208,8 @@ hdf5:
   ssize_t    H5Iget_name( hid_t obj_id, char *name, size_t size)
   hid_t      H5Iget_file_id(hid_t obj_id)
   int        H5Idec_ref(hid_t obj_id) nogil
-  int        H5Iget_ref(hid_t obj_id)
-  int        H5Iinc_ref(hid_t obj_id)
+  int        H5Iget_ref(hid_t obj_id) nogil
+  int        H5Iinc_ref(hid_t obj_id) nogil
   htri_t     H5Iis_valid( hid_t obj_id )
 
 

--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -207,7 +207,7 @@ hdf5:
   H5I_type_t H5Iget_type(hid_t obj_id)
   ssize_t    H5Iget_name( hid_t obj_id, char *name, size_t size)
   hid_t      H5Iget_file_id(hid_t obj_id)
-  int        H5Idec_ref(hid_t obj_id)
+  int        H5Idec_ref(hid_t obj_id) nogil
   int        H5Iget_ref(hid_t obj_id)
   int        H5Iinc_ref(hid_t obj_id)
   htri_t     H5Iis_valid( hid_t obj_id )

--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -208,8 +208,8 @@ hdf5:
   ssize_t    H5Iget_name( hid_t obj_id, char *name, size_t size)
   hid_t      H5Iget_file_id(hid_t obj_id)
   int        H5Idec_ref(hid_t obj_id) nogil
-  int        H5Iget_ref(hid_t obj_id) nogil
-  int        H5Iinc_ref(hid_t obj_id) nogil
+  int        H5Iget_ref(hid_t obj_id)
+  int        H5Iinc_ref(hid_t obj_id)
   htri_t     H5Iis_valid( hid_t obj_id )
 
 

--- a/news/nogil.txt
+++ b/news/nogil.txt
@@ -8,3 +8,4 @@ New features
 * Multi-threaded I/O is possible but no performance gain is to be expected !
 * Conversion callback (in H5T) are re-acquiring the GIL as needed.
 * All other callbacks are now re-acquiring the GIL as needed.
+* Release GIL for internal HDF5 reference counting operation (inc, dec, count)

--- a/news/nogil.txt
+++ b/news/nogil.txt
@@ -8,4 +8,4 @@ New features
 * Multi-threaded I/O is possible but no performance gain is to be expected !
 * Conversion callback (in H5T) are re-acquiring the GIL as needed.
 * All other callbacks are now re-acquiring the GIL as needed.
-* Release GIL for internal HDF5 reference counting operation (inc, dec, count)
+* Release GIL for ``H5Idec_ref``, which can close files.


### PR DESCRIPTION
The *dec_ref* function can be taking ages when closing large datasets. This releases the **GIL** to  ensure the system remains responsive. I checked in the base-code, those functions are not used that often and checked that the modification should not trigger python based call-back functions.

close #1516
PS: The  news folder will be upgraded after the CI passes.
