### PR TITLE
Pin HDF5 1.10.6 on Mac CI jobs

### DIFF
--- a/ci/azure-pipelines-steps.yml
+++ b/ci/azure-pipelines-steps.yml
@@ -40,6 +40,7 @@ steps:
 - ${{ if eq(parameters.installer, 'brew') }}:
   - script: |
       brew install pkg-config hdf5@1.10 ccache open-mpi
+      brew link --force hdf5@1.10
     displayName: 'Install dependencies with brew'
 - ${{ if eq(parameters.installer, 'apt') }}:
   - script: |

--- a/ci/azure-pipelines-steps.yml
+++ b/ci/azure-pipelines-steps.yml
@@ -39,7 +39,7 @@ steps:
     displayName: 'Install dependencies with nuget'
 - ${{ if eq(parameters.installer, 'brew') }}:
   - script: |
-      brew install pkg-config hdf5@1.10.6 ccache open-mpi
+      brew install pkg-config hdf5@1.10 ccache open-mpi
     displayName: 'Install dependencies with brew'
 - ${{ if eq(parameters.installer, 'apt') }}:
   - script: |

--- a/ci/azure-pipelines-steps.yml
+++ b/ci/azure-pipelines-steps.yml
@@ -39,7 +39,7 @@ steps:
     displayName: 'Install dependencies with nuget'
 - ${{ if eq(parameters.installer, 'brew') }}:
   - script: |
-      brew install pkg-config hdf5 ccache open-mpi
+      brew install pkg-config hdf5@1.10.6 ccache open-mpi
     displayName: 'Install dependencies with brew'
 - ${{ if eq(parameters.installer, 'apt') }}:
   - script: |


### PR DESCRIPTION
h5py is not working with HDF5 1.12.0 yet (see #1506). This will hopefully let the CI keep working until it is.