### PR TITLE
MNT: account for changes to cython

### DIFF
--- a/h5py/h5a.pyx
+++ b/h5py/h5a.pyx
@@ -21,6 +21,7 @@ from numpy cimport import_array, ndarray, PyArray_DATA
 from .utils cimport check_numpy_read, check_numpy_write, emalloc, efree
 from ._proxy cimport attr_rw
 
+cimport cython
 #Python level imports
 from ._objects import phil, with_phil
 
@@ -31,6 +32,7 @@ import_array()
 
 # --- create, create_by_name ---
 
+@cython.binding(False)
 @with_phil
 def create(ObjectID loc not None, char* name, TypeID tid not None,
     SpaceID space not None, *, char* obj_name='.', PropID lapl=None):
@@ -50,7 +52,7 @@ def create(ObjectID loc not None, char* name, TypeID tid not None,
 
 
 # --- open, open_by_name, open_by_idx ---
-
+@cython.binding(False)
 @with_phil
 def open(ObjectID loc not None, char* name=NULL, int index=-1, *,
     char* obj_name='.', int index_type=H5_INDEX_NAME, int order=H5_ITER_INC,
@@ -119,6 +121,7 @@ def rename(ObjectID loc not None, char* name, char* new_name, *,
     H5Arename_by_name(loc.id, obj_name, name, new_name, pdefault(lapl))
 
 
+@cython.binding(False)
 @with_phil
 def delete(ObjectID loc not None, char* name=NULL, int index=-1, *,
     char* obj_name='.', int index_type=H5_INDEX_NAME, int order=H5_ITER_INC,
@@ -181,6 +184,7 @@ cdef class AttrInfo:
         return hash((self.corder_valid, self.corder, self.cset, self.data_size))
 
 
+@cython.binding(False)
 @with_phil
 def get_info(ObjectID loc not None, char* name=NULL, int index=-1, *,
             char* obj_name='.', PropID lapl=None,

--- a/h5py/h5o.pyx
+++ b/h5py/h5o.pyx
@@ -19,7 +19,7 @@ from .h5g cimport GroupID
 from .h5i cimport wrap_identifier
 from .h5p cimport PropID
 from .utils cimport emalloc, efree
-
+cimport cython
 # Python level imports:
 from ._objects import phil, with_phil
 
@@ -133,6 +133,7 @@ cdef class ObjInfo(_ObjInfo):
         newcopy.infostruct = self.infostruct
         return newcopy
 
+@cython.binding(False)
 @with_phil
 def get_info(ObjectID loc not None, char* name=NULL, int index=-1, *,
         char* obj_name='.', int index_type=H5_INDEX_NAME, int order=H5_ITER_INC,

--- a/news/mnt_future_proof_cython.rst
+++ b/news/mnt_future_proof_cython.rst
@@ -1,0 +1,30 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* Explicitly mark several Cython functions as non-binding, preparing for the
+  default changing in Cython 3.0
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
In Cython 3.0 the default binding behavior changes from False to True (see https://github.com/cython/cython/pull/2864)

This explicitly marks several functions to not bind.
