### PR TITLE
Fix #1523 by updating the documentation

### DIFF
--- a/docs/high/dims.rst
+++ b/docs/high/dims.rst
@@ -90,3 +90,12 @@ such that::
 though, beware that if you attempt to index the dimension scales with a string,
 the first dimension scale whose name matches the string is the one that will be
 returned. There is no guarantee that the name of the dimension scale is unique.
+
+
+
+Nested dimension scales are not permitted: if a dataset has a dimension scale 
+attached to it, converting the dataset to a dimension scale will fail, since the  
+`HDF5 specification doesn't allow this <https://confluence.hdfgroup.org/display/HDF5/H5DS_SET_SCALE>`_. ::
+
+   >>> f['data'].make_scale()
+   RuntimeError: Unspecified error in H5DSset_scale (return value <0)

--- a/docs/high/dims.rst
+++ b/docs/high/dims.rst
@@ -93,8 +93,8 @@ returned. There is no guarantee that the name of the dimension scale is unique.
 
 
 
-Nested dimension scales are not permitted: if a dataset has a dimension scale 
-attached to it, converting the dataset to a dimension scale will fail, since the  
+Nested dimension scales are not permitted: if a dataset has a dimension scale
+attached to it, converting the dataset to a dimension scale will fail, since the
 `HDF5 specification doesn't allow this <https://confluence.hdfgroup.org/display/HDF5/H5DS_SET_SCALE>`_. ::
 
    >>> f['data'].make_scale()


### PR DESCRIPTION
Added a paragraph to the dimension scales documentation detailing why https://github.com/h5py/h5py/issues/1523 doesn't work.

It didn't really fit at another position in the document, so I added it at the end of it.

<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- Add a release note in the news/ folder (copy TEMPLATE.rst)

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->
