### PR TITLE
Document ndim in dataset documentation

### DIFF
--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -15,6 +15,7 @@ NumPy operations like slicing, along with a variety of descriptive attributes:
 
   - **shape** attribute
   - **size** attribute
+  - **ndim** attribute
   - **dtype** attribute
 
 h5py supports most NumPy dtypes, and uses the same character codes (e.g.
@@ -524,6 +525,10 @@ Reference
     .. attribute:: size
 
         Integer giving the total number of elements in the dataset.
+
+    .. attribute:: ndim
+
+        Integer giving the total number of dimensions in the dataset.
 
     .. attribute:: maxshape
 


### PR DESCRIPTION
Hi,
I'm new here, thanks for taking the time to look at this!

This aims to resolve #1517 which says that the documentation for `Dataset.ndim` is lacking.
I added it below references to `size` as it seemed like the right place.

Thanks!
Cyril