### PR TITLE
Document __bool__ property in file/group/dset

### DIFF
--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -414,6 +414,21 @@ Reference
 
         NumPy-style slicing to write data.  See :ref:`dataset_slicing`.
 
+    .. method:: __bool__()
+
+        Check that the dataset is accessible.
+        A dataset could be inaccessible for several reasons. For instance, the
+        dataset, or the file it belongs to, may have been closed elsewhere.
+
+        >>> f = h5py.open(filename)
+        >>> dset = f["MyDS"]
+        >>> f.close()
+        >>> if dset:
+        ...     print("datset accessible")
+        ... else:
+        ...     print("dataset is inaccessible")
+        dataset unaccessible
+
     .. method:: read_direct(array, source_sel=None, dest_sel=None)
 
         Read from an HDF5 dataset directly into a NumPy array, which can
@@ -614,16 +629,3 @@ Reference
     .. attribute:: parent
 
         :class:`Group` instance containing this dataset.
-
-    .. attribute:: __bool__
-
-        Check that the dataset is accessible:
-
-        >>> f = h5py.open(filename)
-        >>> dset = f["MyDS"]
-        >>> f.close()
-        >>> if dset:
-        ...     print("dset is accessible")
-        ... else:
-        ...     print("dset is unaccessible")
-        dset is unaccessible

--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -614,3 +614,16 @@ Reference
     .. attribute:: parent
 
         :class:`Group` instance containing this dataset.
+
+    .. attribute:: __bool__
+
+        Check that the dataset is accessible:
+
+        >>> f = h5py.open(filename)
+        >>> dset = f["MyDS"]
+        >>> f.close()
+        >>> if dset:
+        ...     print("dset is accessible")
+        ... else:
+        ...     print("dset is unaccessible")
+        dset is unaccessible

--- a/docs/high/file.rst
+++ b/docs/high/file.rst
@@ -324,6 +324,18 @@ Reference
                     ``h5.get_config().track_order``.
     :param kwds:    Driver-specific keywords; see :ref:`file_driver`.
 
+    .. method:: __bool__()
+
+        Check that the file descriptor is valid and the file open:
+
+            >>> f = h5py.File(filename)
+            >>> f.close()
+            >>> if f:
+            ...     print("file is open")
+            ... else:
+            ...     print("file is closed")
+            file is closed
+
     .. method:: close()
 
         Close this file.  All open objects will become invalid.
@@ -359,15 +371,3 @@ Reference
     .. attribute:: userblock_size
 
         Size of user block (in bytes).  Generally 0.  See :ref:`file_userblock`.
-
-    .. attribute:: __bool__
-
-        Check that the file descriptor is valid and the file open:
-
-            >>> f = h5py.File(filename)
-            >>> f.close()
-            >>> if f:
-            ...     print("file is open")
-            ... else:
-            ...     print("file is closed")
-            file is closed

--- a/docs/high/file.rst
+++ b/docs/high/file.rst
@@ -113,7 +113,7 @@ The file-like object must be open for binary I/O, and must have these methods:
 
 
     >>> tf = tempfile.TemporaryFile()
-    >>> f = h5py.File(tf)
+    >>> f = h5py.File(tf, 'w')
 
 Accessing the :class:`File` instance after the underlying file object has been
 closed will result in undefined behaviour.
@@ -359,3 +359,15 @@ Reference
     .. attribute:: userblock_size
 
         Size of user block (in bytes).  Generally 0.  See :ref:`file_userblock`.
+
+    .. attribute:: __bool__
+
+        Check that the file descriptor is valid and the file open:
+
+            >>> f = h5py.File(filename)
+            >>> f.close()
+            >>> if f:
+            ...     print("file is open")
+            ... else:
+            ...     print("file is closed")
+            file is closed

--- a/docs/high/group.rst
+++ b/docs/high/group.rst
@@ -195,6 +195,19 @@ Reference
         Create a new link, or automatically create a dataset.
         See :ref:`group_links`.
 
+    .. method:: __bool__()
+
+        Check that the file the group belongs to is open:
+
+        >>> f = h5py.open(filename)
+        >>> group = f["MyGroup"]
+        >>> f.close()
+        >>> if group:
+        ...     print("group is accessible")
+        ... else:
+        ...     print("group is inaccessible")
+        group is inaccessible
+
     .. method:: keys()
 
         Get the names of directly attached group members.
@@ -438,19 +451,6 @@ Reference
     .. attribute:: parent
 
         :class:`Group` instance containing this group.
-
-    .. attribute:: __bool__
-
-        Check that the group is accessible:
-
-        >>> f = h5py.open(filename)
-        >>> group = f["MyDS"]
-        >>> f.close()
-        >>> if group:
-        ...     print("group is accessible")
-        ... else:
-        ...     print("group is unaccessible")
-        group is unaccessible
 
 
 Link classes

--- a/docs/high/group.rst
+++ b/docs/high/group.rst
@@ -439,6 +439,19 @@ Reference
 
         :class:`Group` instance containing this group.
 
+    .. attribute:: __bool__
+
+        Check that the group is accessible:
+
+        >>> f = h5py.open(filename)
+        >>> group = f["MyDS"]
+        >>> f.close()
+        >>> if group:
+        ...     print("group is accessible")
+        ... else:
+        ...     print("group is unaccessible")
+        group is unaccessible
+
 
 Link classes
 ------------

--- a/docs/high/group.rst
+++ b/docs/high/group.rst
@@ -197,7 +197,9 @@ Reference
 
     .. method:: __bool__()
 
-        Check that the file the group belongs to is open:
+        Check that the group is accessible.
+        A group could be inaccessible for several reasons. For instance, the
+        group, or the file it belongs to, may have been closed elsewhere.
 
         >>> f = h5py.open(filename)
         >>> group = f["MyGroup"]


### PR DESCRIPTION
This PR aims to resolve #1363: documenting how to easily check if a file descriptor is still valid, as well as groups and datasets.

I also quickly updated the `tempfile.TemporaryFile` example in `file.rst`, where explicitly setting the create flag is required as of version 3.0.

Thanks!
Cyril