### PR TITLE
Fixes h5py/h5py#1475

### DIFF
--- a/.authors.yml
+++ b/.authors.yml
@@ -11,6 +11,8 @@
   github: khinsen
 - name: Aleksandar Jelenak
   email: ajelenak@hdfgroup.org
+  alternate_emails:
+    - ajelenak@users.noreply.github.com
   github: ajelenak
   num_commits: 27
   first_commit: 2015-12-14 09:41:05

--- a/.authors.yml
+++ b/.authors.yml
@@ -11,6 +11,7 @@
   github: khinsen
 - name: Aleksandar Jelenak
   email: ajelenak@hdfgroup.org
+  github: ajelenak
   num_commits: 27
   first_commit: 2015-12-14 09:41:05
 - name: pharshalp

--- a/h5py/h5d.pyx
+++ b/h5py/h5d.pyx
@@ -363,14 +363,22 @@ cdef class DatasetID(ObjectID):
     def get_storage_size(self):
         """ () => LONG storage_size
 
-            Determine the amount of file space required for a dataset.  Note
-            this only counts the space which has actually been allocated; it
-            may even be zero.
+            Report the size of storage, in bytes, that is allocated in the
+            file for the dataset's raw data. The reported amount is the storage
+            allocated in the written file, which will typically differ from the
+            space required to hold a dataset in working memory (any associated
+            HDF5 metadata is excluded).
+
+            For contiguous datasets, the returned size equals the current
+            allocated size of the raw data. For unfiltered chunked datasets, the
+            returned size is the number of allocated chunks times the chunk
+            size. For filtered chunked datasets, the returned size is the space
+            required to store the filtered data.
         """
         return H5Dget_storage_size(self.id)
 
-    IF HDF5_VERSION >= SWMR_MIN_HDF5_VERSION:
 
+    IF HDF5_VERSION >= SWMR_MIN_HDF5_VERSION:
         @with_phil
         def flush(self):
             """ no return

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1429,3 +1429,17 @@ def test_empty_shape(writable_file):
     ds = writable_file.create_dataset('empty', dtype='int32')
     assert ds.shape is None
     assert ds.maxshape is None
+
+
+def test_zero_storage_size():
+    # https://github.com/h5py/h5py/issues/1475
+    from io import BytesIO
+    buf = BytesIO()
+    with h5py.File(buf, 'w') as fout:
+        fout.create_dataset('empty', dtype='uint8')
+
+    buf.seek(0)
+    with h5py.File(buf, 'r') as fin:
+        assert fin['empty'].chunks is None
+        assert fin['empty'].id.get_offset() is None
+        assert fin['empty'].id.get_storage_size() == 0

--- a/news/h5dstoragesize.rst
+++ b/news/h5dstoragesize.rst
@@ -1,0 +1,29 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* Fixed ``DatasetID.get_storage_size()`` to report storage size of zero bytes without raising an exception. (https://github.com/h5py/h5py/issues/1475)
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
The most important change here is in `api_gen.py` which for the `H5Dget_storage_size()` function now generates this custom wrapper code:
```python
cdef hsize_t H5Dget_storage_size(hid_t dset_id) except <hsize_t>-1:
    cdef hsize_t r
    set_default_error_handler()
    r = _hdf5.H5Dget_storage_size(dset_id)
    if r==0:
        if set_exception():
            return <hsize_t>-1
    return r
```
`r=0` is now a valid return value unless the HDF5 library reports an error.

Also included are one test and an update to the `DatasetID.get_storage_size()` method's docstring.