### PR TITLE
Make creating a new dataset from strings/bytes more consistent

### DIFF
--- a/h5py/_hl/attrs.py
+++ b/h5py/_hl/attrs.py
@@ -116,19 +116,10 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
         """
 
         with phil:
-            if dtype is None:  # Guess dtype before modifying data
-                dtype = base.guess_dtype(data)
-
             # First, make sure we have a NumPy array.  We leave the data type
-            # conversion for HDF5 to perform (other than the below exception).
+            # conversion for HDF5 to perform.
             if not isinstance(data, Empty):
-                is_list_or_tuple = isinstance(data, (list, tuple))
-                data = numpy.asarray(data, order='C')
-                # If we were passed a list or tuple, then we do not need to respect the
-                # datatype of the numpy array. If it is U type, convert to vlen unicode
-                # strings:
-                if is_list_or_tuple and data.dtype.type == numpy.unicode_:
-                    data = numpy.array(data, dtype=h5t.string_dtype())
+                data = base.array_for_new_object(data, specified_dtype=dtype)
 
             if shape is None:
                 shape = data.shape

--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -11,21 +11,21 @@
     Implements operations common to all high-level objects (File, etc.).
 """
 
-import numpy as np
-import posixpath
+from collections.abc import (
+    Mapping, MutableMapping, KeysView, ValuesView, ItemsView
+)
 import os
-from collections.abc import (Mapping, MutableMapping, KeysView,
-                             ValuesView, ItemsView)
+import posixpath
 
-from .compat import fspath, filename_encode
-
-from .. import h5d, h5i, h5r, h5p, h5f, h5t, h5s
+import numpy as np
 
 # The high-level interface is serialized; every public API function & method
 # is wrapped in a lock.  We re-use the low-level lock because (1) it's fast,
 # and (2) it eliminates the possibility of deadlocks due to out-of-order
 # lock acquisition.
 from .._objects import phil, with_phil
+from .. import h5d, h5i, h5r, h5p, h5f, h5t, h5s
+from .compat import fspath, filename_encode
 
 
 def is_hdf5(fname):

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -32,14 +32,6 @@ _LEGACY_GZIP_COMPRESSION_VALS = frozenset(range(10))
 MPI = h5.get_config().mpi
 
 
-def is_float16_dtype(dt):
-    if dt is None:
-        return False
-
-    dt = numpy.dtype(dt)  # normalize strings -> np.dtype objects
-    return dt.kind == 'f' and dt.itemsize == 2
-
-
 def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
                   chunks=None, compression=None, shuffle=None,
                   fletcher32=None, maxshape=None, compression_opts=None,
@@ -50,23 +42,7 @@ def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
     # Convert data to a C-contiguous ndarray
     if data is not None and not isinstance(data, Empty):
         from . import base
-
-        if is_float16_dtype(dtype):
-            # if we are going to a float16 datatype, pre-convert in python
-            # to workaround a possible h5py bug in the conversion.
-            # https://github.com/h5py/h5py/issues/819
-            as_dtype = dtype
-        else:
-            as_dtype = base.guess_dtype(data)
-
-        data = numpy.asarray(data, order="C", dtype=as_dtype)
-
-        # In most cases, this does nothing. But if data was already an array,
-        # and guess_dtype made a tagged version of the dtype it already had
-        # (e.g. an object array of strings), asarray() doesn't replace its
-        # dtype object. This gives it the tagged dtype:
-        if as_dtype is not None:
-            data.dtype = as_dtype
+        data = base.array_for_new_object(data, specified_dtype=dtype)
 
     # Validate shape
     if shape is None:

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -409,7 +409,7 @@ class Group(HLObject, MutableMappingHDF5):
                 htype.commit(self.id, name, lcpl=lcpl)
 
             else:
-                ds = self.create_dataset(None, data=obj, dtype=base.guess_dtype(obj))
+                ds = self.create_dataset(None, data=obj)
                 h5o.link(ds.id, self.id, name, lcpl=lcpl)
 
         if do_link:

--- a/news/assign-list-of-strings.rst
+++ b/news/assign-list-of-strings.rst
@@ -1,0 +1,33 @@
+New features
+------------
+
+* Creating datasets and attributes from str or bytes objects works more
+  consistently.
+
+Deprecations
+------------
+
+* In previous versions, creating a dataset from a list of bytes objects would
+  choose a fixed length string datatype to fit the biggest item. It will now
+  use a variable length string datatype. To store fixed length strings, use a
+  suitable dtype from :func:`h5py.string_dtype`.
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
This aims to make h5py's behaviour more consistent when you create a new dataset/attribute from string objects, without specifying a dtype, e.g. `f['a'] = x`:

1. A list of strings/bytes should result in the same datatype as a single object. Previously, a single string/bytes object was stored as a variable-length HDF5 string, a list of bytes was stored as fixed length, and a list of str was rejected. Now, they all result in variable-length strings in the file.
2. Treat numpy arrays with an `object` dtype but no h5py tag like lists/tuples. I've referred to these in the code as 'object collections' - as distinct from arrays where the dtype tells us what to do.
3. More similarity between datasets and attributes: attributes had a special case to allow lists/tuples of strings. This makes the same thing work for creating datasets.

This is a step towards #1338. It differs somewhat from what we agreed there, but I'm having doubts about that, as I mentioned in a comment there. I also think the consistency is an improvement even if we decide to change the type relations later.