### PR TITLE
update cython defs to v1.6 compatibility in v1.12

### DIFF
--- a/h5py/_conv.pyx
+++ b/h5py/_conv.pyx
@@ -367,7 +367,7 @@ cdef inline int conv_pyref2regref(void* ipt, void* opt, void* bkg, void* priv) e
         if not isinstance(obj, RegionReference):
             raise TypeError("Can't convert incompatible object to HDF5 region reference")
         ref = <RegionReference>(buf_obj0)
-        memcpy(buf_ref, ref.ref.reg_ref, sizeof(hdset_reg_ref_t))
+        memcpy(buf_ref, ref.ref.reg_ref.data, sizeof(hdset_reg_ref_t))
     else:
         memset(buf_ref, c'\0', sizeof(hdset_reg_ref_t))
 

--- a/h5py/h5r.pxd
+++ b/h5py/h5r.pxd
@@ -13,7 +13,9 @@ from .defs cimport *
 cdef extern from "hdf5.h":
 
   ctypedef haddr_t hobj_ref_t
-  ctypedef unsigned char hdset_reg_ref_t[12]
+
+cdef struct hdset_reg_ref_t:
+    uint8_t data[12] # sizeof(haddr_t) + 4 == sizeof(signed long long) + 4
 
 cdef union ref_u:
     hobj_ref_t         obj_ref


### PR DESCRIPTION
**NOT READY TO BE MERGED** because these changes probably need to be under a conditional based on detected hdf5 version, similar to VOL_MIN_HDF5_VERSION (but I couldn't figure out the right way to do that).

HDF5 v1.12 provides a compatibility feature, however it seems to not have covered everything, i.e. the compatibility-v1.6 is not the same as v1.6, so this PR fixes up the differences. (A fix to a stop-gap until h5py moves to API v1.12 when available).

Note: with HDF5 v1.12.0, a further patch (attached) is required to H5version.h, to fix missing functions/types in the v1.6 compatibility spec. Not sure whether it's a bug in upstream or not; it seems that the information about the API version in which a function is introduced might be inaccurate in H5vers.txt -- @epourmal what do you think?. (I also tried bumping to H5_USE_18_API in setup_build.py, but then other function prototypes are mismatched, which is expected since h5py bindings are presumably written against v1.6).

Fixes issues in #1504 and PR #1506.

A test fails for me even on master even with HDF5 v1.10.6, so appears unrelated:
```
py38-test-deps/lib/python3.8/site-packages/h5py/tests/test_file2.py .........Fatal Python error: Aborted
```
skipping that test, the rest of the test suite passes with this PR on top of master and HDF5 v1.12.0 with the attached HDF5 patch applied:
```= 545 passed, 18 skipped, 17 deselected, 3 xfailed in 11.83s =```

[hdf5-1.12.0-compat-1.6.patch.txt](https://github.com/h5py/h5py/files/4508063/hdf5-1.12.0-compat-1.6.patch.txt)

Note: if you are looking to apply this PR to h5py v2.10.0 release, then you also need this patch:
[h5py-2.10.0-hdf5-v1.12-h5i.patch.txt](https://github.com/h5py/h5py/files/4508062/h5py-2.10.0-hdf5-v1.12-h5i.patch.txt)

