### PR TITLE
Update to use HDF5 1.8 API as the base, rather than 1.6

### DIFF
--- a/h5py/_errors.pxd
+++ b/h5py/_errors.pxd
@@ -213,18 +213,20 @@ cdef extern from "hdf5.h":
         unsigned    line            #  line in file where error occurs
         char    *desc               #  optional supplied description
 
+    int H5E_DEFAULT  # ID for default error stack
+
     char      *H5Eget_major(H5E_major_t n)
     char      *H5Eget_minor(H5E_minor_t n)
-    herr_t    H5Eclear() except *
+    herr_t    H5Eclear(hid_t estack_id) except *
 
     ctypedef herr_t (*H5E_auto_t)(void *client_data)
-    herr_t    H5Eset_auto(H5E_auto_t func, void *client_data) nogil
-    herr_t    H5Eget_auto(H5E_auto_t *func, void** client_data)
+    herr_t    H5Eset_auto(hid_t estack_id, H5E_auto_t func, void *client_data) nogil
+    herr_t    H5Eget_auto(hid_t estack_id, H5E_auto_t *func, void** client_data)
 
-    herr_t    H5Eprint(void *stream)
+    herr_t    H5Eprint(hid_t estack_id, void *stream)
 
     ctypedef herr_t (*H5E_walk_t)(int n, H5E_error_t *err_desc, void* client_data)
-    herr_t    H5Ewalk(H5E_direction_t direction, H5E_walk_t func, void* client_data)
+    herr_t    H5Ewalk(hid_t estack_id, H5E_direction_t direction, H5E_walk_t func, void* client_data)
 
 # --- Functions for managing the HDF5 error callback mechanism ---
 

--- a/h5py/_errors.pyx
+++ b/h5py/_errors.pyx
@@ -110,7 +110,7 @@ cdef int set_exception() except -1:
 
     err.n = -1
 
-    if H5Ewalk(H5E_WALK_UPWARD, walk_cb, &err) < 0:
+    if H5Ewalk(<hid_t>H5E_DEFAULT, H5E_WALK_UPWARD, walk_cb, &err) < 0:
         raise RuntimeError("Failed to walk error stack")
 
     if err.n < 0:   # No HDF5 exception information found
@@ -127,7 +127,7 @@ cdef int set_exception() except -1:
 
     err.n = -1
 
-    if H5Ewalk(H5E_WALK_DOWNWARD, walk_cb, &err) < 0:
+    if H5Ewalk(<hid_t>H5E_DEFAULT, H5E_WALK_DOWNWARD, walk_cb, &err) < 0:
         raise RuntimeError("Failed to walk error stack")
 
     desc_bottom = err.err.desc
@@ -153,7 +153,7 @@ _error_handler.data = NULL
 
 cdef void set_default_error_handler() nogil:
     """Set h5py's current default error handler"""
-    H5Eset_auto(_error_handler.func, _error_handler.data)
+    H5Eset_auto(<hid_t>H5E_DEFAULT, _error_handler.func, _error_handler.data)
 
 def silence_errors():
     """ Disable HDF5's automatic error printing in this thread """
@@ -173,10 +173,10 @@ cdef err_cookie set_error_handler(err_cookie handler):
 
     cdef err_cookie old_handler
 
-    if H5Eget_auto(&old_handler.func, &old_handler.data) < 0:
+    if H5Eget_auto(<hid_t>H5E_DEFAULT, &old_handler.func, &old_handler.data) < 0:
         raise RuntimeError("Failed to retrieve old handler")
 
-    if H5Eset_auto(handler.func, handler.data) < 0:
+    if H5Eset_auto(<hid_t>H5E_DEFAULT, handler.func, handler.data) < 0:
         raise RuntimeError("Failed to install new handler")
 
     return old_handler

--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -237,12 +237,9 @@ hdf5:
   hid_t     H5Oopen_by_addr(hid_t loc_id, haddr_t addr)
   hid_t     H5Oopen_by_idx(hid_t loc_id, char *group_name, H5_index_t idx_type, H5_iter_order_t order, hsize_t n, hid_t lapl_id)
 
-  1.6.0-1.11.2 herr_t    H5Oget_info(hid_t loc_id, H5O_info_t *oinfo)
-  1.11.6 herr_t    H5Oget_info1(hid_t loc_id, H5O_info_t *oinfo)
-  1.6.0-1.11.2 herr_t    H5Oget_info_by_name(hid_t loc_id, char *name, H5O_info_t *oinfo, hid_t lapl_id)
-  1.11.6 herr_t    H5Oget_info_by_name1(hid_t loc_id, char *name, H5O_info_t *oinfo, hid_t lapl_id)
-  1.6.0-1.11.2 herr_t    H5Oget_info_by_idx(hid_t loc_id, char *group_name,  H5_index_t idx_type, H5_iter_order_t order, hsize_t n, H5O_info_t *oinfo, hid_t lapl_id)
-  1.11.6 herr_t    H5Oget_info_by_idx1(hid_t loc_id, char *group_name,  H5_index_t idx_type, H5_iter_order_t order, hsize_t n, H5O_info_t *oinfo, hid_t lapl_id)
+  herr_t    H5Oget_info(hid_t loc_id, H5O_info_t *oinfo)
+  herr_t    H5Oget_info_by_name(hid_t loc_id, char *name, H5O_info_t *oinfo, hid_t lapl_id)
+  herr_t    H5Oget_info_by_idx(hid_t loc_id, char *group_name,  H5_index_t idx_type, H5_iter_order_t order, hsize_t n, H5O_info_t *oinfo, hid_t lapl_id)
 
   herr_t    H5Olink(hid_t obj_id, hid_t new_loc_id, char *new_name, hid_t lcpl_id, hid_t lapl_id)
   herr_t    H5Ocopy(hid_t src_loc_id, char *src_name, hid_t dst_loc_id,  char *dst_name, hid_t ocpypl_id, hid_t lcpl_id)
@@ -255,10 +252,8 @@ hdf5:
   ssize_t   H5Oget_comment(hid_t obj_id, char *comment, size_t bufsize)
   ssize_t   H5Oget_comment_by_name(hid_t loc_id, char *name, char *comment, size_t bufsize, hid_t lapl_id)
 
-  1.6.0-1.11.2 herr_t    H5Ovisit(hid_t obj_id, H5_index_t idx_type, H5_iter_order_t order,  H5O_iterate_t op, void *op_data)
-  1.11.6 herr_t    H5Ovisit1(hid_t obj_id, H5_index_t idx_type, H5_iter_order_t order,  H5O_iterate_t op, void *op_data)
-  1.6.0-1.11.2 herr_t    H5Ovisit_by_name(hid_t loc_id, char *obj_name, H5_index_t idx_type, H5_iter_order_t order, H5O_iterate_t op, void *op_data, hid_t lapl_id)
-  1.11.6 herr_t    H5Ovisit_by_name1(hid_t loc_id, char *obj_name, H5_index_t idx_type, H5_iter_order_t order, H5O_iterate_t op, void *op_data, hid_t lapl_id)
+  herr_t    H5Ovisit(hid_t obj_id, H5_index_t idx_type, H5_iter_order_t order,  H5O_iterate_t op, void *op_data)
+  herr_t    H5Ovisit_by_name(hid_t loc_id, char *obj_name, H5_index_t idx_type, H5_iter_order_t order, H5O_iterate_t op, void *op_data, hid_t lapl_id)
 
   herr_t    H5Oclose(hid_t object_id)
 
@@ -464,8 +459,7 @@ hdf5:
   herr_t    H5Sselect_hyperslab(hid_t space_id, H5S_seloper_t op,  hsize_t *start, hsize_t *_stride, hsize_t *count, hsize_t *_block)
 
 
-  1.6.0-1.11.2 herr_t    H5Sencode(hid_t obj_id, void *buf, size_t *nalloc)
-  1.11.6 herr_t    H5Sencode1(hid_t obj_id, void *buf, size_t *nalloc)
+  herr_t    H5Sencode(hid_t obj_id, void *buf, size_t *nalloc)
   hid_t     H5Sdecode(void *buf)
 
   1.9.233 htri_t H5Sis_regular_hyperslab(hid_t spaceid)

--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -41,7 +41,7 @@ hdf5:
 
   # === H5A - Attributes API ==================================================
 
-  hid_t     H5Acreate(hid_t loc_id, char *name, hid_t type_id, hid_t space_id, hid_t create_plist)
+  hid_t     H5Acreate(hid_t loc_id, char *name, hid_t type_id, hid_t space_id, hid_t acpl_id, hid_t aapl_id)
   hid_t     H5Aopen_idx(hid_t loc_id, unsigned int idx)
   hid_t     H5Aopen_name(hid_t loc_id, char *name)
   herr_t    H5Aclose(hid_t attr_id)
@@ -54,7 +54,6 @@ hdf5:
   ssize_t   H5Aget_name(hid_t attr_id, size_t buf_size, char *buf)
   hid_t     H5Aget_space(hid_t attr_id)
   hid_t     H5Aget_type(hid_t attr_id)
-  herr_t    H5Aiterate(hid_t loc_id, unsigned * idx, H5A_operator_t op, void* op_data)
 
   herr_t    H5Adelete_by_name(hid_t loc_id, char *obj_name, char *attr_name, hid_t lapl_id)
   herr_t    H5Adelete_by_idx(hid_t loc_id, char *obj_name, H5_index_t idx_type, H5_iter_order_t order, hsize_t n, hid_t lapl_id)
@@ -83,7 +82,6 @@ hdf5:
   hid_t     H5Dcreate2(hid_t loc_id, char *name, hid_t type_id, hid_t space_id, hid_t lcpl_id, hid_t dcpl_id, hid_t dapl_id) nogil
   hid_t     H5Dcreate_anon(hid_t file_id, hid_t type_id, hid_t space_id, hid_t plist_id, hid_t dapl_id) nogil
 
-  hid_t     H5Dopen(hid_t file_id, char *name)
   hid_t     H5Dopen2(hid_t loc_id, char *name, hid_t dapl_id )
   herr_t    H5Dclose(hid_t dset_id)
 
@@ -176,8 +174,6 @@ hdf5:
 
   # === H5G - Groups API ======================================================
 
-  hid_t     H5Gcreate(hid_t loc_id, char *name, size_t size_hint)
-  hid_t     H5Gopen(hid_t loc_id, char *name)
   herr_t    H5Gclose(hid_t group_id)
   herr_t    H5Glink2( hid_t curr_loc_id, char *current_name, H5G_link_t link_type, hid_t new_loc_id, char *new_name)
 
@@ -332,8 +328,8 @@ hdf5:
   herr_t        H5Pset_filter(hid_t plist, H5Z_filter_t filter, unsigned int flags, size_t cd_nelmts, unsigned int* cd_values )
   htri_t        H5Pall_filters_avail(hid_t dcpl_id)
   int           H5Pget_nfilters(hid_t plist)
-  H5Z_filter_t  H5Pget_filter(hid_t plist, unsigned int filter_number,   unsigned int *flags, size_t *cd_nelmts,  unsigned int* cd_values, size_t namelen, char* name )
-  herr_t        H5Pget_filter_by_id( hid_t plist_id, H5Z_filter_t filter,  unsigned int *flags, size_t *cd_nelmts,  unsigned int* cd_values, size_t namelen, char* name)
+  H5Z_filter_t  H5Pget_filter(hid_t plist, unsigned int filter_number,   unsigned int *flags, size_t *cd_nelmts,  unsigned int* cd_values, size_t namelen, char* name, unsigned int* filter_config)
+  herr_t        H5Pget_filter_by_id( hid_t plist_id, H5Z_filter_t filter,  unsigned int *flags, size_t *cd_nelmts,  unsigned int* cd_values, size_t namelen, char* name, unsigned int* filter_config)
   herr_t        H5Pmodify_filter(hid_t plist, H5Z_filter_t filter, unsigned int flags, size_t cd_nelmts, unsigned int *cd_values)
   herr_t        H5Premove_filter(hid_t plist, H5Z_filter_t filter )
   herr_t        H5Pset_fletcher32(hid_t plist)
@@ -424,7 +420,7 @@ hdf5:
   herr_t    H5Rcreate(void *ref, hid_t loc_id, char *name, H5R_type_t ref_type,  hid_t space_id)
   hid_t     H5Rdereference(hid_t obj_id, H5R_type_t ref_type, void *ref)
   hid_t     H5Rget_region(hid_t dataset, H5R_type_t ref_type, void *ref)
-  H5G_obj_t H5Rget_obj_type(hid_t id, H5R_type_t ref_type, void *ref)
+  herr_t    H5Rget_obj_type(hid_t id, H5R_type_t ref_type, void *ref, H5O_type_t *obj_type)
   ssize_t   H5Rget_name(hid_t loc_id, H5R_type_t ref_type, void *ref, char *name, size_t size)
 
 
@@ -480,8 +476,7 @@ hdf5:
 
   # General operations
   hid_t         H5Tcreate(H5T_class_t type, size_t size)
-  hid_t         H5Topen(hid_t loc, char* name)
-  herr_t        H5Tcommit(hid_t loc_id, char* name, hid_t type)
+  hid_t         H5Topen(hid_t loc, char* name, hid_t tapl_id)
   htri_t        H5Tcommitted(hid_t type)
   hid_t         H5Tcopy(hid_t type_id)
   htri_t        H5Tequal(hid_t type_id1, hid_t type_id2 )
@@ -557,9 +552,9 @@ hdf5:
   herr_t        H5Tget_member_value(hid_t type,  unsigned int memb_no, void *value )
 
   # Array data types
-  hid_t         H5Tarray_create(hid_t base_id, int ndims, hsize_t *dims, int *perm)
+  hid_t         H5Tarray_create(hid_t base_id, int ndims, hsize_t *dims)
   int           H5Tget_array_ndims(hid_t type_id)
-  int           H5Tget_array_dims(hid_t type_id, hsize_t *dims, int *perm)
+  int           H5Tget_array_dims(hid_t type_id, hsize_t *dims)
 
   # Opaque data types
   herr_t    H5Tset_tag(hid_t type_id, char* tag)

--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -73,16 +73,16 @@ hdf5:
   herr_t    H5Aget_info_by_name(hid_t loc_id, char *obj_name, char *attr_name, H5A_info_t *ainfo, hid_t lapl_id)
   herr_t    H5Aget_info_by_idx(hid_t loc_id, char *obj_name, H5_index_t idx_type, H5_iter_order_t order, hsize_t n, H5A_info_t *ainfo, hid_t lapl_id)
 
-  herr_t    H5Aiterate2(hid_t obj_id, H5_index_t idx_type, H5_iter_order_t order, hsize_t *n, H5A_operator2_t op, void *op_data)
+  herr_t    H5Aiterate(hid_t obj_id, H5_index_t idx_type, H5_iter_order_t order, hsize_t *n, H5A_operator2_t op, void *op_data)
   hsize_t   H5Aget_storage_size(hid_t attr_id)
 
 
   # === H5D - Dataset API =====================================================
 
-  hid_t     H5Dcreate2(hid_t loc_id, char *name, hid_t type_id, hid_t space_id, hid_t lcpl_id, hid_t dcpl_id, hid_t dapl_id) nogil
+  hid_t     H5Dcreate(hid_t loc_id, char *name, hid_t type_id, hid_t space_id, hid_t lcpl_id, hid_t dcpl_id, hid_t dapl_id) nogil
   hid_t     H5Dcreate_anon(hid_t file_id, hid_t type_id, hid_t space_id, hid_t plist_id, hid_t dapl_id) nogil
 
-  hid_t     H5Dopen2(hid_t loc_id, char *name, hid_t dapl_id )
+  hid_t     H5Dopen(hid_t loc_id, char *name, hid_t dapl_id )
   herr_t    H5Dclose(hid_t dset_id)
 
   hid_t     H5Dget_space(hid_t dset_id)
@@ -191,8 +191,8 @@ hdf5:
   int       H5Gget_comment(hid_t loc_id, char *name, size_t bufsize, char *comment)
 
   hid_t     H5Gcreate_anon( hid_t loc_id, hid_t gcpl_id, hid_t gapl_id)
-  hid_t     H5Gcreate2(hid_t loc_id, char *name, hid_t lcpl_id, hid_t gcpl_id, hid_t gapl_id)
-  hid_t     H5Gopen2( hid_t loc_id, char * name, hid_t gapl_id)
+  hid_t     H5Gcreate(hid_t loc_id, char *name, hid_t lcpl_id, hid_t gcpl_id, hid_t gapl_id)
+  hid_t     H5Gopen( hid_t loc_id, char * name, hid_t gapl_id)
   herr_t    H5Gget_info( hid_t group_id, H5G_info_t *group_info)
   herr_t    H5Gget_info_by_name( hid_t loc_id, char *group_name, H5G_info_t *group_info, hid_t lapl_id)
   hid_t     H5Gget_create_plist(hid_t group_id)
@@ -481,7 +481,7 @@ hdf5:
   htri_t        H5Tdetect_class(hid_t type_id, H5T_class_t dtype_class)
   herr_t        H5Tclose(hid_t type_id)
   hid_t         H5Tget_native_type(hid_t type_id, H5T_direction_t direction)
-  herr_t        H5Tcommit2(hid_t loc_id, char *name, hid_t dtype_id, hid_t lcpl_id, hid_t tcpl_id, hid_t tapl_id)
+  herr_t        H5Tcommit(hid_t loc_id, char *name, hid_t dtype_id, hid_t lcpl_id, hid_t tcpl_id, hid_t tapl_id)
   hid_t         H5Tget_create_plist(hid_t dtype_id)
 
   hid_t         H5Tdecode(unsigned char *buf)

--- a/h5py/h5a.pyx
+++ b/h5py/h5a.pyx
@@ -290,7 +290,7 @@ def iterate(ObjectID loc not None, object func, int index=0, *,
     else:
         cfunc = cb_attr_simple
 
-    H5Aiterate2(loc.id, <H5_index_t>index_type, <H5_iter_order_t>order,
+    H5Aiterate(loc.id, <H5_index_t>index_type, <H5_iter_order_t>order,
         &i, cfunc, <void*>vis)
 
     return vis.retval

--- a/h5py/h5d.pyx
+++ b/h5py/h5d.pyx
@@ -84,7 +84,7 @@ def create(ObjectID loc not None, object name, TypeID tid not None,
         cname = name
 
     if cname != NULL:
-        dsid = H5Dcreate2(loc.id, cname, tid.id, space.id,
+        dsid = H5Dcreate(loc.id, cname, tid.id, space.id,
                  pdefault(lcpl), pdefault(dcpl), pdefault(dapl))
     else:
         dsid = H5Dcreate_anon(loc.id, tid.id, space.id,
@@ -99,7 +99,7 @@ def open(ObjectID loc not None, char* name, PropID dapl=None):
 
     If specified, dapl may be a dataset access property list.
     """
-    return DatasetID(H5Dopen2(loc.id, name, pdefault(dapl)))
+    return DatasetID(H5Dopen(loc.id, name, pdefault(dapl)))
 
 # --- Proxy functions for safe(r) threading -----------------------------------
 

--- a/h5py/h5g.pyx
+++ b/h5py/h5g.pyx
@@ -140,7 +140,7 @@ def open(ObjectID loc not None, char* name):
 
     Open an existing HDF5 group, attached to some other group.
     """
-    return GroupID(H5Gopen2(loc.id, name, H5P_DEFAULT))
+    return GroupID(H5Gopen(loc.id, name, H5P_DEFAULT))
 
 
 @with_phil
@@ -159,7 +159,7 @@ def create(ObjectID loc not None, object name, PropID lcpl=None,
         cname = name
 
     if cname != NULL:
-        gid = H5Gcreate2(loc.id, cname, pdefault(lcpl), pdefault(gcpl), H5P_DEFAULT)
+        gid = H5Gcreate(loc.id, cname, pdefault(lcpl), pdefault(gcpl), H5P_DEFAULT)
     else:
         gid = H5Gcreate_anon(loc.id, pdefault(gcpl), H5P_DEFAULT)
 

--- a/h5py/h5g.pyx
+++ b/h5py/h5g.pyx
@@ -140,7 +140,7 @@ def open(ObjectID loc not None, char* name):
 
     Open an existing HDF5 group, attached to some other group.
     """
-    return GroupID(H5Gopen(loc.id, name))
+    return GroupID(H5Gopen2(loc.id, name, H5P_DEFAULT))
 
 
 @with_phil

--- a/h5py/h5o.pyx
+++ b/h5py/h5o.pyx
@@ -160,22 +160,12 @@ def get_info(ObjectID loc not None, char* name=NULL, int index=-1, *,
     if name != NULL and index >= 0:
         raise TypeError("At most one of name or index may be specified")
     elif name != NULL and index < 0:
-        IF HDF5_VERSION < VOL_MIN_HDF5_VERSION:
-            H5Oget_info_by_name(loc.id, name, &info.infostruct, pdefault(lapl))
-        ELSE:
-            H5Oget_info_by_name1(loc.id, name, &info.infostruct, pdefault(lapl))
+        H5Oget_info_by_name(loc.id, name, &info.infostruct, pdefault(lapl))
     elif name == NULL and index >= 0:
-        IF HDF5_VERSION < VOL_MIN_HDF5_VERSION:
-            H5Oget_info_by_idx(loc.id, obj_name, <H5_index_t>index_type,
-                <H5_iter_order_t>order, index, &info.infostruct, pdefault(lapl))
-        ELSE:
-            H5Oget_info_by_idx1(loc.id, obj_name, <H5_index_t>index_type,
-                <H5_iter_order_t>order, index, &info.infostruct, pdefault(lapl))
+        H5Oget_info_by_idx(loc.id, obj_name, <H5_index_t>index_type,
+            <H5_iter_order_t>order, index, &info.infostruct, pdefault(lapl))
     else:
-        IF HDF5_VERSION < VOL_MIN_HDF5_VERSION:
-            H5Oget_info(loc.id, &info.infostruct)
-        ELSE:
-            H5Oget_info1(loc.id, &info.infostruct)
+        H5Oget_info(loc.id, &info.infostruct)
 
     return info
 
@@ -362,11 +352,7 @@ def visit(ObjectID loc not None, object func, *,
     else:
         cfunc = cb_obj_simple
 
-    IF HDF5_VERSION < VOL_MIN_HDF5_VERSION:
-        H5Ovisit_by_name(loc.id, obj_name, <H5_index_t>idx_type,
-            <H5_iter_order_t>order, cfunc, <void*>visit, pdefault(lapl))
-    ELSE:
-        H5Ovisit_by_name1(loc.id, obj_name, <H5_index_t>idx_type,
-            <H5_iter_order_t>order, cfunc, <void*>visit, pdefault(lapl))
+    H5Ovisit_by_name(loc.id, obj_name, <H5_index_t>idx_type,
+        <H5_iter_order_t>order, cfunc, <void*>visit, pdefault(lapl))
 
     return visit.retval

--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -665,7 +665,7 @@ cdef class PropDCID(PropOCID):
             raise ValueError("Filter index must be a non-negative integer")
 
         filter_code = <int>H5Pget_filter(self.id, filter_idx, &flags,
-                                         &nelements, cd_values, 256, name)
+                                         &nelements, cd_values, 256, name, NULL)
         name[256] = c'\0'  # in case it's > 256 chars
 
         vlist = []
@@ -717,7 +717,7 @@ cdef class PropDCID(PropOCID):
             return None
 
         retval = H5Pget_filter_by_id(self.id, <H5Z_filter_t>filter_code,
-                                     &flags, &nelements, cd_values, 256, name)
+                                     &flags, &nelements, cd_values, 256, name, NULL)
         assert nelements <= 16
 
         name[256] = c'\0'  # In case HDF5 doesn't terminate it properly

--- a/h5py/h5r.pyx
+++ b/h5py/h5r.pyx
@@ -112,16 +112,17 @@ def get_obj_type(Reference ref not None, ObjectID id not None):
 
     The return value is one of:
 
-    - h5g.LINK
-    - h5g.GROUP
-    - h5g.DATASET
-    - h5g.TYPE
+    - h5o.TYPE_GROUP
+    - h5o.TYPE_DATASET
+    - h5o.TYPE_NAMED_DATATYPE
 
     If the reference is zero-filled, returns None.
     """
+    cdef H5O_type_t obj_type
     if not ref:
         return None
-    return <int>H5Rget_obj_type(id.id, <H5R_type_t>ref.typecode, &ref.ref)
+    H5Rget_obj_type(id.id, <H5R_type_t>ref.typecode, &ref.ref, &obj_type)
+    return <int>obj_type
 
 
 @with_phil

--- a/h5py/h5s.pyx
+++ b/h5py/h5s.pyx
@@ -162,16 +162,10 @@ cdef class SpaceID(ObjectID):
         cdef void* buf = NULL
         cdef size_t nalloc = 0
 
-        IF HDF5_VERSION < VOL_MIN_HDF5_VERSION:
-            H5Sencode(self.id, NULL, &nalloc)
-        ELSE:
-            H5Sencode1(self.id, NULL, &nalloc)
+        H5Sencode(self.id, NULL, &nalloc)
         buf = emalloc(nalloc)
         try:
-            IF HDF5_VERSION < VOL_MIN_HDF5_VERSION:
-                H5Sencode(self.id, buf, &nalloc)
-            ELSE:
-                H5Sencode1(self.id, buf, &nalloc)
+            H5Sencode(self.id, buf, &nalloc)
             pystr = PyBytes_FromStringAndSize(<char*>buf, nalloc)
         finally:
             efree(buf)

--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -430,7 +430,7 @@ cdef class TypeID(ObjectID):
         Commit this (transient) datatype to a named datatype in a file.
         If present, lcpl may be a link creation property list.
         """
-        H5Tcommit2(group.id, name, self.id, pdefault(lcpl),
+        H5Tcommit(group.id, name, self.id, pdefault(lcpl),
             H5P_DEFAULT, H5P_DEFAULT)
 
 

--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -302,12 +302,13 @@ def create(int classtype, size_t size):
 
 
 @with_phil
-def open(ObjectID group not None, char* name):
+def open(ObjectID group not None, char* name, ObjectID tapl=None):
     """(ObjectID group, STRING name) => TypeID
 
     Open a named datatype from a file.
+    If present, tapl must be a datatype access property list.
     """
-    return typewrap(H5Topen(group.id, name))
+    return typewrap(H5Topen(group.id, name, pdefault(tapl)))
 
 
 @with_phil
@@ -327,7 +328,7 @@ def array_create(TypeID base not None, object dims_tpl):
 
     try:
         convert_tuple(dims_tpl, dims, rank)
-        return TypeArrayID(H5Tarray_create(base.id, rank, dims, NULL))
+        return TypeArrayID(H5Tarray_create(base.id, rank, dims))
     finally:
         efree(dims)
 
@@ -587,10 +588,10 @@ cdef class TypeArrayID(TypeID):
         cdef hsize_t rank
         cdef hsize_t* dims = NULL
 
-        rank = H5Tget_array_dims(self.id, NULL, NULL)
+        rank = H5Tget_array_dims(self.id, NULL)
         dims = <hsize_t*>emalloc(sizeof(hsize_t)*rank)
         try:
-            H5Tget_array_dims(self.id, dims, NULL)
+            H5Tget_array_dims(self.id, dims)
             return convert_dims(dims, rank)
         finally:
             efree(dims)

--- a/setup_build.py
+++ b/setup_build.py
@@ -43,7 +43,7 @@ COMPILER_SETTINGS = {
    'libraries'      : ['hdf5', 'hdf5_hl'],
    'include_dirs'   : [localpath('lzf')],
    'library_dirs'   : [],
-   'define_macros'  : [('H5_USE_16_API', None),
+   'define_macros'  : [('H5_USE_18_API', None),
                        ('NPY_NO_DEPRECATED_API', 0),
                       ]
 }


### PR DESCRIPTION
Build with the `H5_USE_18_API` option, and update APIs changed in 1.8 to use the new variants of the functions. We already dropped support for HDF5 1.6 some time ago, but this wasn't cleaned up.

Where HDF5 1.8 introduced version 2 of a function, we have three options:

1. Explicitly use the old version, e.g. `H5Aiterate1`.
2. Use the new function, e.g. `H5Aiterate2`
3. Use the compatibility macro, e.g. `H5Aiterate`. This is equivalent to option 2 when we use the `H5_USE_18_API` option.

These changes at the moment are a mixture of options 2 & 3. We should be systematic about that, but I wasn't sure which one was preferable, so I stuck to making the fewest possible changes, which varies from case to case.