### PR TITLE
tell mpi4py not to automatically initialize MPI at import

### DIFF
--- a/h5py/__init__.py
+++ b/h5py/__init__.py
@@ -15,6 +15,15 @@
 from warnings import warn as _warn
 import atexit
 
+# Tell mpi4py to not automatically initialize MPI at import;
+# required to avoid problems with 'import h5py' in some environment
+# when h5py was built with MPI support
+try:
+    import mpi4py
+    mpi4py.rc.initialize = False
+except ImportError:
+    pass
+
 
 # --- Library setup -----------------------------------------------------------
 

--- a/h5py/__init__.py
+++ b/h5py/__init__.py
@@ -21,6 +21,7 @@ import atexit
 try:
     import mpi4py
     mpi4py.rc.initialize = False
+    mpi4py.rc.finalize = True
 except ImportError:
     pass
 

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -45,6 +45,8 @@ def _set_fapl_mpio(plist, **kwargs):
         raise ValueError("h5py was built without MPI support, can't use mpio driver")
 
     import mpi4py
+    if not mpi4py.MPI.Is_initialized():
+        mpi4py.MPI.Init()
     kwargs.setdefault('info', mpi4py.MPI.Info())
     plist.set_fapl_mpio(**kwargs)
 

--- a/h5py/tests/common.py
+++ b/h5py/tests/common.py
@@ -58,9 +58,11 @@ class TestCase(ut.TestCase):
         return tempfile.mktemp(suffix, prefix, dir=dir)
 
     def mktemp_mpi(self, comm=None, suffix='.hdf5', prefix='', dir=None):
+        from mpi4py import MPI
         if comm is None:
-            from mpi4py import MPI
             comm = MPI.COMM_WORLD
+        if not MPI.Is_initialized():
+            MPI.Init()
         fname = None
         if comm.Get_rank() == 0:
             fname = self.mktemp(suffix, prefix, dir)

--- a/h5py/tests/common.py
+++ b/h5py/tests/common.py
@@ -57,18 +57,6 @@ class TestCase(ut.TestCase):
             dir = self.tempdir
         return tempfile.mktemp(suffix, prefix, dir=dir)
 
-    def mktemp_mpi(self, comm=None, suffix='.hdf5', prefix='', dir=None):
-        from mpi4py import MPI
-        if comm is None:
-            comm = MPI.COMM_WORLD
-        if not MPI.Is_initialized():
-            MPI.Init()
-        fname = None
-        if comm.Get_rank() == 0:
-            fname = self.mktemp(suffix, prefix, dir)
-        fname = comm.bcast(fname, 0)
-        return fname
-
     def setUp(self):
         self.f = h5py.File(self.mktemp(), 'w')
 

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -699,6 +699,17 @@ class TestPickle(TestCase):
 # hence no subclassing TestCase
 @pytest.mark.mpi
 class TestMPI(object):
+
+    @pytest.fixture(autouse=True)
+    def init_mpi(self):
+        # make sure MPI is initialized;
+        # this is required because:
+        # i) mpi4py is told not to initialize on import by h5py
+        # ii) the mpi_file_name fixture provides by pytest-mpi calls MPI_Comm_rank
+        from mpi4py import MPI
+        if not MPI.Is_initialized():
+            MPI.Init()
+
     def test_mpio(self, mpi_file_name):
         """ MPIO driver and options """
         from mpi4py import MPI

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
     test: python -c "import sys; print('64 bit?', sys.maxsize > 2**32)"
     test: python {toxinidir}/ci/fix_paths.py
     test-!mpi4py: python -m pytest --pyargs h5py --cov=h5py -rxXs --cov-config={toxinidir}/.coveragerc {posargs}
-    test-mpi4py: mpirun -n {env:MPI_N_PROCS:2} {envpython} -m pytest --pyargs h5py -rxXs --with-mpi {posargs}
+    test-mpi4py: mpirun -n {env:MPI_N_PROCS:2} {envpython} -m pytest --verbose --pyargs h5py -rxXs --with-mpi {posargs}
 changedir =
     test: {toxworkdir}
 passenv =


### PR DESCRIPTION
This is an (incomplete) attempt at fixing #917.

The issue is that anything beyond a simple `import mpi4py` will trigger an `MPI_Init` call, which is problematic in a number of contexts. That's annoying, since it means `import h5py` will trigger an `MPI_Init` call, which often results in a hard crash, even when there's no intention to leverage the MPI support at all...

This can be avoided by instructing `mpi4py` to not initialize MPI automatically on import via `mpi4p.rc.initialize` ('rc' is runtime configuration here), but then the `mpi4py.MPI.Init()` needs to be done whenever any MPI calls will actually be used...

I'm clearly still figuring out the last part, but I'm stabbing in the dark a bit since I'm not very familiar with the `h5py` codebase, so I would appreciate some pointers on this.
Is there a central place where doing the `MPI.Init()` would make sense? Or am I overlooking a location in my current changes?

Also, the tests are currently just exiting without producing much helpful information, I can't actually tell where the MPI error is coming from...
Is there a way to make `pytest` not hide that information?

Overall, would this change make sense to get merged (once it's done properly)?