### PR TITLE
Fix writing Python integers as uint64

### DIFF
--- a/h5py/_hl/attrs.py
+++ b/h5py/_hl/attrs.py
@@ -222,12 +222,15 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
             if not name in self:
                 self[name] = value
             else:
-                value = numpy.asarray(value, order='C')
-
                 attr = h5a.open(self._id, self._e(name))
 
                 if is_empty_dataspace(attr):
                     raise IOError("Empty attributes can't be modified")
+
+                # If the input data is already an array, let HDF5 do the conversion.
+                # If it's a list or similar, don't make numpy guess a dtype for it.
+                dt = None if isinstance(value, numpy.ndarray) else attr.dtype
+                value = numpy.asarray(value, order='C', dtype=dt)
 
                 # Allow the case of () <-> (1,)
                 if (value.shape != attr.shape) and not \

--- a/h5py/_hl/attrs.py
+++ b/h5py/_hl/attrs.py
@@ -19,7 +19,7 @@ import uuid
 
 from .. import h5, h5s, h5t, h5a, h5p
 from . import base
-from .base import phil, with_phil, Empty, is_empty_dataspace
+from .base import phil, with_phil, Empty, is_empty_dataspace, product
 from .datatype import Datatype
 
 
@@ -234,7 +234,7 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
 
                 # Allow the case of () <-> (1,)
                 if (value.shape != attr.shape) and not \
-                   (numpy.product(value.shape, dtype=numpy.ulonglong) == 1 and numpy.product(attr.shape, dtype=numpy.ulonglong) == 1):
+                   (value.size == 1 and product(attr.shape) == 1):
                     raise TypeError("Shape of data is incompatible with existing attribute")
                 attr.write(value)
 

--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -105,17 +105,20 @@ def array_for_new_object(data, specified_dtype=None):
     # https://github.com/h5py/h5py/issues/819
     if is_float16_dtype(specified_dtype):
         as_dtype = specified_dtype
+    elif not isinstance(data, np.ndarray) and (specified_dtype is not None):
+        # If we need to convert e.g. a list to an array, don't leave numpy
+        # to guess a dtype we already know.
+        as_dtype = specified_dtype
     else:
         as_dtype = guess_dtype(data)
 
     data = np.asarray(data, order="C", dtype=as_dtype)
 
     # In most cases, this does nothing. But if data was already an array,
-    # and guess_dtype made a tagged version of the dtype it already had
-    # (e.g. an object array of strings), asarray() doesn't replace its
-    # dtype object. This gives it the tagged dtype:
+    # and as_dtype is a tagged h5py dtype (e.g. for an object array of strings),
+    # asarray() doesn't replace its dtype object. This gives it the tagged dtype:
     if as_dtype is not None:
-        data.dtype = as_dtype
+        data = data.view(dtype=as_dtype)
 
     return data
 

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -790,7 +790,10 @@ class Dataset(HLObject):
                 val = val.view(numpy.dtype([(names[0], dtype)]))
                 val = val.reshape(val.shape[:len(val.shape) - len(dtype.shape)])
         else:
-            val = numpy.asarray(val, order='C')
+            # If the input data is already an array, let HDF5 do the conversion.
+            # If it's a list or similar, don't make numpy guess a dtype for it.
+            dt = None if isinstance(val, numpy.ndarray) else self.dtype
+            val = numpy.asarray(val, order='C', dtype=dt)
 
         # Check for array dtype compatibility and convert
         if self.dtype.subdtype is not None:

--- a/h5py/tests/test_attrs.py
+++ b/h5py/tests/test_attrs.py
@@ -200,3 +200,16 @@ class TestDatatype(BaseAttrs):
         dt.attrs.create('a', 4.0)
         self.assertEqual(list(dt.attrs.keys()), ['a'])
         self.assertEqual(list(dt.attrs.values()), [4.0])
+
+def test_python_int_uint64(writable_file):
+    f = writable_file
+    data = [np.iinfo(np.int64).max, np.iinfo(np.int64).max + 1]
+
+    # Check creating a new attribute
+    f.attrs.create('a', data, dtype=np.uint64)
+    assert f.attrs['a'].dtype == np.dtype(np.uint64)
+    np.testing.assert_array_equal(f.attrs['a'], np.array(data, dtype=np.uint64))
+
+    # Check modifying an existing attribute
+    f.attrs.modify('a', data)
+    np.testing.assert_array_equal(f.attrs['a'], np.array(data, dtype=np.uint64))

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1454,7 +1454,7 @@ def test_zero_storage_size():
         assert fin['empty'].id.get_storage_size() == 0
 
 
-def test_create_uint64(writable_file):
+def test_python_int_uint64(writable_file):
     # https://github.com/h5py/h5py/issues/1547
     data = [np.iinfo(np.int64).max, np.iinfo(np.int64).max + 1]
 

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1457,6 +1457,12 @@ def test_zero_storage_size():
 def test_create_uint64(writable_file):
     # https://github.com/h5py/h5py/issues/1547
     data = [np.iinfo(np.int64).max, np.iinfo(np.int64).max + 1]
+
+    # Check creating a new dataset
     ds = writable_file.create_dataset('x', data=data, dtype=np.uint64)
     assert ds.dtype == np.dtype(np.uint64)
+    np.testing.assert_array_equal(ds[:], np.array(data, dtype=np.uint64))
+
+    # Check writing to an existing dataset
+    ds[:] = data
     np.testing.assert_array_equal(ds[:], np.array(data, dtype=np.uint64))

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1452,3 +1452,11 @@ def test_zero_storage_size():
         assert fin['empty'].chunks is None
         assert fin['empty'].id.get_offset() is None
         assert fin['empty'].id.get_storage_size() == 0
+
+
+def test_create_uint64(writable_file):
+    # https://github.com/h5py/h5py/issues/1547
+    data = [np.iinfo(np.int64).max, np.iinfo(np.int64).max + 1]
+    ds = writable_file.create_dataset('x', data=data, dtype=np.uint64)
+    assert ds.dtype == np.dtype(np.uint64)
+    np.testing.assert_array_equal(ds[:], np.array(data, dtype=np.uint64))


### PR DESCRIPTION
Closes #1547.

I discovered that the same flaw appeared in writing to an existing dataset, and with creating & modifying attributes.

This should fix all four cases, by not relying on numpy's dtype inference when we have a target dtype to aim for. But if a numpy array is passed in, we still leave the conversion to HDF5 rather than asking numpy to do it, which would create a temporary copy in memory.