### PR TITLE
Addresses file mode and SWMR mode inconsistencies pointed out in gh-1580

### DIFF
--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -304,7 +304,7 @@ class File(Group):
             else:
                 raise ValueError("It is not possible to forcibly switch SWMR mode off.")
         else:
-            raise RuntimeError('SWMR support is not available for version {}.{}.{}.'.format(*hdf5_version))
+            raise RuntimeError('SWMR support is not available in HDF5 version {}.{}.{}.'.format(*hdf5_version))
 
     def __init__(self, name, mode=None, driver=None,
                  libver=None, userblock_size=None, swmr=False,

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -254,7 +254,10 @@ class File(Group):
     @with_phil
     def mode(self):
         """ Python mode used to open file """
-        intent = self.id.get_intent() & (h5f.ACC_SWMR_WRITE | h5f.ACC_RDWR)
+        if swmr_support:
+            intent = self.id.get_intent() & (h5f.ACC_SWMR_WRITE | h5f.ACC_RDWR)
+        else:
+            intent = self.id.get_intent() & h5f.ACC_RDWR
         if 0 < intent:
             return 'r+'
         else:

--- a/h5py/tests/test_dataset_swmr.py
+++ b/h5py/tests/test_dataset_swmr.py
@@ -36,9 +36,17 @@ class TestSwmrNotAvailable(TestCase):
         with self.assertRaises(AttributeError):
             self.dset.flush()
 
-    def test_swmr_mode_raises(self):
-        with self.assertRaises(AttributeError):
-            self.f.swmr_mode
+    def test_swmr_mode_false(self):
+        """ The SWMR getter should just be False
+        """
+        assert not self.f.swmr_mode
+
+    def test_set_swmr_mode_raises(self):
+        """ If the SWMR feature is not available, setting swmr_mode = True
+        should raise a RuntimeError
+        """
+        with self.assertRaises(RuntimeError):
+            self.f.swmr_mode = True
 
 @ut.skipUnless(h5py.version.hdf5_version_tuple >= (1, 9, 178), 'SWMR requires HDF5 >= 1.9.178')
 class TestDatasetSwmrRead(TestCase):

--- a/h5py/tests/test_dataset_swmr.py
+++ b/h5py/tests/test_dataset_swmr.py
@@ -47,6 +47,7 @@ class TestSwmrNotAvailable(TestCase):
         """
         with self.assertRaises(RuntimeError):
             self.f.swmr_mode = True
+        assert not self.f.swmr_mode
 
 @ut.skipUnless(h5py.version.hdf5_version_tuple >= (1, 9, 178), 'SWMR requires HDF5 >= 1.9.178')
 class TestDatasetSwmrRead(TestCase):

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -726,3 +726,34 @@ class TestMPI(object):
         f.create_group("test")
         f.close()
         f.close()
+
+
+@ut.skipIf(h5py.version.hdf5_version_tuple < (1, 10, 1),
+               'Requires HDF5 1.10.1 or later')
+class TestSWMRMode(TestCase):
+
+    """
+        Feature: Create file that switches on SWMR mode
+    """
+
+    def test_file_mode_generalizes(self):
+        fname = self.mktemp()
+        fid = File(fname, 'w', libver='latest')
+        g = fid.create_group('foo')
+        # fid and group member file attribute should have the same mode
+        assert fid.mode == g.file.mode == 'r+'
+        fid.swmr_mode = True
+        # fid and group member file attribute should still be 'r+'
+        # even though file intent has changed
+        assert fid.mode == g.file.mode == 'r+'
+        fid.close()
+
+    def test_swmr_mode_consistency(self):
+        fname = self.mktemp()
+        fid = File(fname, 'w', libver='latest')
+        g = fid.create_group('foo')
+        assert fid.swmr_mode == g.file.swmr_mode == False
+        fid.swmr_mode = True
+        # This setter should affect both fid and group member file attribute
+        assert fid.swmr_mode == g.file.swmr_mode == True
+        fid.close()

--- a/news/swmr_property_getters.rst
+++ b/news/swmr_property_getters.rst
@@ -1,0 +1,30 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* The ``File.swmr_mode`` property is consistent with the file's access mode (via ``id.get_intent()``)
+* ``File.mode`` property handles SWMR access modes in addition to plain RDONLY/RDWR modes
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
* Remove _swmr_mode private attribute
* Both FID and group/dataset "file" attribute have consistent modes
  before and after swmr_mode setter
* Both FID and group/dataset "file" attribute have consistent
  swmr_mode getters

<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- Add a release note in the news/ folder (copy TEMPLATE.rst)

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->
