### PR TITLE
Fix spelling in user documentation and code

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -23,7 +23,7 @@ attributes:
         container creation order is tracked, its links and attributes
         are iterated in ascending creation order (consistent with
         ``dict`` in Python 3.7+); otherwise in ascending alphanumeric
-        order.  Global configuration value can be overriden for
+        order.  Global configuration value can be overridden for
         particular container by specifying ``track_order`` argument to
         :class:`h5py.File`, :meth:`h5py.Group.create_group`,
         :meth:`h5py.Group.create_dataset`.  The default is ``False``.

--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -321,7 +321,7 @@ Multi-Block Selection
 
 The full H5Sselect_hyperslab API is exposed via the MultiBlockSlice object.
 This takes four elements to define the selection (start, count, stride and
-block) in constrast to the built-in slice object, which takes three elements.
+block) in contrast to the built-in slice object, which takes three elements.
 A MultiBlockSlice can be used in place of a slice to select a number of (count)
 blocks of multiple elements separated by a stride, rather than a set of single
 elements separated by a step.
@@ -413,7 +413,7 @@ or by ``data`` to an instance of ``h5py.Empty``::
 An empty dataset has shape defined as ``None``, which is the best way of
 determining whether a dataset is empty or not. An empty dataset can be "read" in
 a similar way to scalar datasets, i.e. if ``empty_dataset`` is an empty
-dataset,::
+dataset::
 
     >>> empty_dataset[()]
     h5py.Empty(dtype="f")
@@ -452,8 +452,8 @@ Reference
         >>> if dset:
         ...     print("datset accessible")
         ... else:
-        ...     print("dataset is inaccessible")
-        dataset unaccessible
+        ...     print("dataset inaccessible")
+        dataset inaccessible
 
     .. method:: read_direct(array, source_sel=None, dest_sel=None)
 
@@ -583,7 +583,7 @@ Reference
 
     .. attribute:: maxshape
 
-        NumPy-style shape tuple indicating the maxiumum dimensions up to which
+        NumPy-style shape tuple indicating the maximum dimensions up to which
         the dataset may be resized.  Axes with ``None`` are unlimited.
 
     .. attribute:: chunks
@@ -641,7 +641,7 @@ Reference
 
     .. attribute:: id
 
-        The dataset's low-level identifer; an instance of
+        The dataset's low-level identifier; an instance of
         :class:`DatasetID <low:h5py.h5d.DatasetID>`.
 
     .. attribute:: ref

--- a/docs/high/group.rst
+++ b/docs/high/group.rst
@@ -429,7 +429,7 @@ Reference
 
     .. attribute:: id
 
-        The groups's low-level identifer; an instance of
+        The groups's low-level identifier; an instance of
         :class:`GroupID <low:h5py.h5g.GroupID>`.
 
     .. attribute:: ref

--- a/docs/whatsnew/2.7.rst
+++ b/docs/whatsnew/2.7.rst
@@ -3,7 +3,7 @@ What's new in h5py 2.7
 
 Python 3.2 is no longer supported
 ---------------------------------
-``h5py`` 2.7 drops Python 3.2 support, and testing is not longer preformed on Python 3.2. The latest versions of ``pip``, ``virtualenv``, ``setuptools`` and ``numpy`` do not support Python 3.2, and dropping 3.2 allows both ``u`` and ``b`` prefixes to be used for strings. A clean up of some of the legacy code was done in `#675`_ by Andrew Collette.
+``h5py`` 2.7 drops Python 3.2 support, and testing is not longer performed on Python 3.2. The latest versions of ``pip``, ``virtualenv``, ``setuptools`` and ``numpy`` do not support Python 3.2, and dropping 3.2 allows both ``u`` and ``b`` prefixes to be used for strings. A clean up of some of the legacy code was done in `#675`_ by Andrew Collette.
 
 Additionally, support for Python 2.6 is soon to be dropped for ``pip`` (See https://github.com/pypa/pip/issues/3955) and ``setuptools`` (See https://github.com/pypa/setuptools/issues/878), and ``numpy`` has dropped Python 2.6 also in the latest release. While ``h5py`` has not dropped Python 2.6 this release, users are strongly encouraged to move to Python 2.7 where possible.
 

--- a/h5py/_conv.pyx
+++ b/h5py/_conv.pyx
@@ -639,7 +639,7 @@ cdef int conv_vlen2ndarray(void* ipt,
 
     :param ipt: input pointer: Point to the input data
     :param opt: output pointer: will contains the numpy array after exit
-    :param elem_dtype: dtype of the elemnt
+    :param elem_dtype: dtype of the element
     :param intype: ?
     :param outtype: ?
     """

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -865,7 +865,7 @@ class Dataset(HLObject):
         # the dataset used an appropriate chunk size according the available
         # memory. In any case, if we cannot afford to create an intermediate
         # array of the same size as the dataset chunk size, the user program has
-        # little hope to go much further. Solves h5py isue #1067
+        # little hope to go much further. Solves h5py issue #1067
         if mshape == () and selection.array_shape != ():
             if self.dtype.subdtype is not None:
                 raise TypeError("Scalar broadcasting is not supported for array dtypes")

--- a/h5py/_hl/selections.py
+++ b/h5py/_hl/selections.py
@@ -310,7 +310,7 @@ class FancySelection(Selection):
         Implements advanced NumPy-style selection operations in addition to
         the standard slice-and-int behavior.
 
-        Indexing arguments may be ints, slices, lists of indicies, or
+        Indexing arguments may be ints, slices, lists of indices, or
         per-axis (1D) boolean arrays.
 
         Broadcasting is not supported for these selections.

--- a/h5py/_objects.pyx
+++ b/h5py/_objects.pyx
@@ -64,7 +64,7 @@ def with_phil(func):
 #
 # With HDF5 1.8, when an identifier is closed its value may be immediately
 # re-used for a new object.  This leads to odd behavior when an ObjectID
-# with an old identifier is left hanging around... for example, a GroupID
+# with an old identifier is left hanging around... For example, a GroupID
 # belonging to a closed file could suddenly "mutate" into one from a
 # different file.
 #
@@ -79,7 +79,7 @@ def with_phil(func):
 # nonlocal_close() does.  We maintain an inventory of all live ObjectID
 # instances in the registry dict.  Then, when a nonlocal event occurs,
 # nonlocal_close() walks through the inventory and sets the stale identifiers
-# to 0.  It must be explictly called; currently, this happens in FileID.close()
+# to 0.  It must be explicitly called; currently, this happens in FileID.close()
 # as well as the high-level File.close().
 #
 # The entire low-level API is now explicitly locked, so only one thread at at

--- a/h5py/h5fd.pyx
+++ b/h5py/h5fd.pyx
@@ -92,7 +92,7 @@ LOG_ALL       = H5FD_LOG_ALL        # (H5FD_LOG_ALLOC|H5FD_LOG_TIME_IO|H5FD_LOG_
 # taking file-like object from FAPL and returning struct
 # H5FD_fileobj_t (descendant of base H5FD_t) which will hold file
 # state. Other callbacks receive H5FD_fileobj_t and operate on
-# f.fileobj. If successful, callbacks must return zero; otherwize
+# f.fileobj. If successful, callbacks must return zero; otherwise
 # non-zero value.
 
 

--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -358,7 +358,7 @@ def vlen_create(TypeID base not None):
 def decode(char* buf):
     """(STRING buf) => TypeID
 
-    Unserialize an HDF5 type.  You can also do this with the native
+    Deserialize an HDF5 type.  You can also do this with the native
     Python pickling machinery.
     """
     return typewrap(H5Tdecode(<unsigned char*>buf))
@@ -1647,7 +1647,7 @@ cpdef TypeID py_create(object dtype_in, bint logical=0, bint aligned=0):
         char kind
 
     dt = np.dtype(dtype_in)
-    # dt is now the C side of dtype_in. Sometimes the Python behavour is easier to handle than the C-version
+    # dt is now the C side of dtype_in. Sometimes the Python behaviour is easier to handle than the C-version
     kind = dt.kind
     aligned = getattr(dtype_in, "isalignedstruct", aligned)
 

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -267,15 +267,15 @@ class TestCreateChunked(BaseDataset):
         """ Test scalar assignment of chunked dataset """
         dset = self.f.create_dataset('foo', shape=(3, 50, 50),
                                      dtype=np.int32, chunks=(1, 50, 50))
-        # test assignement of selection smaller than chunk size
+        # test assignment of selection smaller than chunk size
         dset[1, :, 40] = 10
         self.assertTrue(np.all(dset[1, :, 40] == 10))
 
-        # test assignement of selection equal to chunk size
+        # test assignment of selection equal to chunk size
         dset[1] = 11
         self.assertTrue(np.all(dset[1] == 11))
 
-        # test assignement of selection bigger than chunk size
+        # test assignment of selection bigger than chunk size
         dset[0:2] = 12
         self.assertTrue(np.all(dset[0:2] == 12))
 

--- a/h5py/tests/test_dtype.py
+++ b/h5py/tests/test_dtype.py
@@ -234,7 +234,7 @@ class TestOffsets(TestCase):
         self.assertTrue(dt.itemsize == itemsize)
         data = np.empty(10, dtype=dt)
 
-        # don't trust numpy struct handling , keep fields out of band incase content insertion is erroneous
+        # don't trust numpy struct handling, keep fields out of band in case content insertion is erroneous
         # yes... this has also been known to happen.
         f1 = np.array([1 + i * 4 for i in range(data.shape[0])], dtype=dt.fields['f1'][0])
         f2 = np.array([2 + i * 4 for i in range(data.shape[0])], dtype=dt.fields['f2'][0])

--- a/h5py/tests/test_errors.py
+++ b/h5py/tests/test_errors.py
@@ -25,7 +25,7 @@ def _access_not_existing_object(filename):
 
 
 def test_unsilence_errors(tmp_path, capfd):
-    """Chech that HDF5 errors can be mute/unmute from h5py"""
+    """Check that HDF5 errors can be muted/unmuted from h5py"""
     filename = tmp_path / 'test.h5'
 
     # Unmute HDF5 errors

--- a/news/file-space-strat.rst
+++ b/news/file-space-strat.rst
@@ -2,7 +2,7 @@ New features
 ------------
 
 * Support for setting file space strategy at file creation.  Includes option to
-  presist empty space tracking between sessions.
+  persist empty space tracking between sessions.
 
 Deprecations
 ------------

--- a/news/scalar_assignment.rst
+++ b/news/scalar_assignment.rst
@@ -1,7 +1,7 @@
 New features
 ------------
 
-* Efficient handling of scalar assignement of chunked datasets when the number of assigned elements is smaller or equal to the size of one chunk.
+* Efficient handling of scalar assignment of chunked datasets when the number of assigned elements is smaller or equal to the size of one chunk.
 
 Deprecations
 ------------


### PR DESCRIPTION
This PR fixes minor spelling mistakes across the user documentation, and some in the code.
It aims to close #1558 

Thanks for having a look :)