### PR TITLE
Stricter rules for writing into vlen string datasets

### DIFF
--- a/h5py/_conv.pyx
+++ b/h5py/_conv.pyx
@@ -179,14 +179,7 @@ cdef int conv_str2vlen(void* ipt, void* opt, void* bkg, void* priv) except -1:
             temp_object = temp_object.encode('utf-8')
 
         elif not isinstance(temp_object, bytes):
-            # There is not test on this !
-            if sizes.cset == H5T_CSET_ASCII:
-                encoding = 'ascii'
-            elif sizes.cset == H5T_CSET_UTF8:
-                encoding = 'utf-8'
-            else:
-                raise TypeError("Unrecognized dataset encoding")
-            temp_object = str(temp_object).encode(encoding)
+            raise TypeError("Can't implicitly convert non-string objects to strings")
 
         # temp_object is bytes
         temp_string = temp_object  # cython cast it as char *

--- a/h5py/_conv.pyx
+++ b/h5py/_conv.pyx
@@ -165,25 +165,17 @@ cdef int conv_str2vlen(void* ipt, void* opt, void* bkg, void* priv) except -1:
         object temp_object
 
     buf_obj0 = buf_obj[0]
-    if buf_obj0 == NULL:
-        temp_object = None
-    else:
-        temp_object = <object> buf_obj0
+    temp_object = <object> buf_obj0
 
-    if temp_object is None:
-        temp_string = ""
-        temp_string_len = 0
-    else:
+    if isinstance(temp_object, unicode):
+        temp_object = temp_object.encode('utf-8')
 
-        if isinstance(temp_object, unicode):
-            temp_object = temp_object.encode('utf-8')
+    elif not isinstance(temp_object, bytes):
+        raise TypeError("Can't implicitly convert non-string objects to strings")
 
-        elif not isinstance(temp_object, bytes):
-            raise TypeError("Can't implicitly convert non-string objects to strings")
-
-        # temp_object is bytes
-        temp_string = temp_object  # cython cast it as char *
-        temp_string_len = len(temp_object)
+    # temp_object is bytes
+    temp_string = temp_object  # cython cast it as char *
+    temp_string_len = len(temp_object)
 
     if strlen(temp_string) != temp_string_len:
         raise ValueError("VLEN strings do not support embedded NULLs")

--- a/h5py/_conv.pyx
+++ b/h5py/_conv.pyx
@@ -168,7 +168,8 @@ cdef int conv_str2vlen(void* ipt, void* opt, void* bkg, void* priv) except -1:
     temp_object = <object> buf_obj0
 
     if isinstance(temp_object, unicode):
-        temp_object = temp_object.encode('utf-8')
+        enc = 'utf-8' if (sizes[0].cset == H5T_CSET_UTF8) else 'ascii'
+        temp_object = temp_object.encode(enc)
 
     elif not isinstance(temp_object, bytes):
         raise TypeError("Can't implicitly convert non-string objects to strings")

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1007,16 +1007,6 @@ class TestStrings(BaseDataset):
         self.assertEqual(type(out), bytes)
         self.assertEqual(out, data)
 
-    def test_vlen_bytes_write_none(self):
-        """ Writing None to ascii vlen dataset is OK
-        """
-        dt = h5py.string_dtype('ascii')
-        ds = self.f.create_dataset('x', (100,), dtype=dt)
-        ds[0] = None
-        out = ds[0]
-        self.assertEqual(type(out), bytes)
-        self.assertEqual(out, b'')
-
     def test_vlen_bytes_write_ascii_str(self):
         """ Writing an ascii str to ascii vlen dataset is OK
         """

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1007,17 +1007,6 @@ class TestStrings(BaseDataset):
         self.assertEqual(type(out), bytes)
         self.assertEqual(out, data)
 
-    def test_vlen_bytes_write_object(self):
-        """ Writing an object to ascii vlen dataset is OK
-        """
-        dt = h5py.string_dtype('ascii')
-        ds = self.f.create_dataset('x', (100,), dtype=dt)
-        data = object()
-        ds[0] = data
-        out = ds[0]
-        self.assertEqual(type(out), bytes)
-        self.assertEqual(out, str(data).encode('ascii'))
-
     def test_vlen_bytes_write_none(self):
         """ Writing None to ascii vlen dataset is OK
         """

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -986,14 +986,12 @@ class TestStrings(BaseDataset):
             ds.asstr()[:1], np.array([data], dtype=object)
         )
 
-    @ut.expectedFailure
     def test_unicode_write_error(self):
-        """ Writing a non-utf8 byte string to a unicode vlen dataset raises
-        ValueError """
-        dt = h5py.string_dtype()
+        """Encoding error when writing a non-ASCII string to an ASCII vlen dataset"""
+        dt = h5py.string_dtype('ascii')
         ds = self.f.create_dataset('x', (100,), dtype=dt)
-        data = "Hello\xef"
-        with self.assertRaises(ValueError):
+        data = "fàilte"
+        with self.assertRaises(UnicodeEncodeError):
             ds[0] = data
 
     def test_unicode_write_bytes(self):


### PR DESCRIPTION
This is part of the string changes described in #1338. Specifically, it affects writing to existing variable length string datasets. Changes:

- Writing `None` to these datasets is no longer allowed. Previously it was equivalent to storing an empty string.
- Only str and bytes objects are now accepted. Previously, any Python object would be automatically converted as `str(obj)`, in an uncanny echo of Javascript.
- ASCII vlen string datasets now only accept str made of ASCII characters, rather than using UTF-8 encoding.
  - bytes objects are still stored with no check of the text encoding, if you need to store something in the 'wrong' encoding.