### PR TITLE
BLD: require at least cython 0.29

### DIFF
--- a/docs/build.rst
+++ b/docs/build.rst
@@ -78,6 +78,7 @@ Source installation
 To install h5py from source, you need three things installed:
 
 * A supported Python version with development headers
+* Cython >=0.29
 * HDF5 1.8.4 or newer with development headers
 * A C compiler
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ RUN_REQUIRES = [NUMPY_DEP, "cached-property"]
 # these are required to build h5py
 # RUN_REQUIRES is included as setup.py test needs RUN_REQUIRES for testing
 # RUN_REQUIRES can be removed when setup.py test is removed
-SETUP_REQUIRES = RUN_REQUIRES + [NUMPY_DEP, 'Cython>=0.25', 'pkgconfig']
+SETUP_REQUIRES = RUN_REQUIRES + [NUMPY_DEP, 'Cython>=0.29', 'pkgconfig']
 
 # Needed to avoid trying to install numpy/cython on pythons which the latest
 # versions don't support

--- a/tox.ini
+++ b/tox.ini
@@ -10,14 +10,11 @@ deps =
     test: pytest-cov
     test: pytest-mpi>=0.2
 
-    py36-deps: cython>=0.23
-    py37-deps: cython>=0.29
-
     py36-deps: numpy>=1.12
     py37-deps: numpy>=1.14.3
     py38-deps: numpy>=1.17.4
 
-    py36-mindeps: cython==0.23
+    py36-mindeps: cython==0.29
     py37-mindeps: cython==0.29
     py38-mindeps: cython==0.29.14
 


### PR DESCRIPTION
closes #1538

For reasons that are not clear to me cython 0.25 to 0.29 compile but do not work (but cython 0.23 and 0.24 do at least import).  I think this is fallout from https://github.com/h5py/h5py/pull/1390.    Rather than trying to sort out what changed in Cython, I propose we require at least cython 0.29 for all versions of Python.