### PR TITLE
BLD: use json to pickle to stash build configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ h5py/*.dll
 h5py/*.so
 *.hdf5
 *.pkl
+h5config.json
 h5py/defs.*
 build/
 *.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ h5py/_hdf5.*
 h5py/*.dll
 h5py/*.so
 *.hdf5
-*.pkl
 h5config.json
 h5py/defs.*
 build/


### PR DESCRIPTION
While sorting out #1611 I found we are using a pickle to stash configuration information between steps of the build process.  The information we are stashing is a `Dict[str, str]` so switch to json.