### PR TITLE
Update documentation for strings

### DIFF
--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -496,6 +496,19 @@ Reference
                >>> with dset.astype('int16'):
                ...     out = dset[:]
 
+    .. method:: asstr(encoding=None, errors='strict')
+
+       Only for string datasets. Returns a wrapper to read data as Python
+       string objects::
+
+           >>> s = dataset.asstr()[0]
+
+       encoding and errors work like ``bytes.decode()``, but the default
+       encoding is defined by the datatype - ASCII or UTF-8.
+       This is not guaranteed to be correct.
+
+       .. versionadded:: 3.0
+
     .. method:: fields(names)
 
         Get a wrapper to read a subset of fields from a compound data type::

--- a/docs/special.rst
+++ b/docs/special.rst
@@ -59,10 +59,6 @@ Here's an example showing how to create a VL array of strings::
    :param length: ``None`` for variable-length, or an integer for fixed-length
                   string data, giving the length in bytes.
 
-If ``encoding`` is ``'utf-8'``, the variable length strings should be passed as
-Python ``str`` objects (``unicode`` in Python 2).
-For ``'ascii'``, they should be passed as bytes.
-
 .. function:: check_string_dtype(dt)
 
    Check if ``dt`` is a string dtype.


### PR DESCRIPTION
I've been working on making the string interfaces more consistent for h5py 3.0. This updates the documentation, trying to present the rules concisely.

To do: examples.