### PR TITLE
Add current version and build date to API docs

### DIFF
--- a/docs_api/conf.py
+++ b/docs_api/conf.py
@@ -112,7 +112,7 @@ html_theme = 'nature'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-html_title = "Low-level API for h5py"
+html_title = "Low-level API for h5py (v{})".format(release)
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None
@@ -138,7 +138,7 @@ html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-#html_last_updated_fmt = '%b %d, %Y'
+html_last_updated_fmt = '%b %d, %Y'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.

--- a/docs_api/index.rst
+++ b/docs_api/index.rst
@@ -4,7 +4,7 @@ h5py Low-Level API Reference
 
 
 This documentation contains the auto-generated API information for the
-HDF5 for Python "low-level" interface, a collection of Cython modules
+h5py |release| "low-level" interface, a collection of Cython modules
 which form the interface to the HDF5 C library.  It's hosted separately from
 our main documentation as it requires autodoc.
 


### PR DESCRIPTION
Currently the changes to the API docs are subtle: there may be a function added or modified, but this isn't noticeable when browsing. This adds the version to the title, and the build date to the page (so it's more noticeable that things are changing).
