### PR TITLE
Use plat_specific site-packages dir in CI script

### DIFF
--- a/ci/fix_paths.py
+++ b/ci/fix_paths.py
@@ -10,7 +10,7 @@ def main():
     Copy HDF5 DLLs into installed h5py package
     """
     # This is the function Tox also uses to locate site-packages (Apr 2019)
-    sitepackagesdir = distutils.sysconfig.get_python_lib()
+    sitepackagesdir = distutils.sysconfig.get_python_lib(plat_specific=True)
     print("site packages dir:", sitepackagesdir)
 
     hdf5_path = os.environ.get("HDF5_DIR")


### PR DESCRIPTION
I just noticed that running the tests through tox failed on my laptop (I normally install into an environment manually to test). This script was looking in a `lib/` folder, while h5py was installed under `lib64/`. This is with Fedora. I think this fix should work everywhere - in most cases the 'purelib' and 'platlib' directories are the same.