### PR TITLE
Relative path to virtual datasets

### DIFF
--- a/docs/vds.rst
+++ b/docs/vds.rst
@@ -113,7 +113,7 @@ Reference
    When `creating a virtual dataset <creating_vds_>`_, paths to sources present
    in the same file are changed to a ".", refering to the current file (see
    `set virtual <https://portal.hdfgroup.org/display/HDF5/H5P_SET_VIRTUAL>`_).
-   This will keep such sources valid is the file is renamed.
+   This will keep such sources valid in case the file is renamed.
 
    :param path_or_dataset:
        The path to a file, or a :class:`Dataset` object. If a dataset is given,

--- a/docs/vds.rst
+++ b/docs/vds.rst
@@ -112,7 +112,7 @@ Reference
 
    When `creating a virtual dataset <creating_vds_>`_, paths to sources present
    in the same file are changed to a ".", refering to the current file (see
-   `set virtual <https://portal.hdfgroup.org/display/HDF5/H5P_SET_VIRTUAL>`_).
+   `H5Pset_virtual <https://portal.hdfgroup.org/display/HDF5/H5P_SET_VIRTUAL>`_).
    This will keep such sources valid in case the file is renamed.
 
    :param path_or_dataset:

--- a/docs/vds.rst
+++ b/docs/vds.rst
@@ -31,6 +31,7 @@ HDF5 dataset.
 The HDF Group has documented the VDS features in detail on the website:
 `Virtual Datasets (VDS) Documentation <https://support.hdfgroup.org/HDF5/docNewFeatures/NewFeaturesVirtualDatasetDocs.html>`_.
 
+.. _creating_vds:
 
 Creating virtual datasets in h5py
 ---------------------------------
@@ -108,6 +109,11 @@ Reference
 
    Instantiate this class to represent an entire source dataset, and then
    slice it to indicate which regions should be used in the virtual dataset.
+
+   When `creating a virtual dataset <creating_vds_>`_, paths to sources present
+   in the same file are changed to a ".", refering to the current file (see
+   `set virtual <https://portal.hdfgroup.org/display/HDF5/H5P_SET_VIRTUAL>`_).
+   This will keep such sources valid is the file is renamed.
 
    :param path_or_dataset:
        The path to a file, or a :class:`Dataset` object. If a dataset is given,

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -168,10 +168,15 @@ class Group(HLObject, MutableMappingHDF5):
             """
             from .vds import VDSmap
             # Encode filenames and dataset names appropriately.
-            sources = [VDSmap(vspace, filename_encode(file_name),
-                              self._e(dset_name), src_space)
-                       for (vspace, file_name, dset_name, src_space)
-                       in layout.sources]
+            sources = []
+            for vspace, file_name, dset_name, src_space in layout.sources:
+                if file_name == self.file.filename:
+                    # use relative path if the source dataset is in the same
+                    # file, in order to keed the virtual dataset valid in case
+                    # the file is renamed.
+                    file_name = '.'
+                sources.append(VDSmap(vspace, filename_encode(file_name),
+                                      self._e(dset_name), src_space))
 
             with phil:
                 group = self

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -172,7 +172,7 @@ class Group(HLObject, MutableMappingHDF5):
             for vspace, file_name, dset_name, src_space in layout.sources:
                 if file_name == self.file.filename:
                     # use relative path if the source dataset is in the same
-                    # file, in order to keed the virtual dataset valid in case
+                    # file, in order to keep the virtual dataset valid in case
                     # the file is renamed.
                     file_name = '.'
                 sources.append(VDSmap(vspace, filename_encode(file_name),

--- a/news/relative_virtual_source.rst
+++ b/news/relative_virtual_source.rst
@@ -1,0 +1,29 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* Use relative path for virtual data sources if the source dataset is in the same file.
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
Before opening a pull request, please:

- [x] Run simple static checks with `tox -e pre-commit`
- [x] Run the tests with e.g. `tox -e py37-test-deps`
- [x] Add a release note in the news/ folder (copy TEMPLATE.rst)

---
Hi!

this should hopefully fix #1546 

when creating a virtual dataset, check if each source filename matches the file it's being created in, and if so, use '.' as the filename.