### PR TITLE
Fix cross-reference of constants in API docs

### DIFF
--- a/h5py/_objects.pyx
+++ b/h5py/_objects.pyx
@@ -54,7 +54,7 @@ def with_phil(func):
         with _phil:
             return func(*args, **kwds)
 
-    functools.update_wrapper(wrapper, func, ('__name__', '__doc__'))
+    functools.update_wrapper(wrapper, func)
     return wrapper
 
 # --- End locking code --------------------------------------------------------

--- a/h5py/h5f.pyx
+++ b/h5py/h5f.pyx
@@ -215,7 +215,7 @@ def get_obj_count(object where=OBJ_ALL, int types=H5F_OBJ_ALL):
         special constant OBJ_ALL, to count objects in all files.
 
     type
-        Specify what kinds of object to include.  May be one of ``OBJ*``,
+        Specify what kinds of object to include.  May be one of OBJ*,
         or any bitwise combination (e.g. ``OBJ_FILE | OBJ_ATTR``).
 
         The special value OBJ_ALL matches all object types, and
@@ -244,7 +244,7 @@ def get_obj_ids(object where=OBJ_ALL, int types=H5F_OBJ_ALL):
         special constant OBJ_ALL, to list objects in all files.
 
     type
-        Specify what kinds of object to include.  May be one of ``OBJ*``,
+        Specify what kinds of object to include.  May be one of OBJ*,
         or any bitwise combination (e.g. ``OBJ_FILE | OBJ_ATTR``).
 
         The special value OBJ_ALL matches all object types, and


### PR DESCRIPTION
I noticed cross-referencing wasn't fully working in the API docs, because functions wrapped in `@with_phil` appeared to be part of `h5py._objects`, rather than the module they should be associated with. This fixes it.

There's even a special extension which recognises `OBJ*` references and links to the constant group. :-)