### PR TITLE
Update Windows CI to newer HDF5

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,19 +23,39 @@ environment:
       TOXENV: "py36-test-deps"
       HDF5_VSVERSION: "14"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
-      HDF5_VERSION: "1.10.1"
+      HDF5_VERSION: "1.10.6"
 
     - PYTHON: "C:\\Python37"
       TOXENV: "py37-test-deps"
       HDF5_VSVERSION: "14"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
-      HDF5_VERSION: "1.10.1"
+      HDF5_VERSION: "1.10.6"
 
     - PYTHON: "C:\\Python38"
       TOXENV: "py38-test-deps"
       HDF5_VSVERSION: "14"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
-      HDF5_VERSION: "1.10.1"
+      HDF5_VERSION: "1.10.6"
+
+    ### USING HDF5 1.12 ###
+
+    - PYTHON: "C:\\Python36"
+      TOXENV: "py36-test-deps"
+      HDF5_VSVERSION: "14"
+      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
+      HDF5_VERSION: "1.12.0"
+
+    - PYTHON: "C:\\Python37"
+      TOXENV: "py37-test-deps"
+      HDF5_VSVERSION: "14"
+      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
+      HDF5_VERSION: "1.12.0"
+
+    - PYTHON: "C:\\Python38"
+      TOXENV: "py38-test-deps"
+      HDF5_VSVERSION: "14"
+      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
+      HDF5_VERSION: "1.12.0"
 
 install:
   # We need wheel installed to build wheels

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -118,21 +118,43 @@ jobs:
       py36-hdf5110:
         python.version: '3.6'
         TOXENV: py36-test-deps,py36-test-mindeps,py36-test-deps-pre
-        HDF5_VERSION: 1.10.1
+        HDF5_VERSION: 1.10.6
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         HDF5_VSVERSION: "15-64"
         H5PY_ENFORCE_COVERAGE: yes
       py37-hdf5110:
         python.version: '3.7'
         TOXENV: py37-test-deps,py37-test-mindeps,py37-test-deps-pre
-        HDF5_VERSION: 1.10.1
+        HDF5_VERSION: 1.10.6
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         HDF5_VSVERSION: "15-64"
         H5PY_ENFORCE_COVERAGE: yes
       py38-hdf5110:
         python.version: '3.8'
         TOXENV: py38-test-deps,py38-test-mindeps,py38-test-deps-pre
-        HDF5_VERSION: 1.10.1
+        HDF5_VERSION: 1.10.6
+        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
+        HDF5_VSVERSION: "15-64"
+        H5PY_ENFORCE_COVERAGE: yes
+    # 64 bit - HDF5 1.10
+      py36-hdf5112:
+        python.version: '3.6'
+        TOXENV: py36-test-deps,py36-test-mindeps,py36-test-deps-pre
+        HDF5_VERSION: 1.12.0
+        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
+        HDF5_VSVERSION: "15-64"
+        H5PY_ENFORCE_COVERAGE: yes
+      py37-hdf5112:
+        python.version: '3.7'
+        TOXENV: py37-test-deps,py37-test-mindeps,py37-test-deps-pre
+        HDF5_VERSION: 1.12.0
+        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
+        HDF5_VSVERSION: "15-64"
+        H5PY_ENFORCE_COVERAGE: yes
+      py38-hdf5112:
+        python.version: '3.8'
+        TOXENV: py38-test-deps,py38-test-mindeps,py38-test-deps-pre
+        HDF5_VERSION: 1.12.0
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         HDF5_VSVERSION: "15-64"
         H5PY_ENFORCE_COVERAGE: yes

--- a/ci/appveyor/get_hdf5.py
+++ b/ci/appveyor/get_hdf5.py
@@ -17,11 +17,7 @@ from subprocess import run, PIPE, STDOUT
 from zipfile import ZipFile
 import requests
 
-HDF5_18_URL = "https://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-{version}/src/"
-HDF5_110_URL = "https://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-{version}/src/"
-HDF5_18_FILE = HDF5_18_URL + "hdf5-{version}.zip"
-HDF5_110_FILE = HDF5_110_URL + "hdf5-{version}.zip"
-
+HDF5_URL = "https://www.hdfgroup.org/ftp/HDF5/releases/hdf5-{series}/hdf5-{version}/src/hdf5-{version}.zip"
 
 CMAKE_CONFIGURE_CMD = [
     "cmake", "-DBUILD_SHARED_LIBS:BOOL=ON", "-DCMAKE_BUILD_TYPE:STRING=RELEASE",
@@ -49,10 +45,8 @@ VSVERSION_TO_GENERATOR = {
 
 
 def download_hdf5(version, outfile):
-    if version.split(".")[:2] == ["1", "10"]:
-        file = HDF5_110_FILE.format(version=version)
-    else:
-        file = HDF5_18_FILE.format(version=version)
+    series = '.'.join(version.split(".")[:2])
+    file = HDF5_URL.format(version=version, series=series)
 
     print("Downloading " + file, file=stderr)
     r = requests.get(file, stream=True)

--- a/h5py/_hl/compat.py
+++ b/h5py/_hl/compat.py
@@ -3,8 +3,9 @@ Compatibility module for high-level h5py
 """
 import sys
 from os import fspath, fsencode, fsdecode
+from ..version import hdf5_built_version_tuple
 
-WINDOWS_ENCODING = "mbcs"
+WINDOWS_ENCODING = "utf-8" if hdf5_built_version_tuple >= (1, 10, 6) else "mbcs"
 
 
 def filename_encode(filename):

--- a/h5py/tests/test_h5d_direct_chunk.py
+++ b/h5py/tests/test_h5d_direct_chunk.py
@@ -10,55 +10,55 @@ class TestWriteDirectChunk(TestCase):
     def test_write_direct_chunk(self):
 
         filename = self.mktemp().encode()
-        filehandle = h5py.File(filename, "w")
+        with h5py.File(filename, "w") as filehandle:
 
-        dataset = filehandle.create_dataset("data", (100, 100, 100),
-                                            maxshape=(None, 100, 100),
-                                            chunks=(1, 100, 100),
-                                            dtype='float32')
+            dataset = filehandle.create_dataset("data", (100, 100, 100),
+                                                maxshape=(None, 100, 100),
+                                                chunks=(1, 100, 100),
+                                                dtype='float32')
 
-        # writing
-        array = numpy.zeros((10, 100, 100))
-        for index in range(10):
-            a = numpy.random.rand(100, 100).astype('float32')
-            dataset.id.write_direct_chunk((index, 0, 0), a.tostring(), filter_mask=1)
-            array[index] = a
+            # writing
+            array = numpy.zeros((10, 100, 100))
+            for index in range(10):
+                a = numpy.random.rand(100, 100).astype('float32')
+                dataset.id.write_direct_chunk((index, 0, 0), a.tostring(), filter_mask=1)
+                array[index] = a
 
-        filehandle.close()
 
         # checking
-        filehandle = h5py.File(filename, "r")
-        for i in range(10):
-            read_data = filehandle["data"][i]
-            numpy.testing.assert_array_equal(array[i], read_data)
+        with h5py.File(filename, "r") as filehandle:
+            for i in range(10):
+                read_data = filehandle["data"][i]
+                numpy.testing.assert_array_equal(array[i], read_data)
 
 
 @ut.skipUnless(h5py.version.hdf5_version_tuple >= (1, 10, 2), 'Direct Chunk Reading requires HDF5 >= 1.10.2')
+@ut.skipIf('gzip' not in h5py.filters.encode, "DEFLATE is not installed")
 class TestReadDirectChunk(TestCase):
     def test_read_compressed_offsets(self):
 
         filename = self.mktemp().encode()
-        filehandle = h5py.File(filename, "w")
+        with h5py.File(filename, "w") as filehandle:
 
-        frame = numpy.arange(16).reshape(4, 4)
-        frame_dataset = filehandle.create_dataset("frame",
-                                                  data=frame,
-                                                  compression="gzip",
-                                                  compression_opts=9)
-        dataset = filehandle.create_dataset("compressed_chunked",
-                                            data=[frame, frame, frame],
-                                            compression="gzip",
-                                            compression_opts=9,
-                                            chunks=(1, ) + frame.shape)
-        filter_mask, compressed_frame = frame_dataset.id.read_direct_chunk((0, 0))
-        # No filter must be disabled
-        self.assertEqual(filter_mask, 0)
-
-        for i in range(dataset.shape[0]):
-            filter_mask, data = dataset.id.read_direct_chunk((i, 0, 0))
-            self.assertEqual(compressed_frame, data)
+            frame = numpy.arange(16).reshape(4, 4)
+            frame_dataset = filehandle.create_dataset("frame",
+                                                      data=frame,
+                                                      compression="gzip",
+                                                      compression_opts=9)
+            dataset = filehandle.create_dataset("compressed_chunked",
+                                                data=[frame, frame, frame],
+                                                compression="gzip",
+                                                compression_opts=9,
+                                                chunks=(1, ) + frame.shape)
+            filter_mask, compressed_frame = frame_dataset.id.read_direct_chunk((0, 0))
             # No filter must be disabled
             self.assertEqual(filter_mask, 0)
+
+            for i in range(dataset.shape[0]):
+                filter_mask, data = dataset.id.read_direct_chunk((i, 0, 0))
+                self.assertEqual(compressed_frame, data)
+                # No filter must be disabled
+                self.assertEqual(filter_mask, 0)
 
     def test_read_uncompressed_offsets(self):
 
@@ -88,29 +88,28 @@ class TestReadDirectChunk(TestCase):
     def test_read_write_chunk(self):
 
         filename = self.mktemp().encode()
-        filehandle = h5py.File(filename, "w")
+        with h5py.File(filename, "w") as filehandle:
 
-        # create a reference
-        frame = numpy.arange(16).reshape(4, 4)
-        frame_dataset = filehandle.create_dataset("source",
-                                                  data=frame,
-                                                  compression="gzip",
-                                                  compression_opts=9)
-        # configure an empty dataset
-        filter_mask, compressed_frame = frame_dataset.id.read_direct_chunk((0, 0))
-        dataset = filehandle.create_dataset("created",
-                                            shape=frame_dataset.shape,
-                                            maxshape=frame_dataset.shape,
-                                            chunks=frame_dataset.chunks,
-                                            dtype=frame_dataset.dtype,
-                                            compression="gzip",
-                                            compression_opts=9)
+            # create a reference
+            frame = numpy.arange(16).reshape(4, 4)
+            frame_dataset = filehandle.create_dataset("source",
+                                                      data=frame,
+                                                      compression="gzip",
+                                                      compression_opts=9)
+            # configure an empty dataset
+            filter_mask, compressed_frame = frame_dataset.id.read_direct_chunk((0, 0))
+            dataset = filehandle.create_dataset("created",
+                                                shape=frame_dataset.shape,
+                                                maxshape=frame_dataset.shape,
+                                                chunks=frame_dataset.chunks,
+                                                dtype=frame_dataset.dtype,
+                                                compression="gzip",
+                                                compression_opts=9)
 
-        # copy the data
-        dataset.id.write_direct_chunk((0, 0), compressed_frame, filter_mask=filter_mask)
-        filehandle.close()
+            # copy the data
+            dataset.id.write_direct_chunk((0, 0), compressed_frame, filter_mask=filter_mask)
 
         # checking
-        filehandle = h5py.File(filename, "r")
-        dataset = filehandle["created"][...]
-        numpy.testing.assert_array_equal(dataset, frame)
+        with h5py.File(filename, "r") as filehandle:
+            dataset = filehandle["created"][...]
+            numpy.testing.assert_array_equal(dataset, frame)

--- a/news/utf8-windows.rst
+++ b/news/utf8-windows.rst
@@ -1,0 +1,30 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* As HDF5 1.10.6 and later support UTF-8 paths on Windows, h5py built against
+  HDF5 1.10.6 will use UTF-8 for file names.
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
Heads up, this will take a while to run, looks like 15-20 minutes per environment, I suspect this may lock up appveyor for a while (once the cache is filled, things will be much faster).

Appears to close #839 (as 1.10.6 uses UTF-8 now).