### PR TITLE
Add missing objects to H5P API docs

### DIFF
--- a/docs_api/h5d.rst
+++ b/docs_api/h5d.rst
@@ -2,7 +2,18 @@ Module H5D
 ==========
 
 .. automodule:: h5py.h5d
-    :members:
+
+Functional API
+--------------
+
+.. autofunction:: open
+.. autofunction:: create
+
+Dataset Objects
+---------------
+
+.. autoclass:: DatasetID
+   :members:
 
 Module constants
 ----------------

--- a/docs_api/h5p.rst
+++ b/docs_api/h5p.rst
@@ -94,7 +94,7 @@ Group creation
     :members:
 
 Datatype creation
-----------------
+-----------------
 
 .. autoclass:: PropTCID
     :show-inheritance:

--- a/docs_api/h5p.rst
+++ b/docs_api/h5p.rst
@@ -27,6 +27,10 @@ Base classes
     :show-inheritance:
     :members:
 
+.. autoclass:: PropOCID
+    :show-inheritance:
+    :members:
+
 .. autoclass:: PropCopyID
     :show-inheritance:
     :members:
@@ -52,6 +56,19 @@ Dataset creation
     :show-inheritance:
     :members:
 
+Dataset access
+--------------
+
+.. autoclass:: PropDAID
+    :show-inheritance:
+    :members:
+
+Dataset transfer
+----------------
+
+.. autoclass:: PropDXID
+    :show-inheritance:
+    :members:
 
 Link creation
 -------------
@@ -76,6 +93,12 @@ Group creation
     :show-inheritance:
     :members:
 
+Datatype creation
+----------------
+
+.. autoclass:: PropTCID
+    :show-inheritance:
+    :members:
 
 Module constants
 ----------------
@@ -88,7 +111,15 @@ Predefined classes
 .. data:: FILE_ACCESS
 .. data:: DATASET_CREATE
 .. data:: DATASET_XFER
+.. data:: DATASET_ACCESS
 .. data:: OBJECT_COPY
 .. data:: LINK_CREATE
 .. data:: LINK_ACCESS
 .. data:: GROUP_CREATE
+.. data:: OBJECT_CREATE
+
+Order tracking flags
+~~~~~~~~~~~~~~~~~~~~
+
+.. data:: CRT_ORDER_TRACKED
+.. data:: CRT_ORDER_INDEXED

--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -1449,7 +1449,10 @@ cdef class PropLAID(PropInstanceID):
 
 # Datatype creation
 cdef class PropTCID(PropOCID):
-    """ Datatype creation property list """
+    """ Datatype creation property list
+
+    No methods yet.
+    """
 
     pass
 


### PR DESCRIPTION
Also rearrange the H5D page to match other similar page (H5F, H5G), with a 'Functional API' section at the top.