### PR TITLE
FIX: init `self.mpi` as None in `setup_configure.py`

### DIFF
--- a/setup_configure.py
+++ b/setup_configure.py
@@ -59,7 +59,7 @@ def get_env_options():
         'hdf5_libdir': os.environ.get('HDF5_LIBDIR'),
         'hdf5_pkgconfig_name': os.environ.get('HDF5_PKGCONFIG_NAME'),
         'hdf5_version': os.environ.get('HDF5_VERSION'),
-        'mpi': os.environ.get('HDF5_MPI'),
+        'mpi': True if os.environ.get('HDF5_MPI') == "ON" else None,
     }
 
 

--- a/setup_configure.py
+++ b/setup_configure.py
@@ -59,7 +59,7 @@ def get_env_options():
         'hdf5_libdir': os.environ.get('HDF5_LIBDIR'),
         'hdf5_pkgconfig_name': os.environ.get('HDF5_PKGCONFIG_NAME'),
         'hdf5_version': os.environ.get('HDF5_VERSION'),
-        'mpi': os.environ.get('HDF5_MPI') == "ON",
+        'mpi': os.environ.get('HDF5_MPI'),
     }
 
 


### PR DESCRIPTION
<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- Add a release note in the news/ folder (copy TEMPLATE.rst)

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->

This fixes building `h5py` when invoked with `--mpi` (without set env var).

XRef: https://github.com/conda-forge/h5py-feedstock/pull/79 (break) and https://github.com/conda-forge/h5py-feedstock/pull/80 (fix)