### PR TITLE
Update ndarray comparison in tests

### DIFF
--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -720,7 +720,7 @@ class TestExternal(BaseDataset):
         # verify file's existence, size, and contents
         with open(ext_file, 'rb') as fid:
             contents = fid.read()
-        assert contents == testdata.tostring()
+        assert contents == testdata.tobytes()
 
     def test_name_str(self):
         """ External argument may be a file name str only """

--- a/h5py/tests/test_h5d_direct_chunk.py
+++ b/h5py/tests/test_h5d_direct_chunk.py
@@ -21,7 +21,7 @@ class TestWriteDirectChunk(TestCase):
             array = numpy.zeros((10, 100, 100))
             for index in range(10):
                 a = numpy.random.rand(100, 100).astype('float32')
-                dataset.id.write_direct_chunk((index, 0, 0), a.tostring(), filter_mask=1)
+                dataset.id.write_direct_chunk((index, 0, 0), a.tobytes(), filter_mask=1)
                 array[index] = a
 
 


### PR DESCRIPTION
This a simple PR aiming to silence the `DeprecationWarning`s documented in #1654 , in which numpy arrays were being compared using their `tostring` method.

Thanks :)