### PR TITLE
Require a dtype in VirtualLayout

### DIFF
--- a/docs/vds.rst
+++ b/docs/vds.rst
@@ -86,7 +86,7 @@ found in the examples folder:
 Reference
 ---------
 
-.. class:: VirtualLayout(shape, dtype=None, maxshape=None)
+.. class:: VirtualLayout(shape, dtype, maxshape=None)
 
    Object for building a virtual dataset.
 

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -139,7 +139,7 @@ def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
     return dset_id
 
 
-def make_new_virtual_dset(parent, shape, sources, dtype=None, name=None,
+def make_new_virtual_dset(parent, shape, sources, dtype, name=None,
                           maxshape=None, fillvalue=None):
     """ Return a new low-level dataset identifier for a virtual dataset """
 
@@ -160,10 +160,7 @@ def make_new_virtual_dset(parent, shape, sources, dtype=None, name=None,
         # Named types are used as-is
         tid = dtype.id
     else:
-        if dtype is None:
-            dtype = numpy.dtype("=f4")
-        else:
-            dtype = numpy.dtype(dtype)
+        dtype = numpy.dtype(dtype)
         tid = h5t.py_create(dtype, logical=1)
 
     return h5d.create(parent.id, name=name, tid=tid, space=virt_dspace,

--- a/h5py/_hl/vds.py
+++ b/h5py/_hl/vds.py
@@ -122,7 +122,7 @@ class VirtualLayout(object):
         The virtual dataset is resizable up to this shape. Use None for
         axes you want to be unlimited.
     """
-    def __init__(self, shape, dtype=None, maxshape=None):
+    def __init__(self, shape, dtype, maxshape=None):
         self.shape = (shape,) if isinstance(shape, int) else shape
         self.dtype = dtype
         self.maxshape = (maxshape,) if isinstance(maxshape, int) else maxshape

--- a/h5py/tests/test_vds/test_lowlevel_vds.py
+++ b/h5py/tests/test_vds/test_lowlevel_vds.py
@@ -285,7 +285,7 @@ def test_virtual_prefix(tmp_path):
     src_file['data'] = np.arange(10)
 
     vds_file = h5.File(tmp_path / 'b' / 'vds.h5', 'w')
-    layout = h5.VirtualLayout(shape=(10,))
+    layout = h5.VirtualLayout(shape=(10,), dtype=np.int64)
     layout[:] = h5.VirtualSource('src.h5', 'data', shape=(10,))
     vds_file.create_virtual_dataset('data', layout, fillvalue=-1)
 

--- a/news/virtuallayout-no-default-dtype.rst
+++ b/news/virtuallayout-no-default-dtype.rst
@@ -1,0 +1,31 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* When making a virtual dataset, a dtype must be specified in
+  :class:`VirtuaLayout`. There is no longer a default dtype, as this was
+  surprising in some cases.
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
The previous default would convert integer data to floats, which is surprising. I think most people would expect that if you don't specify a dtype, it reflects the dtype of the source data. But that's trickier than it sounds - there might not be any source data, or you might be describing source data that's not available yet. So let's keep it simple, and just require the caller to pass a dtype.

This is an API break, but aimed for a major release. If people were happy with the previous behaviour, all they need to do is pass `VirtualLayout(..., dtype='=f4')` to preserve it.

Closes #1474