### PR TITLE
Import mpi4py.MPI instead of mpi4py when using 'mpio' driver mode

### DIFF
--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -45,7 +45,7 @@ def _set_fapl_mpio(plist, **kwargs):
     if not mpi:
         raise ValueError("h5py was built without MPI support, can't use mpio driver")
 
-    import mpi4py
+    import mpi4py.MPI
     kwargs.setdefault('info', mpi4py.MPI.Info())
     plist.set_fapl_mpio(**kwargs)
 


### PR DESCRIPTION
Close https://github.com/h5py/h5py/issues/1489
