### PR TITLE
Add missing module h5ds in low-level API reference

### DIFF
--- a/docs_api/h5ds.rst
+++ b/docs_api/h5ds.rst
@@ -3,18 +3,4 @@ Module H5DS
 
 .. automodule:: h5py.h5ds
     :members:
-
-
-Functional API
---------------
-
-.. autofunction:: set_scale
-.. autofunction:: is_scale
-.. autofunction:: attach_scale
-.. autofunction:: is_attached
-.. autofunction:: detach_scale
-.. autofunction:: get_num_scales
-.. autofunction:: set_label
-.. autofunction:: get_label
-.. autofunction:: get_scale_name
-.. autofunction:: iterate
+    :undoc-members:

--- a/docs_api/h5ds.rst
+++ b/docs_api/h5ds.rst
@@ -1,0 +1,20 @@
+Module H5DS
+===========
+
+.. automodule:: h5py.h5ds
+    :members:
+
+
+Functional API
+--------------
+
+.. autofunction:: set_scale
+.. autofunction:: is_scale
+.. autofunction:: attach_scale
+.. autofunction:: is_attached
+.. autofunction:: detach_scale
+.. autofunction:: get_num_scales
+.. autofunction:: set_label
+.. autofunction:: get_label
+.. autofunction:: get_scale_name
+.. autofunction:: iterate

--- a/docs_api/h5fd.rst
+++ b/docs_api/h5fd.rst
@@ -6,8 +6,8 @@ Module H5FD
 Module constants
 ----------------
 
-Multi-file drivers
-~~~~~~~~~~~~~~~~~~
+Memory usage types for MULTI file driver
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. data:: MEM_DEFAULT
 .. data:: MEM_SUPER
@@ -19,8 +19,8 @@ Multi-file drivers
 .. data:: MEM_NTYPES
 
 
-MPI drivers
-~~~~~~~~~~~
+Data transfer modes for MPIO driver
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. data:: MPIO_INDEPENDENT
 .. data:: MPIO_COLLECTIVE

--- a/docs_api/h5fd.rst
+++ b/docs_api/h5fd.rst
@@ -6,6 +6,9 @@ Module H5FD
 Module constants
 ----------------
 
+Multi-file drivers
+~~~~~~~~~~~~~~~~~~
+
 .. data:: MEM_DEFAULT
 .. data:: MEM_SUPER
 .. data:: MEM_BTREE
@@ -15,8 +18,15 @@ Module constants
 .. data:: MEM_OHDR
 .. data:: MEM_NTYPES
 
-File drivers
-~~~~~~~~~~~~
+
+MPI drivers
+~~~~~~~~~~~
+
+.. data:: MPIO_INDEPENDENT
+.. data:: MPIO_COLLECTIVE
+
+File drivers types
+~~~~~~~~~~~~~~~~~~
 
 .. data:: CORE
 .. data:: FAMILY

--- a/docs_api/index.rst
+++ b/docs_api/index.rst
@@ -24,6 +24,7 @@ Contents
     h5a
     h5ac
     h5d
+    h5ds
     h5f
     h5fd
     h5g


### PR DESCRIPTION
Fix https://github.com/h5py/h5py/issues/1667