### PR TITLE
Replace a couple more arr.tostring with tobytes

### DIFF
--- a/docs/strings.rst
+++ b/docs/strings.rst
@@ -64,7 +64,7 @@ recover it::
     >>> binary_blob = b"Hello\x00Hello\x00"
     >>> dset.attrs["attribute_name"] = np.void(binary_blob)
     >>> out = dset.attrs["attribute_name"]
-    >>> binary_blob = out.tostring()
+    >>> binary_blob = out.tobytes()
 
 Object names
 ------------

--- a/h5py/tests/test_h5d_direct_chunk.py
+++ b/h5py/tests/test_h5d_direct_chunk.py
@@ -72,7 +72,7 @@ class TestReadDirectChunk(TestCase):
                                                 compression_opts=9)
             # Write uncompressed data
             DISABLE_ALL_FILTERS = 0xFFFFFFFF
-            dataset.id.write_direct_chunk((0, 0, 0), frame.tostring(), filter_mask=DISABLE_ALL_FILTERS)
+            dataset.id.write_direct_chunk((0, 0, 0), frame.tobytes(), filter_mask=DISABLE_ALL_FILTERS)
 
         # FIXME: Here we have to close the file and load it back else
         #     a runtime error occurs:
@@ -83,7 +83,7 @@ class TestReadDirectChunk(TestCase):
 
         # At least 1 filter is supposed to be disabled
         self.assertNotEqual(filter_mask, 0)
-        self.assertEqual(compressed_frame, frame.tostring())
+        self.assertEqual(compressed_frame, frame.tobytes())
 
     def test_read_write_chunk(self):
 


### PR DESCRIPTION
These must have been overlooked before. I noticed the deprecation warnings while running the tests.