### PR TITLE
Fix copy() method's bug when source is Dataset, dest is Group

### DIFF
--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -499,7 +499,10 @@ class Group(HLObject, MutableMappingHDF5):
                     dest_path = name
                 else:
                     # copy source into dest group: dest_name/source_name
-                    dest_path = pp.basename(h5i.get_name(source[source_path].id))
+                    if isinstance(source, dataset.Dataset):
+                        dest_path = pp.basename(h5i.get_name(dest.id))
+                    else:
+                        dest_path = pp.basename(h5i.get_name(source[source_path].id))
 
             elif isinstance(dest, HLObject):
                 raise TypeError("Destination must be path or Group object")

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -497,12 +497,11 @@ class Group(HLObject, MutableMappingHDF5):
             if isinstance(dest, Group):
                 if name is not None:
                     dest_path = name
+                elif source_path == '.':
+                    dest_path = pp.basename(h5i.get_name(source.id))
                 else:
                     # copy source into dest group: dest_name/source_name
-                    if isinstance(source, dataset.Dataset):
-                        dest_path = pp.basename(h5i.get_name(dest.id))
-                    else:
-                        dest_path = pp.basename(h5i.get_name(source[source_path].id))
+                    dest_path = pp.basename(h5i.get_name(source[source_path].id))
 
             elif isinstance(dest, HLObject):
                 raise TypeError("Destination must be path or Group object")

--- a/h5py/tests/test_group.py
+++ b/h5py/tests/test_group.py
@@ -886,7 +886,7 @@ class TestCopy(TestCase):
         self.assertArrayEqual(self.f1['baz'], np.array([1,2,3]))
 
         self.f1.copy(foo, grp)
-        self.assertArrayEqual(self.f1['/grp/grp'], np.array([1,2,3]))
+        self.assertArrayEqual(self.f1['/grp/foo'], np.array([1,2,3]))
 
         self.f1.copy('foo', self.f2)
         self.assertArrayEqual(self.f2['foo'], np.array([1,2,3]))

--- a/h5py/tests/test_group.py
+++ b/h5py/tests/test_group.py
@@ -877,12 +877,16 @@ class TestCopy(TestCase):
     def test_copy_dataset(self):
         self.f1['foo'] = [1,2,3]
         foo = self.f1['foo']
+        grp = self.f1.create_group("grp")
 
         self.f1.copy(foo, 'bar')
         self.assertArrayEqual(self.f1['bar'], np.array([1,2,3]))
 
         self.f1.copy('foo', 'baz')
         self.assertArrayEqual(self.f1['baz'], np.array([1,2,3]))
+
+        self.f1.copy(foo, grp)
+        self.assertArrayEqual(self.f1['/grp/grp'], np.array([1,2,3]))
 
         self.f1.copy('foo', self.f2)
         self.assertArrayEqual(self.f2['foo'], np.array([1,2,3]))

--- a/news/copy_an_object.rst
+++ b/news/copy_an_object.rst
@@ -1,0 +1,29 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* Fix bug when copy source is HLObject and dest is Group (:issue:`1005`).
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
This PR try to fix https://github.com/h5py/h5py/issues/1005. 
In copy(self, source, dest, ...) method, when source is Dataset, dest is Group, the `'.'` will be passed as a slice to the dataset, so there is a crash at `dest_path = pp.basename(h5i.get_name(source[source_path].id))`. 
