### PR TITLE
Raise IndexError when index elemetns aren't in increasing order

### DIFF
--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -497,6 +497,8 @@ class Group(HLObject, MutableMappingHDF5):
             if isinstance(dest, Group):
                 if name is not None:
                     dest_path = name
+                elif source_path == '.':
+                    dest_path = pp.basename(h5i.get_name(source.id))
                 else:
                     # copy source into dest group: dest_name/source_name
                     dest_path = pp.basename(h5i.get_name(source[source_path].id))

--- a/h5py/tests/test_dataset_getitem.py
+++ b/h5py/tests/test_dataset_getitem.py
@@ -470,6 +470,11 @@ class Test1DFloat(TestCase):
         with self.assertRaises(TypeError):
             self.dset[[1,3,2]]
 
+    def test_indexlist_bidirectional(self):
+        """ we require index list values to be strictly increasing """
+        with self.assertRaises(IndexError):
+            self.dset[[-2,0,2]]
+
     def test_indexlist_monotonic_negative(self):
         # This should work: indices are logically increasing
         self.assertNumpyBehavior(self.dset, self.data,  np.s_[[0, 2, -2]])

--- a/h5py/tests/test_group.py
+++ b/h5py/tests/test_group.py
@@ -877,12 +877,16 @@ class TestCopy(TestCase):
     def test_copy_dataset(self):
         self.f1['foo'] = [1,2,3]
         foo = self.f1['foo']
+        grp = self.f1.create_group("grp")
 
         self.f1.copy(foo, 'bar')
         self.assertArrayEqual(self.f1['bar'], np.array([1,2,3]))
 
         self.f1.copy('foo', 'baz')
         self.assertArrayEqual(self.f1['baz'], np.array([1,2,3]))
+
+        self.f1.copy(foo, grp)
+        self.assertArrayEqual(self.f1['/grp/foo'], np.array([1,2,3]))
 
         self.f1.copy('foo', self.f2)
         self.assertArrayEqual(self.f2['foo'], np.array([1,2,3]))

--- a/news/copy_an_object.rst
+++ b/news/copy_an_object.rst
@@ -1,0 +1,29 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* Fix bug when copy source is HLObject and dest is Group (:issue:`1005`).
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
### major change:
+ raise IndexError when index elemetns aren't in increasing order
+ add test for bidirectional indices