### PR TITLE
Check the asv benchmarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,13 @@ matrix:
         - pip install doctr
         - doctr deploy . --built-docs docs_api/_build/html
 
+    # Checks the asv benchmarks
+    - python: 3.8
+      env:
+        - TOXENV=asv
+        - HDF5_VERSION=1.10.5
+        - HDF5_DIR=$HDF5_CACHE_DIR/$HDF5_VERSION
+
     # MPI tests
     # TODO: We should test with newer versions of HDF5
     - python: 3.6

--- a/tox.ini
+++ b/tox.ini
@@ -99,3 +99,11 @@ deps=
     ruamel.yaml
 commands=
     rever check --activities authors,version_bump,changelog
+
+[testenv:asv]
+skip_install = True
+deps =
+    asv
+    virtualenv
+commands =
+    asv check


### PR DESCRIPTION
This adds `asv check` to (quoting command) "Import and check benchmark suite, but do not run benchmarks." I think this should mean we're checking for syntax errors and such, but not actually running the benchmarks (which might be a bit slow...). I've put this on travis just in case it does take some time, but there's nothing special about the python or HDF5 version used.
