### PR TITLE
Test that gzip & lzf filters are available in wheels

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -140,6 +140,8 @@ jobs:
   dependsOn: linux_wheels
   pool:
     vmImage: ubuntu-16.04
+  variables:
+    H5PY_TEST_CHECK_FILTERS: 1
 
   strategy:
     matrix:
@@ -224,6 +226,8 @@ jobs:
   dependsOn: windows_wheels
   pool:
     vmImage: vs2017-win2016
+  variables:
+    H5PY_TEST_CHECK_FILTERS: 1
 
   strategy:
     matrix:
@@ -310,6 +314,8 @@ jobs:
   dependsOn: macos_wheels
   pool:
     vmImage: macOS-10.15
+  variables:
+    H5PY_TEST_CHECK_FILTERS: 1
 
   strategy:
     matrix:

--- a/h5py/tests/test_filters.py
+++ b/h5py/tests/test_filters.py
@@ -11,6 +11,7 @@
     Tests the h5py._hl.filters module.
 
 """
+import os
 import numpy as np
 import h5py
 import pytest
@@ -85,3 +86,10 @@ def test_unregister_filter(request):
     if h5py.h5z.filter_avail(h5py.h5z.FILTER_LZF):
         res = h5py.h5z.unregister_filter(h5py.h5z.FILTER_LZF)
         assert res
+
+@ut.skipIf(not os.getenv('H5PY_TEST_CHECK_FILTERS'),  "H5PY_TEST_CHECK_FILTERS not set")
+def test_filters_available():
+    assert 'gzip' in h5py.filters.decode
+    assert 'gzip' in h5py.filters.encode
+    assert 'lzf' in h5py.filters.decode
+    assert 'lzf' in h5py.filters.encode

--- a/h5py/tests/test_filters.py
+++ b/h5py/tests/test_filters.py
@@ -87,6 +87,7 @@ def test_unregister_filter(request):
         res = h5py.h5z.unregister_filter(h5py.h5z.FILTER_LZF)
         assert res
 
+
 @ut.skipIf(not os.getenv('H5PY_TEST_CHECK_FILTERS'),  "H5PY_TEST_CHECK_FILTERS not set")
 def test_filters_available():
     assert 'gzip' in h5py.filters.decode


### PR DESCRIPTION
The new test is disabled by default, and enabled by an environment variable set in the CI for the jobs testing installation from a wheel.

Should we also check for szip? The docs don't guarantee its availability, but I think it's been there previously.