### PR TITLE
Get processor architecture at compile time

### DIFF
--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -33,12 +33,10 @@ import numpy as np
 from .h5 import get_config
 
 from ._objects import phil, with_phil
-import platform
-
 
 cfg = get_config()
 
-MACHINE = platform.machine()
+DEF MACHINE = UNAME_MACHINE  # processor architecture, provided by Cython
 cdef char* H5PY_PYTHON_OPAQUE_TAG = "PYTHON:OBJECT"
 
 # === Custom C API ============================================================

--- a/news/machine-compile-time.rst
+++ b/news/machine-compile-time.rst
@@ -1,0 +1,30 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* Avoid launching a subprocess by using ``platform.machine()`` at import time.
+  This could trigger a warning in MPI.
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
Avoids the platform module running a subprocess during import.

Hopefully this might fix #1079.