### PR TITLE
Don't install cibuildwheel for test jobs

### DIFF
--- a/ci/azure-pipelines-steps.yml
+++ b/ci/azure-pipelines-steps.yml
@@ -53,7 +53,7 @@ steps:
 
 - script: |
     python -m pip install --upgrade pip
-    pip install tox codecov cibuildwheel==1.6.0
+    pip install tox codecov
   displayName: 'Install pip dependencies'
 
 - script: env


### PR DESCRIPTION
This was a leftover from when I was experimenting with different ways to arrange the build.

I'll merge this myself if CI passes.