### PR TITLE
Minor documentation fixes

### DIFF
--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -286,7 +286,7 @@ the decimal point to retain.
 .. warning::
     Currently the scale-offset filter does not preserve special float values
     (i.e. NaN, inf), see
-    https://lists.hdfgroup.org/pipermail/hdf-forum_lists.hdfgroup.org/2015-January/008296.html
+    https://forum.hdfgroup.org/t/scale-offset-filter-and-special-float-values-nan-infinity/3379
     for more information and follow-up.
 
 

--- a/docs/high/file.rst
+++ b/docs/high/file.rst
@@ -353,7 +353,7 @@ Reference
     :param swmr:    If ``True`` open the file in single-writer-multiple-reader
                     mode. Only used when mode="r".
     :param rdcc_nbytes:  Total size of the raw data chunk cache in bytes. The
-                    default size is :math:`1024^2` (1 MB) per dataset.
+                    default size is :math:`1024^2` (1 MiB) per dataset.
     :param rdcc_w0: Chunk preemption policy for all datasets.  Default value is
                     0.75.
     :param rdcc_nslots:  Number of chunk slots in the raw data chunk cache for


### PR DESCRIPTION
* Fix a broken link.
* Correct units: "MiB" instead of "MB".