### PR TITLE
CI: build libhdf5 when building macos wheels

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,9 @@ jobs:
   pool:
     vmImage: macOS-10.15
   variables:
-    CIBW_ENVIRONMENT: "HDF5_DIR='/usr/local'"  # HDF5 installed with brew
+    MACOSX_DEPLOYMENT_TARGET: 10.9
+    HDF5_VERSION: 1.12.0
+    HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
     CIBW_BUILD: cp3[678]-macosx_x86_64
   steps:
     - template: ci/azure-pipelines-wheels.yml

--- a/ci/azure-pipelines-wheels.yml
+++ b/ci/azure-pipelines-wheels.yml
@@ -28,11 +28,6 @@ steps:
       echo ##vso[task.setvariable variable=LINK]/LIBPATH:$(build.BinariesDirectory)\zlib-msvc-x64\build\native\lib_release
       echo ##vso[task.setvariable variable=ZLIB_ROOT]$(build.BinariesDirectory)\zlib-msvc-x64\build\native
     displayName: 'Install nuget dependencies'
-- ${{ if eq(parameters.platform, 'macos') }}:
-  - script: |
-      brew install pkg-config hdf5@1.12 ccache open-mpi
-      brew link --force hdf5@1.12
-    displayName: 'Install brew dependencies'
 
 - script: |
     python -m pip install --upgrade pip
@@ -42,12 +37,16 @@ steps:
 - script: env
   displayName: 'Print env'
 
-# On Mac, we already installed HDF5 from brew. On Linux, the wheel will be
+# On Linux, the wheel will be
 # built inside a Docker image which already contains HDF5.
 - ${{ if eq(parameters.platform, 'windows') }}:
     - script: |
         python -m pip install requests
         python ci\\appveyor\\get_hdf5.py
+      displayName: 'Ensure HDF5'
+- ${{ if eq(parameters.platform, 'macos') }}:
+    - script: |
+        ci/travis/get_hdf5_if_needed.sh
       displayName: 'Ensure HDF5'
 
 - script: |

--- a/news/macos-build-hdf5.rst
+++ b/news/macos-build-hdf5.rst
@@ -1,0 +1,4 @@
+Building h5py
+-------------
+
+* Fixed build of macos wheels to generate wheels compatible with older versions of macos.


### PR DESCRIPTION
This PR updates the CI build of macos wheels to use a built version of libhdf5 rather than the one from homebrew in order to improve the compatibility of the wheels with different version of macos.
From what I tested, generated wheels passes the test on macos10.12 using python3.[678] from python.org.

closes  #1701
