### PR TITLE
Add testing lzf compression with actual data

### DIFF
--- a/ci/azure-pipelines-steps.yml
+++ b/ci/azure-pipelines-steps.yml
@@ -10,7 +10,7 @@ steps:
     # HDF5_VSVERSION is only for Windows - it's just a fixed string elsewhere.
     # Increment the first number to clear the cache if you change e.g.
     # dependencies or build options.
-    key: 1 | HDF5 | "$(Agent.OS)" | "${{ parameters.vmImage }}" | "$(HDF5_VERSION)" | "$(HDF5_VSVERSION)"
+    key: 2 | HDF5 | "$(Agent.OS)" | "${{ parameters.vmImage }}" | "$(HDF5_VERSION)" | "$(HDF5_VSVERSION)"
     path: $(HDF5_CACHE_DIR)
   condition: and(succeeded(), ne(variables['HDF5_VERSION'], ''))
 

--- a/ci/travis/get_hdf5_if_needed.sh
+++ b/ci/travis/get_hdf5_if_needed.sh
@@ -18,7 +18,7 @@ else
         pushd hdf5-$HDF5_VERSION
         chmod u+x autogen.sh
         if [[ "${HDF5_VERSION%.*}" = "1.12" ]]; then
-          ./configure --prefix $HDF5_DIR
+          ./configure --prefix $HDF5_DIR --enable-build-mode=production
         else
           ./configure --prefix $HDF5_DIR
         fi

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -540,6 +540,16 @@ class TestCreateLZF(BaseDataset):
         self.assertEqual(dset.compression, 'lzf')
         self.assertEqual(dset.compression_opts, None)
 
+        testdata = np.arange(100)
+        dset = self.f.create_dataset('bar', data=testdata, compression='lzf')
+        self.assertEqual(dset.compression, 'lzf')
+        self.assertEqual(dset.compression_opts, None)
+
+        self.f.flush()  # Actually write to file
+
+        readdata = self.f['bar'][()]
+        self.assertArrayEqual(readdata, testdata)
+
     def test_lzf_exc(self):
         """ Giving lzf options raises ValueError """
         with self.assertRaises(ValueError):


### PR DESCRIPTION
This PR adds testing of lzf compression with actual data.

On my macos laptop, this test crashes with HDF5 1.12.0.
