### PR TITLE
Only depend on 3rd party cached-property if Py<3.8.

### DIFF
--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -11,7 +11,10 @@
     Implements support for high-level dataset access.
 """
 
-from cached_property import cached_property
+try:
+    from functools import cached_property
+except ImportError:
+    from cached_property import cached_property
 import posixpath as pp
 import sys
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ NUMPY_MIN_VERSIONS = [
 ]
 
 # these are required to use h5py
-RUN_REQUIRES = ["cached-property"] + [
+RUN_REQUIRES = ["cached-property; python_version<'3.8'"] + [
     f"numpy >={np_min}; python_version{py_condition}"
     for np_min, py_condition in NUMPY_MIN_VERSIONS
 ]


### PR DESCRIPTION
On Py3.8+ we can just use the stdlib version instead.

<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- Add a release note in the news/ folder (copy TEMPLATE.rst)

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->

(given that the new dependency on cached-property is not even in the current whatsnew, I assumed removing it doesn't warrant a whatsnew entry...)