### PR TITLE
Remove Python 3.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,9 @@ matrix:
 
     # MPI tests
     # TODO: We should test with newer versions of HDF5
-    - python: 3.6
+    - python: 3.8
       env:
-      - TOXENV=py36-test-mindeps-mpi4py
+      - TOXENV=py38-test-mindeps-mpi4py
       - CC="mpicc"
       - HDF5_MPI="ON"
       - H5PY_ENFORCE_COVERAGE=yes

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,10 +7,6 @@ environment:
   matrix:
 
     ### USING HDF5 1.8 ###
-    - PYTHON: "C:\\Python36"
-      TOXENV: "py36-test-deps"
-      HDF5_VSVERSION: "14"
-      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
 
     - PYTHON: "C:\\Python37"
       TOXENV: "py37-test-deps"
@@ -18,12 +14,6 @@ environment:
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
 
     ### USING HDF5 1.10 ###
-
-    - PYTHON: "C:\\Python36"
-      TOXENV: "py36-test-deps"
-      HDF5_VSVERSION: "14"
-      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
-      HDF5_VERSION: "1.10.6"
 
     - PYTHON: "C:\\Python37"
       TOXENV: "py37-test-deps"
@@ -38,12 +28,6 @@ environment:
       HDF5_VERSION: "1.10.6"
 
     ### USING HDF5 1.12 ###
-
-    - PYTHON: "C:\\Python36"
-      TOXENV: "py36-test-deps"
-      HDF5_VSVERSION: "14"
-      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
-      HDF5_VERSION: "1.12.0"
 
     - PYTHON: "C:\\Python37"
       TOXENV: "py37-test-deps"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -114,13 +114,6 @@ jobs:
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         H5PY_ENFORCE_COVERAGE: yes
     # do mpi tests
-      py36-deps-hdf51103-mpi:
-        python.version: '3.6'
-        TOXENV: py36-test-mindeps-mpi4py
-        HDF5_VERSION: 1.10.3
-        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
-        HDF5_MPI: ON
-        CC: mpicc
       py37-deps-hdf51103-mpi:
         python.version: '3.7'
         TOXENV: py37-test-mindeps-mpi4py

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ jobs:
   pool:
     vmImage: ubuntu-16.04
   variables:
-    CIBW_BUILD: cp3[6789]-manylinux_x86_64
+    CIBW_BUILD: cp3[789]-manylinux_x86_64
     CIBW_MANYLINUX_X86_64_IMAGE: docker.io/h5py/manylinux2010_x86_64-hdf5
     # Include less debugging info for smaller wheels (default is -g2)
     CIBW_ENVIRONMENT: "CFLAGS=-g1"
@@ -43,7 +43,7 @@ jobs:
     HDF5_VERSION: 1.12.0
     HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
     HDF5_VSVERSION: "15-64"
-    CIBW_BUILD: cp3[6789]-win_amd64
+    CIBW_BUILD: cp3[789]-win_amd64
   steps:
     - template: ci/azure-pipelines-wheels.yml
       parameters:
@@ -56,7 +56,7 @@ jobs:
     MACOSX_DEPLOYMENT_TARGET: 10.9
     HDF5_VERSION: 1.12.0
     HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
-    CIBW_BUILD: cp3[6789]-macosx_x86_64
+    CIBW_BUILD: cp3[789]-macosx_x86_64
   steps:
     - template: ci/azure-pipelines-wheels.yml
       parameters:
@@ -141,10 +141,6 @@ jobs:
 
   strategy:
     matrix:
-      py36:
-        python.version: '3.6'
-        TOXENV: py36-test-deps,py36-test-mindeps,py36-test-deps-pre,py36-test-deps-tables
-        WHL_FILE: h5py*-cp36-*manylinux1_x86_64.whl
       py37:
         python.version: '3.7'
         TOXENV: py37-test-deps,py37-test-mindeps,py37-test-deps-pre,py37-test-deps-tables
@@ -223,10 +219,6 @@ jobs:
 
   strategy:
     matrix:
-      py36:
-        python.version: '3.6'
-        TOXENV: py36-test-deps,py36-test-mindeps,py36-test-deps-tables
-        WHL_FILE: h5py*-cp36-*.whl
       py37:
         python.version: '3.7'
         TOXENV: py37-test-deps,py37-test-mindeps,py37-test-deps-tables
@@ -299,10 +291,6 @@ jobs:
 
   strategy:
     matrix:
-      py36:
-        python.version: '3.6'
-        TOXENV: py36-test-deps,py36-test-mindeps,py36-test-deps-tables
-        WHL_FILE: h5py*-cp36-*.whl
       py37:
         python.version: '3.7'
         TOXENV: py37-test-deps,py37-test-mindeps,py37-test-deps-tables

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ VERSION = '3.0.0'
 # Minimum supported versions of Numpy & Cython depend on the Python version
 NUMPY_MIN_VERSIONS = [
     # Numpy    Python
-    ('1.12',   "=='3.6'"),
     ('1.14.5', "=='3.7'"),
     ('1.17.5', "=='3.8'"),
     ('1.19.3', ">='3.9'"),
@@ -122,8 +121,6 @@ License :: OSI Approved :: BSD License
 Programming Language :: Cython
 Programming Language :: Python
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.6
-Programming Language :: Python :: 3.7
 Programming Language :: Python :: Implementation :: CPython
 Topic :: Scientific/Engineering
 Topic :: Database
@@ -179,6 +176,6 @@ setup(
   ext_modules = [Extension('h5py.x',['x.c'])],  # To trick build into running build_ext
   install_requires = RUN_REQUIRES,
   setup_requires = SETUP_REQUIRES,
-  python_requires='>=3.6',
+  python_requires='>=3.7',
   cmdclass = CMDCLASS,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # We want an envlist like
 # envlist = {py36,py37,pypy3}-{test}-{deps,mindeps}-{,mpi4py}-{,pre},nightly,docs,checkreadme,pre-commit
 # but we want to skip mpi and pre by default, so this envlist is below
-envlist = {py36,py37,py38,py39,pypy3}-{test}-{deps,mindeps},nightly,docs,apidocs,checkreadme,pre-commit,rever
+envlist = {py37,py38,py39,pypy3}-{test}-{deps,mindeps},nightly,docs,apidocs,checkreadme,pre-commit,rever
 isolated_build = True
 
 [testenv]
@@ -11,17 +11,14 @@ deps =
     test: pytest-cov
     test: pytest-mpi>=0.2
 
-    py36-deps: numpy>=1.12
     py37-deps: numpy>=1.14.5
     py38-deps: numpy>=1.17.5
     py39-deps: numpy>=1.19.3
 
-    py36-mindeps: cython==0.29
     py37-mindeps: cython==0.29
     py38-mindeps: cython==0.29.14
     py39-mindeps: cython==0.29.14
 
-    py36-mindeps: numpy==1.12
     py37-mindeps: numpy==1.14.5
     py38-mindeps: numpy==1.17.5
     py39-mindeps: numpy==1.19.3


### PR DESCRIPTION
This ditches wheel building and tests on Python 3.6, and marks it as supporting 3.7 and above.

I don't think there's much in 3.7 we're eager to start using, so we could keep supporting 3.6 for a while if there's a need - perhaps without building wheels for it. But testing on lots of Python versions takes CI time, and if we don't test it then sooner or later it will break. Dropping it now is OK by [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html). So I propose to leave this for a couple of weeks to see if anyone makes a case for extending 3.6 support.

(I made a bit of a mess by accidentally pushing the first two commits to master. Sorry about that. :-( I've reverted them in master, and re-made them for this PR)