### PR TITLE
Properly handle reading non-native endian data. Fixes #1792

### DIFF
--- a/.authors.yml
+++ b/.authors.yml
@@ -828,3 +828,10 @@
   num_commits: 2
   first_commit: 2020-10-13 03:57:42
   github: opoplawski
+- name: Kacper Kowalik
+  email: xarthisius.kk@gmail.com
+  aliases:
+    - Kacper Kowalik (Xarthisius)
+  num_commit: 2
+  first_commit: 2020-10-31 18:30:45
+  github: Xarthisius

--- a/h5py/tests/test_big_endian_file.py
+++ b/h5py/tests/test_big_endian_file.py
@@ -1,34 +1,50 @@
 import pytest
 
+import numpy as np
 from h5py import File
+from .common import TestCase
 from .data_files import get_data_file_path
 
 
 def test_vlen_big_endian():
     with File(get_data_file_path("vlen_string_s390x.h5")) as f:
-        assert f.attrs['created_on_s390x'] == 1
+        assert f.attrs["created_on_s390x"] == 1
 
-        dset = f['DSvariable']
-        assert dset[0] == b'Parting'
-        assert dset[1] == b'is such'
-        assert dset[2] == b'sweet'
-        assert dset[3] == b'sorrow...'
+        dset = f["DSvariable"]
+        assert dset[0] == b"Parting"
+        assert dset[1] == b"is such"
+        assert dset[2] == b"sweet"
+        assert dset[3] == b"sorrow..."
 
-        dset = f['DSLEfloat']
+        dset = f["DSLEfloat"]
         assert dset[0] == 3.14
         assert dset[1] == 1.61
         assert dset[2] == 2.71
         assert dset[3] == 2.41
         assert dset[4] == 1.2
-        assert dset.dtype == '<f8'
+        assert dset.dtype == "<f8"
 
         # Same float values with big endianess
-        assert f['DSBEfloat'][0] == pytest.approx(7.9824696849641e-157)
-        assert f['DSBEfloat'].dtype == '>f8'
+        assert f["DSBEfloat"][0] == 3.14
+        assert f["DSBEfloat"].dtype == ">f8"
 
-        assert f['DSLEint'][0] == 1
-        assert f['DSLEint'].dtype == 'uint64'
+        assert f["DSLEint"][0] == 1
+        assert f["DSLEint"].dtype == "uint64"
 
         # Same int values with big endianess
-        assert f['DSBEint'][0] == 72057594037927936
-        assert f['DSBEint'].dtype == '>i8'
+        assert f["DSBEint"][0] == 1
+        assert f["DSBEint"].dtype == ">i8"
+
+
+class TestEndianess(TestCase):
+    def test_simple_int_be(self):
+        fname = self.mktemp()
+
+        arr = np.ndarray(shape=(1,), dtype=">i4", buffer=bytearray([0, 1, 3, 2]))
+        be_number = 0 * 256 ** 3 + 1 * 256 ** 2 + 3 * 256 ** 1 + 2 * 256 ** 0
+
+        with File(fname, mode="w") as f:
+            f.create_dataset("int", data=arr)
+
+        with File(fname, mode="r") as f:
+            assert f["int"][()][0] == be_number

--- a/news/fix_be_fastread.rst
+++ b/news/fix_be_fastread.rst
@@ -1,0 +1,4 @@
+Bug fixes
+---------
+
+* Preserve endianess in Cython dataset Reader (:issue:`1729`).


### PR DESCRIPTION
This PR ensures that `H5Dread` stores data in a buffer that preserves endianess. 

Please note that I modified the original behavior of `h5py/tests/test_big_endian_file.py:test_vlen_big_endian`, which was comparing numbers stored with BE with their LE interpration.