### PR TITLE
Polish Cython fix for reading data in opposite byte order.

### DIFF
--- a/h5py/_selector.pyx
+++ b/h5py/_selector.pyx
@@ -9,7 +9,10 @@ Python & numpy distinguish indexing a[3] from slicing a single element a[3:4],
 but there is no equivalent to this when selecting data in HDF5. So we store a
 separate boolean ('scalar') for each dimension to distinguish these cases.
 """
-from numpy cimport ndarray, npy_intp, PyArray_SimpleNew, PyArray_DATA, import_array
+from numpy cimport (
+    ndarray, npy_intp, PyArray_SimpleNew, PyArray_DATA, import_array,
+    PyArray_IsNativeByteOrder,
+)
 from cpython cimport PyNumber_Index
 
 import numpy as np
@@ -18,8 +21,6 @@ from .h5d cimport DatasetID
 from .h5s cimport SpaceID
 from .h5t cimport TypeID, typewrap, py_create
 from .utils cimport emalloc, efree, convert_dims
-
-import sys
 
 import_array()
 
@@ -329,7 +330,7 @@ cdef class Reader:
                     arr_rank += 1
 
             arr = PyArray_SimpleNew(arr_rank, arr_shape, self.np_typenum)
-            if self.np_byteorder == (sys.byteorder == 'little' and '>' or '<'):
+            if not PyArray_IsNativeByteOrder(self.np_byteorder):
                 arr = arr.byteswap().newbyteorder()
         finally:
             efree(arr_shape)

--- a/h5py/_selector.pyx
+++ b/h5py/_selector.pyx
@@ -296,7 +296,7 @@ cdef class Reader:
     cdef Selector selector
     cdef TypeID h5_memory_datatype
     cdef int np_typenum
-    cdef char np_byteorder
+    cdef bint native_byteorder
 
     def __cinit__(self, DatasetID dsid):
         self.dataset = dsid.id
@@ -309,7 +309,7 @@ cdef class Reader:
         h5_stored_datatype = typewrap(H5Dget_type(self.dataset))
         np_dtype = h5_stored_datatype.py_dtype()
         self.np_typenum = np_dtype.num
-        self.np_byteorder = np_dtype.byteorder
+        self.native_byteorder = PyArray_IsNativeByteOrder(np_dtype.byteorder)
         self.h5_memory_datatype = py_create(np_dtype)
 
     cdef ndarray make_array(self, hsize_t* mshape):
@@ -330,7 +330,7 @@ cdef class Reader:
                     arr_rank += 1
 
             arr = PyArray_SimpleNew(arr_rank, arr_shape, self.np_typenum)
-            if not PyArray_IsNativeByteOrder(self.np_byteorder):
+            if not self.native_byteorder:
                 arr = arr.byteswap().newbyteorder()
         finally:
             efree(arr_shape)

--- a/h5py/_selector.pyx
+++ b/h5py/_selector.pyx
@@ -331,7 +331,7 @@ cdef class Reader:
 
             arr = PyArray_SimpleNew(arr_rank, arr_shape, self.np_typenum)
             if not self.native_byteorder:
-                arr = arr.byteswap().newbyteorder()
+                arr = arr.newbyteorder()
         finally:
             efree(arr_shape)
 


### PR DESCRIPTION
Follow up to #1730. This simplifies the code in the fast read path for handling data in the non-native byte order. This should have lower overhead for reading both data that already matches the native byte order, and data that doesn't.