### PR TITLE
Test and fix creating datasets with names in bytes

### DIFF
--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -140,15 +140,10 @@ class Group(HLObject, MutableMappingHDF5):
         with phil:
             group = self
             if name:
-                if '/' in name:
-                    h5objects = [obj for obj in name.split('/') if len(obj)]
-                    name = h5objects[-1]
-                    h5objects = h5objects[:-1]
-
-                    for new_group in h5objects:
-                        group = group.get(new_group) or group.create_group(new_group)
-
                 name = self._e(name)
+                if b'/' in name.lstrip(b'/'):
+                    parent_path, name = name.rsplit(b'/', 1)
+                    group = self.require_group(parent_path)
 
             dsid = dataset.make_new_dset(group, shape, dtype, data, name, **kwds)
             dset = dataset.Dataset(dsid)
@@ -186,15 +181,10 @@ class Group(HLObject, MutableMappingHDF5):
                 group = self
 
                 if name:
-                    if '/' in name:
-                        h5objects = [obj for obj in name.split('/') if len(obj)]
-                        name = h5objects[-1]
-                        h5objects = h5objects[:-1]
-
-                        for new_group in h5objects:
-                            group = group.get(new_group) or group.create_group(new_group)
-
                     name = self._e(name)
+                    if b'/' in name.lstrip(b'/'):
+                        parent_path, name = name.rsplit(b'/', 1)
+                        group = self.require_group(parent_path)
 
                 dsid = dataset.make_new_virtual_dset(group, layout.shape,
                          sources=sources, dtype=layout.dtype, name=name,

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -116,6 +116,12 @@ class TestCreateShape(BaseDataset):
                                      dtype=np.dtype('complex256'))
         self.assertEqual(dset.dtype, np.dtype('complex256'))
 
+    def test_name_bytes(self):
+        dset = self.f.create_dataset(b'foo', (1,))
+        self.assertEqual(dset.shape, (1,))
+
+        dset2 = self.f.create_dataset(b'bar/baz', (2,))
+        self.assertEqual(dset2.shape, (2,))
 
 class TestCreateData(BaseDataset):
 
@@ -284,7 +290,7 @@ class TestCreateRequire(BaseDataset):
         self.assertEqual(dset, dset2)
 
         dset = self.f.require_dataset('baz', 10, 'f')
-        dset2 = self.f.require_dataset('baz', (10,), 'f')
+        dset2 = self.f.require_dataset(b'baz', (10,), 'f')
         self.assertEqual(dset, dset2)
 
     def test_shape_conflict(self):

--- a/h5py/tests/test_group.py
+++ b/h5py/tests/test_group.py
@@ -62,10 +62,16 @@ class TestCreate(BaseGroup):
         grp = self.f.create_group('foo')
         self.assertIsInstance(grp, Group)
 
+        grp2 = self.f.create_group(b'bar')
+        self.assertIsInstance(grp, Group)
+
     def test_create_intermediate(self):
         """ Intermediate groups can be created automatically """
         grp = self.f.create_group('foo/bar/baz')
         self.assertEqual(grp.name, '/foo/bar/baz')
+
+        grp2 = self.f.create_group(b'boo/bar/baz')
+        self.assertEqual(grp2.name, '/boo/bar/baz')
 
     def test_create_exception(self):
         """ Name conflict causes group creation to fail with ValueError """
@@ -107,6 +113,11 @@ class TestDatasetAssignment(BaseGroup):
         self.assertIsInstance(self.f['a'], Dataset)
         self.assertArrayEqual(self.f['a'][...], data)
 
+    def test_name_bytes(self):
+        data = np.ones((4, 4), dtype='f')
+        self.f[b'b'] = data
+        self.assertIsInstance(self.f[b'b'], Dataset)
+
 class TestDtypeAssignment(BaseGroup):
 
     """
@@ -120,6 +131,13 @@ class TestDtypeAssignment(BaseGroup):
         self.assertIsInstance(self.f['a'], Datatype)
         self.assertEqual(self.f['a'].dtype, dtype)
 
+    def test_name_bytes(self):
+        """ Named type creation """
+        dtype = np.dtype('|S10')
+        self.f[b'b'] = dtype
+        self.assertIsInstance(self.f[b'b'], Datatype)
+
+
 class TestRequire(BaseGroup):
 
     """
@@ -130,7 +148,10 @@ class TestRequire(BaseGroup):
         """ Existing group is opened and returned """
         grp = self.f.create_group('foo')
         grp2 = self.f.require_group('foo')
-        self.assertEqual(grp, grp2)
+        self.assertEqual(grp2, grp)
+
+        grp3 = self.f.require_group(b'foo')
+        self.assertEqual(grp3, grp)
 
     def test_create(self):
         """ Group is created if it doesn't exist """
@@ -538,7 +559,7 @@ class TestGet(BaseGroup):
         self.assertIs(out, default)
 
         grp = self.f.create_group('a')
-        out = self.f.get('a')
+        out = self.f.get(b'a')
         self.assertEqual(out, grp)
 
     def test_get_class(self):

--- a/h5py/tests/test_vds/test_highlevel_vds.py
+++ b/h5py/tests/test_vds/test_highlevel_vds.py
@@ -319,7 +319,7 @@ class IndexingTestCase(ut.TestCase):
         # Add virtual datasets to output file and close
         with h5.File(outfile, 'w', libver='latest') as f:
             f.create_virtual_dataset('/data', layout, fillvalue=-5)
-            f.create_virtual_dataset('/data2', layout2, fillvalue=-3)
+            f.create_virtual_dataset(b'/data2', layout2, fillvalue=-3)
 
         # Read data from virtual datasets
         with h5.File(outfile, 'r') as f:

--- a/news/create-dataset-bytes.rst
+++ b/news/create-dataset-bytes.rst
@@ -1,0 +1,30 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* Fix using bytes as names for :meth:`~Group.create_dataset` and
+  :meth:`~Group.create_virtual_dataset`.
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
Closes #1732

The docs say object names can be passed as bytes, and this works for most operations. I've added some tests of operations which take object names - it seems only creating datasets was broken.