### PR TITLE
Remove Travis jobs with allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,22 +60,6 @@ matrix:
             - libopenmpi-dev
             - libhdf5-openmpi-dev # 1.8.11 based on trusty
 
-    # Additional python versions which are not officially supported
-    - python: "nightly"
-      env:
-      - TOXENV=nightly
-      - HDF5_VERSION=1.10.5
-      - HDF5_DIR=$HDF5_CACHE_DIR/$HDF5_VERSION
-      - H5PY_ENFORCE_COVERAGE=yes
-
-    - python: pypy3
-      env:
-      - TOXENV=pypy3-test-deps
-      - H5PY_ENFORCE_COVERAGE=yes
-  allow_failures:
-    - python: pypy3
-    - python: 'nightly'
-
 before_install:
   # - export PATH=/usr/lib/ccache:$PATH
   - ccache -s


### PR DESCRIPTION
Relates to #1733

AFAIK, we don't pay any attention to the jobs which allow failures - they're both currently failing and no-one seems to mind. But the two jobs together take about 10 minutes of builder time on each commit. So if our Travis build time will be rationed in any way, we don't want to spend it on these.