### PR TITLE
Fix test of little-endian dtype for big-endian systems

### DIFF
--- a/h5py/tests/test_big_endian_file.py
+++ b/h5py/tests/test_big_endian_file.py
@@ -29,7 +29,7 @@ def test_vlen_big_endian():
         assert f["DSBEfloat"].dtype == ">f8"
 
         assert f["DSLEint"][0] == 1
-        assert f["DSLEint"].dtype == "uint64"
+        assert f["DSLEint"].dtype == "<u8"
 
         # Same int values with big endianess
         assert f["DSBEint"][0] == 1

--- a/news/test-endian-dtype.rst
+++ b/news/test-endian-dtype.rst
@@ -1,0 +1,29 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* Fix a test which was failing on big-endian systems.


### PR DESCRIPTION
See discussion on #1739.

Educated guesswork: `== 'uint64'` checks for a uint64 in system-native byteorder. Hopefully `== '<u8'` checks for explicitly little-endian uint64.