### PR TITLE
Ensure the pytest plugin pytest-mpi is present

### DIFF
--- a/.authors.yml
+++ b/.authors.yml
@@ -166,6 +166,8 @@
   num_commits: 4
   first_commit: 2019-07-02 14:30:12
   github: Anthchirp
+  alternate_emails:
+  - 2102431+Anthchirp@users.noreply.github.com
 - name: root
   email: root@acdlab11.lims.acdlabs.ru
   num_commits: 1

--- a/news/require-pytest-mpi.rst
+++ b/news/require-pytest-mpi.rst
@@ -1,0 +1,29 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* If pytest is missing pytest-mpi then it will now fail immediately with a clear warning message.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 filterwarnings =
     error::h5py.h5py_warnings.H5pyDeprecationWarning
+required_plugins = pytest-mpi


### PR DESCRIPTION
and fail with a clear warning when it is not.
Resolves #1696.

<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->
