### PR TITLE
Allow to use tuples as dataset indices. Fixes #1757

### DIFF
--- a/h5py/_selector.pyx
+++ b/h5py/_selector.pyx
@@ -14,6 +14,7 @@ from numpy cimport (
     PyArray_IsNativeByteOrder,
 )
 from cpython cimport PyNumber_Index
+from collections.abc import Iterable
 
 import numpy as np
 from .defs cimport *
@@ -172,8 +173,8 @@ cdef class Selector:
                 continue
 
             # [[0, 2, 10]] - list/array of indices ('fancy indexing')
-            if isinstance(a, (list, np.ndarray)):
-                if isinstance(a, list) and len(a) == 0:
+            if isinstance(a, Iterable):
+                if not isinstance(a, np.ndarray) and len(a) == 0:
                     a = np.asarray(a, dtype=np.intp)
                 else:
                     a = np.asarray(a)

--- a/h5py/tests/test_selections.py
+++ b/h5py/tests/test_selections.py
@@ -105,6 +105,10 @@ class TestSelection(BaseSelection):
         st = sel.select((10,), list([1,2,3]), dset)
         self.assertIsInstance(st, sel.FancySelection)
 
+        # args is a tuple, return a FancySelection
+        st = sel.select((3,), (0, (1,2,3)), dset)
+        self.assertIsInstance(st, sel.FancySelection)
+
         # args is a Boolean mask, return a PointSelection
         st1 = sel.select((5,), np.array([True,False,False,False,True]), dset)
         self.assertIsInstance(st1, sel.PointSelection)

--- a/news/tuple_index.rst
+++ b/news/tuple_index.rst
@@ -1,0 +1,4 @@
+Bug fixes
+---------
+
+* Fix dataset selection using tuple indices (:issue:`1757`)


### PR DESCRIPTION
Simply check if index is iterable. Since it's immediately converted into numpy array, anything should work.