### PR TITLE
Address numpy 1.20 deprecation warnings

### DIFF
--- a/.authors.yml
+++ b/.authors.yml
@@ -818,6 +818,8 @@
   github: kmuehlbauer
 - name: V. Armando Solé
   email: sole@esrf.fr
+  alternate_emails:
+    - vasole@users.noreply.github.com
   num_commits: 6
   first_commit: 2019-09-19 13:06:48
   github: vasole

--- a/examples/dataset_concatenation.py
+++ b/examples/dataset_concatenation.py
@@ -10,7 +10,7 @@ def concatenate(file_names_to_concatenate):
     entry_key = 'data'  # where the data is inside of the source files.
     sh = h5py.File(file_names_to_concatenate[0], 'r')[entry_key].shape  # get the first ones shape.
     layout = h5py.VirtualLayout(shape=(len(file_names_to_concatenate),) + sh,
-                                dtype=np.float)
+                                dtype=np.float64)
     with h5py.File("VDS.h5", 'w', libver='latest') as f:
         for i, filename in enumerate(file_names_to_concatenate):
             vsource = h5py.VirtualSource(filename, entry_key, shape=sh)

--- a/examples/eiger_use_case.py
+++ b/examples/eiger_use_case.py
@@ -11,7 +11,7 @@ files = ['1.h5', '2.h5', '3.h5', '4.h5', '5.h5']
 entry_key = 'data' # where the data is inside of the source files.
 sh = h5py.File(files[0], 'r')[entry_key].shape # get the first ones shape.
 
-layout = h5py.VirtualLayout(shape=(len(files) * sh[0], ) + sh[1:], dtype=np.float)
+layout = h5py.VirtualLayout(shape=(len(files) * sh[0], ) + sh[1:], dtype=np.float64)
 M_start = 0
 for i, filename in enumerate(files):
     M_end = M_start + sh[0]

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -2,7 +2,7 @@
 #
 # http://www.h5py.org
 #
-# Copyright 2008-2013 Andrew Collette and contributors
+# Copyright 2008-2020 Andrew Collette and contributors
 #
 # License:  Standard 3-clause BSD; see "license.txt" for full license terms
 #           and contributor agreement.
@@ -764,7 +764,10 @@ class Dataset(HLObject):
         if self.shape == ():
             fspace = self.id.get_space()
             selection = sel2.select_read(fspace, args)
-            arr = numpy.ndarray(selection.mshape, dtype=new_dtype)
+            if selection.mshape is None:
+                arr = numpy.ndarray((), dtype=new_dtype)
+            else:
+                arr = numpy.ndarray(selection.mshape, dtype=new_dtype)
             for mspace, fspace in selection:
                 self.id.read(mspace, fspace, arr, mtype)
             if selection.mshape is None:
@@ -930,8 +933,8 @@ class Dataset(HLObject):
         if mshape == () and selection.array_shape != ():
             if self.dtype.subdtype is not None:
                 raise TypeError("Scalar broadcasting is not supported for array dtypes")
-            if self.chunks and (numpy.prod(self.chunks, dtype=numpy.float) >=
-                                numpy.prod(selection.array_shape, dtype=numpy.float)):
+            if self.chunks and (numpy.prod(self.chunks, dtype=numpy.float64) >=
+                                numpy.prod(selection.array_shape, dtype=numpy.float64)):
                 val2 = numpy.empty(selection.array_shape, dtype=val.dtype)
             else:
                 val2 = numpy.empty(selection.array_shape[-1], dtype=val.dtype)

--- a/h5py/tests/test_dtype.py
+++ b/h5py/tests/test_dtype.py
@@ -47,7 +47,7 @@ class TestVlen(TestCase):
 
         dt_vb = np.dtype([
             ('foo', vidt),
-            ('logical', np.bool)])
+            ('logical', bool)])
         vb = f.create_dataset('dt_vb', shape=(4,), dtype=dt_vb)
         data = np.array([(a([1, 2, 3]), True),
                          (a([1    ]), False),
@@ -67,11 +67,11 @@ class TestVlen(TestCase):
         dt_vvb = np.dtype([
             ('foo', vidt),
             ('bar', vidt),
-            ('logical', np.bool)])
+            ('logical', bool)])
         vvb = f.create_dataset('dt_vvb', shape=(2,), dtype=dt_vvb)
 
         dt_bvv = np.dtype([
-            ('logical', np.bool),
+            ('logical', bool),
             ('foo', vidt),
             ('bar', vidt)])
         bvv = f.create_dataset('dt_bvv', shape=(2,), dtype=dt_bvv)
@@ -390,7 +390,7 @@ class TestB8(TestCase):
     """
 
     def test_b8_bool(self):
-        arr1 = np.array([False, True], dtype=np.bool)
+        arr1 = np.array([False, True], dtype=bool)
         self._test_b8(arr1)
         self._test_b8(arr1, dtype=np.uint8)
 

--- a/h5py/tests/test_slicing.py
+++ b/h5py/tests/test_slicing.py
@@ -238,7 +238,7 @@ class TestZeroLengthSlicing(BaseSlicing):
         """ Slice a dataset with a zero in its shape vector
             along the zero-length dimension """
         for i, shape in enumerate([(0,), (0, 3), (0, 2, 1)]):
-            dset = self.f.create_dataset('x%d'%i, shape, dtype=np.int, maxshape=(None,)*len(shape))
+            dset = self.f.create_dataset('x%d'%i, shape, dtype=int, maxshape=(None,)*len(shape))
             self.assertEqual(dset.shape, shape)
             out = dset[...]
             self.assertIsInstance(out, np.ndarray)
@@ -255,7 +255,7 @@ class TestZeroLengthSlicing(BaseSlicing):
         """ Slice a dataset with a zero in its shape vector
             along a non-zero-length dimension """
         for i, shape in enumerate([(3, 0), (1, 2, 0), (2, 0, 1)]):
-            dset = self.f.create_dataset('x%d'%i, shape, dtype=np.int, maxshape=(None,)*len(shape))
+            dset = self.f.create_dataset('x%d'%i, shape, dtype=int, maxshape=(None,)*len(shape))
             self.assertEqual(dset.shape, shape)
             out = dset[:1]
             self.assertIsInstance(out, np.ndarray)
@@ -264,7 +264,7 @@ class TestZeroLengthSlicing(BaseSlicing):
     def test_slice_of_length_zero(self):
         """ Get a slice of length zero from a non-empty dataset """
         for i, shape in enumerate([(3,), (2, 2,), (2,  1, 5)]):
-            dset = self.f.create_dataset('x%d'%i, data=np.zeros(shape, np.int), maxshape=(None,)*len(shape))
+            dset = self.f.create_dataset('x%d'%i, data=np.zeros(shape, int), maxshape=(None,)*len(shape))
             self.assertEqual(dset.shape, shape)
             out = dset[1:1]
             self.assertIsInstance(out, np.ndarray)

--- a/h5py/tests/test_vds/test_highlevel_vds.py
+++ b/h5py/tests/test_vds/test_highlevel_vds.py
@@ -188,7 +188,7 @@ class TestPercivalHighLevel(ut.TestCase):
         outfile = osp.join(self.working_dir,  'percival.h5')
 
         # Virtual layout is a representation of the output dataset
-        layout = h5.VirtualLayout(shape=(79, 200, 200), dtype=np.float)
+        layout = h5.VirtualLayout(shape=(79, 200, 200), dtype=np.float64)
         for k, filename in enumerate(self.fname):
             dim1 = 19 if k == 3 else 20
             vsource = h5.VirtualSource(filename, 'data',shape=(dim1, 200, 200))
@@ -209,7 +209,7 @@ class TestPercivalHighLevel(ut.TestCase):
         outfile = osp.join(self.working_dir,  'percival.h5')
 
         # Virtual layout is a representation of the output dataset
-        layout = h5.VirtualLayout(shape=(79, 200, 200), dtype=np.float)
+        layout = h5.VirtualLayout(shape=(79, 200, 200), dtype=np.float64)
         for k, filename in enumerate(self.fname):
             with h5.File(filename, 'r') as f:
                 vsource = h5.VirtualSource(f['data'])

--- a/h5py/tests/test_vds/test_highlevel_vds.py
+++ b/h5py/tests/test_vds/test_highlevel_vds.py
@@ -414,7 +414,7 @@ class VDSUnlimitedTestCase(ut.TestCase):
                 chunks=(10, 1),
                 fillvalue=-1
             )
-            self.layout = h5.VirtualLayout((10, 1), np.int, maxshape=(None, 1))
+            self.layout = h5.VirtualLayout((10, 1), int, maxshape=(None, 1))
             layout_source = h5.VirtualSource(source_dset)
             self.layout[:h5.UNLIMITED, 0] = layout_source[:h5.UNLIMITED, 1]
 
@@ -436,7 +436,7 @@ class VDSUnlimitedTestCase(ut.TestCase):
             np.testing.assert_array_equal(comp1, virtual_dset)
             source_dset.resize(20, axis=0)
             np.testing.assert_array_equal(comp2, virtual_dset)
-            source_dset[10:, 1] = np.zeros((10,), dtype=np.int)
+            source_dset[10:, 1] = np.zeros((10,), dtype=int)
             np.testing.assert_array_equal(comp3, virtual_dset)
 
     def tearDown(self):

--- a/news/warnings.rst
+++ b/news/warnings.rst
@@ -6,7 +6,7 @@ New features
 Deprecations
 ------------
 
-* Replace np.float by np.float64, np.int by int and np.bool by bool
+* <news item>
 
 Exposing HDF5 functions
 -----------------------

--- a/news/warnings.rst
+++ b/news/warnings.rst
@@ -1,0 +1,29 @@
+New features
+------------
+
+* Suppress numpy 1.20 deprecation warnings concerning the use of None as shape, np.float, np.int and np.bool
+
+Deprecations
+------------
+
+* Replace np.float by np.float64, np.int by int and np.bool by bool
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
- Suppress annoying warning concerning the use of None as shape. The warning was triggered when retrieving a dataset as [()]
- Replaces np.float by np.float64
- Replaces np.int by int (it was an alias)
- Replaces np.bool by bool (it was an alias)