### PR TITLE
Use the next patch version of Cython on Python 3.9 to avoid building it

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ RUN_REQUIRES = ["cached-property; python_version<'3.8'"] + [
 SETUP_REQUIRES = [
     'pkgconfig',
     f"Cython >=0.29; python_version<'3.8'",
-    f"Cython >=0.29.14; python_version>='3.8'",
+    f"Cython >=0.29.14; python_version=='3.8'",
+    f"Cython >=0.29.15; python_version>='3.9'",
 ] + [
     f"numpy =={np_min}; python_version{py_condition}"
     for np_min, py_condition in NUMPY_MIN_VERSIONS

--- a/setup.py
+++ b/setup.py
@@ -46,9 +46,9 @@ RUN_REQUIRES = ["cached-property; python_version<'3.8'"] + [
 # versions.
 SETUP_REQUIRES = [
     'pkgconfig',
-    f"Cython >=0.29; python_version<'3.8'",
-    f"Cython >=0.29.14; python_version=='3.8'",
-    f"Cython >=0.29.15; python_version>='3.9'",
+    "Cython >=0.29; python_version<'3.8'",
+    "Cython >=0.29.14; python_version=='3.8'",
+    "Cython >=0.29.15; python_version>='3.9'",
 ] + [
     f"numpy =={np_min}; python_version{py_condition}"
     for np_min, py_condition in NUMPY_MIN_VERSIONS

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
     py36-mindeps: cython==0.29
     py37-mindeps: cython==0.29
     py38-mindeps: cython==0.29.14
-    py39-mindeps: cython==0.29.14
+    py39-mindeps: cython==0.29.15
 
     py36-mindeps: numpy==1.12
     py37-mindeps: numpy==1.14.5


### PR DESCRIPTION
Hopefully this will fix the recent CI failures. Cython now has a fallback pure Python (`py2.py3-none-any`) wheel, and the README seems to indicate that the benefits of the compiled parts are outweighed for CI by the time taken to compile them.