### PR TITLE
Move low-level API docs creation to Github actions

### DIFF
--- a/.github/workflows/lowlevel-api-docs.yml
+++ b/.github/workflows/lowlevel-api-docs.yml
@@ -1,0 +1,46 @@
+name: Build low-level API docs
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-18.04
+    env:
+      HDF5_VERSION: 1.12.0
+      HDF5_DIR: ${{ github.workspace }}/cache/hdf5
+      TOXENV: apidocs
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache HDF5
+          uses: actions/cache@v2
+          with:
+            path: ${{ env.HDF5_DIR }}
+            key: ${{ runner.os }}-hdf5-${{ env.HDF5_VERSION }}
+
+      - name: Build HDF5
+        run: |
+          ./ci/get_hdf5_if_needed.sh
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - name: Install tox
+        run: |
+          python -m pip install --upgrade pip
+          python3 -m pip install tox
+
+      - name: Build API docs
+        run: tox
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: github.repository == 'h5py/h5py' && github.ref == 'refs/heads/master'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs_api/_build/html

--- a/.github/workflows/lowlevel-api-docs.yml
+++ b/.github/workflows/lowlevel-api-docs.yml
@@ -8,7 +8,7 @@ on:
     pull_request:
 
 jobs:
-  deploy:
+  api-docs:
     runs-on: ubuntu-18.04
     env:
       HDF5_VERSION: 1.12.0

--- a/.github/workflows/lowlevel-api-docs.yml
+++ b/.github/workflows/lowlevel-api-docs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - apidocs-gh-actions  # Temporary, for testing before workflow merged
     pull_request:
 
 jobs:

--- a/.github/workflows/lowlevel-api-docs.yml
+++ b/.github/workflows/lowlevel-api-docs.yml
@@ -3,7 +3,7 @@ name: Build low-level API docs
 on:
   push:
     branches:
-      - main
+      - master
     pull_request:
 
 jobs:

--- a/.github/workflows/lowlevel-api-docs.yml
+++ b/.github/workflows/lowlevel-api-docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+    pull_request:
 
 jobs:
   deploy:

--- a/.github/workflows/lowlevel-api-docs.yml
+++ b/.github/workflows/lowlevel-api-docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - apidocs-gh-actions  # Temporary, for testing before workflow merged
     pull_request:
 
 jobs:

--- a/.github/workflows/lowlevel-api-docs.yml
+++ b/.github/workflows/lowlevel-api-docs.yml
@@ -40,6 +40,12 @@ jobs:
       - name: Build API docs
         run: tox
 
+      - name: Upload built docs
+        uses: actions/upload-artifact@v2
+        with:
+          name: docs-html
+          path: docs_api/_build/html
+
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         if: github.repository == 'h5py/h5py' && github.ref == 'refs/heads/master' && github.event_name == 'push'

--- a/.github/workflows/lowlevel-api-docs.yml
+++ b/.github/workflows/lowlevel-api-docs.yml
@@ -17,10 +17,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Cache HDF5
-          uses: actions/cache@v2
-          with:
-            path: ${{ env.HDF5_DIR }}
-            key: ${{ runner.os }}-hdf5-${{ env.HDF5_VERSION }}
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.HDF5_DIR }}
+          key: ${{ runner.os }}-hdf5-${{ env.HDF5_VERSION }}
 
       - name: Build HDF5
         run: |

--- a/.github/workflows/lowlevel-api-docs.yml
+++ b/.github/workflows/lowlevel-api-docs.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: github.repository == 'h5py/h5py' && github.ref == 'refs/heads/master'
+        if: github.repository == 'h5py/h5py' && github.ref == 'refs/heads/master' && github.event_name == 'push'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs_api/_build/html

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ cache:
 env:
   global:
     - HDF5_CACHE_DIR=$HOME/.cache/hdf5
-    - secure: "PVgKiZwB5Kr7KFAmjoMYtsKsVGUhDdiYq0YoMMEk/COFHpnRt/3CUKYwW+4vTCSKcaai/1ZiPUrHruCwdnU7sUkJZZdKkh2C+Vqx+DnnfAFMbLPGqgaBG2UEMtDIinXHDtV4k9wSJB2X9KPchA+kkCeB1ZPsELo7J5y2R55AcOw="
 
 matrix:
   include:
@@ -33,17 +32,6 @@ matrix:
       - HDF5_DIR=$HDF5_CACHE_DIR/$HDF5_VERSION
       - H5PY_ENFORCE_COVERAGE=yes
       os: linux-ppc64le
-
-    # Builds the API docs
-    - python: 3.8
-      env:
-        - TOXENV=apidocs
-        - HDF5_VERSION=1.10.5
-        - HDF5_DIR=$HDF5_CACHE_DIR/$HDF5_VERSION
-      script:
-        - tox
-        - pip install doctr
-        - doctr deploy . --built-docs docs_api/_build/html
 
 before_install:
   # - export PATH=/usr/lib/ccache:$PATH


### PR DESCRIPTION
Part of moving CI away from Travis, issue #1733. Github actions is the obvious choice for this, since it is published to Github pages.

Like the previous set-up, it should build the docs for pull requests, so we can check they're not broken, but only publish them on changes in master.