### PR TITLE
Deprecate setting default_file_mode to values other than 'r'

### DIFF
--- a/h5py/h5.pyx
+++ b/h5py/h5.pyx
@@ -10,8 +10,10 @@
 
 include "config.pxi"
 
+from warnings import warn
 from .defs cimport *
 from ._objects import phil, with_phil
+from .h5py_warnings import H5pyDeprecationWarning
 
 ITER_INC    = H5_ITER_INC     # Increasing order
 ITER_DEC    = H5_ITER_DEC     # Decreasing order
@@ -160,6 +162,11 @@ cdef class H5PYConfig:
 
         def __set__(self, val):
             if val in {'r', 'r+', 'x', 'w-', 'w', 'a'}:
+                if val != 'r':
+                    warn("Using default_file_mode other than 'r' is deprecated. "
+                         "Pass the mode to h5py.File() instead.",
+                         category=H5pyDeprecationWarning,
+                    )
                 self._default_file_mode = val
             else:
                 raise ValueError("Invalid mode; must be one of r, r+, w, w-, x, a")

--- a/news/default-file-mode-r.rst
+++ b/news/default-file-mode-r.rst
@@ -1,0 +1,30 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* Setting the config option ``default_file_mode`` to values other than ``'r'``
+  is deprecated. Pass the desired mode when opening a :class:`~.File` instead.
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
This config option was added to help people transition to h5py 3.0, where the default file mode changed to read-only.

In h5py 2.x, opening a file without specifying a mode (`h5py.File('foo.h5')`) would try to guess based on whether the file existed and what permissions you had. From 2.10 (#1143), this issued a warning that the default in h5py 3.0 would be read-only. We added this option as a way for people to silence the warning when they couldn't change the code opening the file, by setting an appropriate file mode externally.

This was intended as a temporary feature to help with the transition, not a permanent part of the API. It is clearly better to pass the mode where the file is opened, rather than modifying global state. This is the first step towards getting rid of it:

1. Setting the default to anything other than `'r'` (which is the default since 3.0 anyway) warns
2. Setting the default to `'r'` warns, and to anything else is an error
3. Remove the `default_file_mode` option