### PR TITLE
Fix chunk_iter mistake

### DIFF
--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -185,10 +185,10 @@ shape for you::
 Auto-chunking is also enabled when using compression or ``maxshape``, etc.,
 if a chunk shape is not manually specified.
 
-The chunk_iter method returns an iterator that can be used to perform chunk by chunk
+The iter_chunks method returns an iterator that can be used to perform chunk by chunk
 reads or writes::
 
-    >>> for s in dset.chunk_iter():
+    >>> for s in dset.iter_chunks():
     >>>     arr = dset[s]  # get numpy array for chunk
 
 


### PR DESCRIPTION
I only fixed a typo in an .rst docs file and believe tests are not necessary in this case.

<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->
