### PR TITLE
Fix read_direct when source and destination have different shapes

### DIFF
--- a/.authors.yml
+++ b/.authors.yml
@@ -850,7 +850,9 @@
   first_commit: 2020-11-06 23:32:13
   github: uellue
 - name: Bruce Merry
-  email: 1963944+bmerry@users.noreply.github.com
+  email: bmerry@ska.ac.za
+  alternate_emails:
+    - 1963944+bmerry@users.noreply.github.com
   num_commit: 1
   first_commit: 2021-01-18 09:30:28
   github: bmerry

--- a/.authors.yml
+++ b/.authors.yml
@@ -850,7 +850,7 @@
   first_commit: 2020-11-06 23:32:13
   github: uellue
 - name: Bruce Merry
-  email: bmerry@ska.ac.za
+  email: 1963944+bmerry@users.noreply.github.com
   num_commit: 1
   first_commit: 2021-01-18 09:30:28
   github: bmerry

--- a/.authors.yml
+++ b/.authors.yml
@@ -849,3 +849,8 @@
   num_commit: 2
   first_commit: 2020-11-06 23:32:13
   github: uellue
+- name: Bruce Merry
+  email: bmerry@ska.ac.za
+  num_commit: 1
+  first_commit: 2021-01-18 09:30:28
+  github: bmerry

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -986,7 +986,7 @@ class Dataset(HLObject):
             if source_sel is None:
                 source_sel = sel.SimpleSelection(source.shape)
             else:
-                source_sel = sel.select(source.shape, source_sel, self)  # for numpy.s_
+                source_sel = sel.select(source.shape, source_sel)  # for numpy.s_
             mspace = source_sel.id
 
             if dest_sel is None:

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -967,7 +967,7 @@ class Dataset(HLObject):
             if dest_sel is None:
                 dest_sel = sel.SimpleSelection(dest.shape)
             else:
-                dest_sel = sel.select(dest.shape, dest_sel, self)
+                dest_sel = sel.select(dest.shape, dest_sel)
 
             for mspace in dest_sel.broadcast(source_sel.mshape):
                 self.id.read(mspace, fspace, dest, dxpl=self._dxpl)

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -259,29 +259,43 @@ class TestReadDirectly:
         with pytest.raises(TypeError):
             dset.read_direct(arr)
 
-class TestWriteDirectly(BaseDataset):
+class TestWriteDirectly:
 
     """
         Feature: Write Numpy array directly into Dataset
     """
 
-    def test_write_direct(self):
-        dset = self.f.create_dataset('dset', (100,), dtype='int32')
-        empty_dset = self.f.create_dataset("edset", dtype='int64')
-        arr = np.ones((100,))
-        arr2 = np.ones((200,))
+    @pytest.mark.parametrize(
+        'source_shape,dest_shape,source_sel,dest_sel',
+        [
+            ((100,), (100,), np.s_[0:10], np.s_[50:60]),
+            ((70,), (100,), np.s_[50:60], np.s_[90:]),
+            ((30, 10), (20, 20), np.s_[:20, :], np.s_[:, :10])
+        ])
+    def test_write_direct(self, writable_file, source_shape, dest_shape, source_sel, dest_sel):
+        dset = writable_file.create_dataset('dset', dest_shape, dtype='int32', fillvalue=-1)
+        arr = np.arange(np.product(source_shape)).reshape(source_shape)
+        expected = np.full(dest_shape, -1, dtype='int32')
+        expected[dest_sel] = arr[source_sel]
+        dset.write_direct(arr, source_sel, dest_sel)
+        np.testing.assert_array_equal(dset[:], expected)
 
-        # write into empty dataset
-        with self.assertRaises(TypeError):
-            empty_dset.write_direct(arr, np.s_[0:10], np.s_[50:60])
+    def test_empty(self, writable_file):
+        empty_dset = writable_file.create_dataset("edset", dtype='int64')
+        with pytest.raises(TypeError):
+            empty_dset.write_direct(np.ones((100,)), np.s_[0:10], np.s_[50:60])
 
-        dset.write_direct(arr2, np.s_[0:10], np.s_[50:60])
-        for e in dset[50:60]:
-            self.assertEqual(e, 1)
+    def test_wrong_shape(self, writable_file):
+        dset = writable_file.create_dataset("dset", (100,), dtype='int64')
+        arr = np.ones((200,))
+        with pytest.raises(TypeError):
+            dset.write_direct(arr)
 
-        # Can't broadcast from dset shape (100,) to arr2 shape (200,)
-        with self.assertRaises(TypeError):
-            dset.write_direct(arr2)
+    def test_not_c_contiguous(self, writable_file):
+        dset = writable_file.create_dataset("dset", (10, 10), dtype='int64')
+        arr = np.ones((10, 10), order='F')
+        with pytest.raises(TypeError):
+            dset.write_direct(arr)
 
 
 class TestCreateRequire(BaseDataset):

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -212,53 +212,51 @@ class TestCreateData(BaseDataset):
             self.f.create_dataset('bar', shape=4, data= np.arange(3))
 
 
-class TestReadDirectly(BaseDataset):
+class TestReadDirectly:
 
     """
         Feature: Read data directly from Dataset into a Numpy array
     """
 
-    def _test(self, dset_shape, out_shape, source_sel, dest_sel):
-        dset_values = np.arange(np.product(dset_shape), dtype='int64').reshape(dset_shape)
-        dset = self.f.create_dataset("dset", dset_shape, data=dset_values)
-        arr = np.full(out_shape, -1)
+    @pytest.mark.parametrize(
+        'source_shape,dest_shape,source_sel,dest_sel',
+        [
+            ((100,), (100,), np.s_[0:10], np.s_[50:60]),
+            ((70,), (100,), np.s_[50:60], np.s_[90:]),
+            ((30, 10), (20, 20), np.s_[:20, :], np.s_[:, :10])
+        ])
+    def test_read_direct(self, writable_file, source_shape, dest_shape, source_sel, dest_sel):
+        source_values = np.arange(np.product(source_shape), dtype="int64").reshape(source_shape)
+        dset = writable_file.create_dataset("dset", source_shape, data=source_values)
+        arr = np.full(dest_shape, -1, dtype="int64")
         expected = arr.copy()
-        expected[dest_sel] = dset_values[source_sel]
+        expected[dest_sel] = source_values[source_sel]
 
         dset.read_direct(arr, source_sel, dest_sel)
         np.testing.assert_array_equal(arr, expected)
 
-    def test_read_direct_1d_simple(self):
-        self._test((100,), (100,), np.s_[0:10], np.s_[50:60])
-
-    def test_read_direct_1d_open_slice(self):
-        self._test((70,), (100,), np.s_[50:60], np.s_[90:])
-
-    def test_read_direct_2d(self):
-        self._test((30, 10), (20, 20), np.s_[:20, :], np.s_[:, :10])
-
-    def test_read_direct_no_sel(self):
-        dset = self.f.create_dataset("dset", (10,), data=np.arange(10, dtype="int64"))
+    def test_no_sel(self, writable_file):
+        dset = writable_file.create_dataset("dset", (10,), data=np.arange(10, dtype="int64"))
         arr = np.ones((10,), dtype="int64")
         dset.read_direct(arr)
         np.testing.assert_array_equal(arr, np.arange(10, dtype="int64"))
 
-    def test_read_empty(self):
-        empty_dset = self.f.create_dataset("edset", dtype='int64')
+    def test_empty(self, writable_file):
+        empty_dset = writable_file.create_dataset("edset", dtype='int64')
         arr = np.ones((100,), 'int64')
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             empty_dset.read_direct(arr, np.s_[0:10], np.s_[50:60])
 
-    def test_read_wrong_shape(self):
-        dset = self.f.create_dataset("dset", (100,), dtype='int64')
+    def test_wrong_shape(self, writable_file):
+        dset = writable_file.create_dataset("dset", (100,), dtype='int64')
         arr = np.ones((200,))
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             dset.read_direct(arr)
 
-    def test_not_c_contiguous(self):
-        dset = self.f.create_dataset("dset", (10, 10), dtype='int64')
+    def test_not_c_contiguous(self, writable_file):
+        dset = writable_file.create_dataset("dset", (10, 10), dtype='int64')
         arr = np.ones((10, 10), order='F')
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             dset.read_direct(arr)
 
 class TestWriteDirectly(BaseDataset):

--- a/news/read-direct-fix.rst
+++ b/news/read-direct-fix.rst
@@ -1,0 +1,29 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* Fix ``read_direct`` when the source and destination have different shapes.
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>

--- a/news/read-write-direct-fix.rst
+++ b/news/read-write-direct-fix.rst
@@ -16,7 +16,8 @@ Exposing HDF5 functions
 Bug fixes
 ---------
 
-* Fix ``read_direct`` when the source and destination have different shapes.
+* Fix :meth:`.DataSet.read_direct` and :meth:`.DataSet.write_direct` when the
+  source and destination have different shapes.
 
 Building h5py
 -------------


### PR DESCRIPTION
Also strengthened the unit tests to pick up the bug and check a few
other conditions.

Closes #1773 and #1792.