### PR TITLE
FIX: make sure we explicitly close attrs rather than relying on gc

### DIFF
--- a/h5py/_hl/attrs.py
+++ b/h5py/_hl/attrs.py
@@ -215,6 +215,8 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
                         attr.close()
                         h5a.delete(self._id, self._e(tempname))
                         raise
+                finally:
+                    attr.close()
 
     def modify(self, name, value):
         """ Change the value of an attribute while preserving its type.

--- a/h5py/_hl/attrs.py
+++ b/h5py/_hl/attrs.py
@@ -193,30 +193,26 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
 
             tempname = uuid.uuid4().hex
 
+            attr = h5a.create(self._id, self._e(tempname), htype, space)
             try:
-                attr = h5a.create(self._id, self._e(tempname), htype, space)
+                if not isinstance(data, Empty):
+                    attr.write(data, mtype=htype2)
             except:
+                attr.close()
+                h5a.delete(self._id, self._e(tempname))
                 raise
             else:
                 try:
-                    if not isinstance(data, Empty):
-                        attr.write(data, mtype=htype2)
+                    # No atomic rename in HDF5 :(
+                    if h5a.exists(self._id, self._e(name)):
+                        h5a.delete(self._id, self._e(name))
+                    h5a.rename(self._id, self._e(tempname), self._e(name))
                 except:
                     attr.close()
                     h5a.delete(self._id, self._e(tempname))
                     raise
-                else:
-                    try:
-                        # No atomic rename in HDF5 :(
-                        if h5a.exists(self._id, self._e(name)):
-                            h5a.delete(self._id, self._e(name))
-                        h5a.rename(self._id, self._e(tempname), self._e(name))
-                    except:
-                        attr.close()
-                        h5a.delete(self._id, self._e(tempname))
-                        raise
-                finally:
-                    attr.close()
+            finally:
+                attr.close()
 
     def modify(self, name, value):
         """ Change the value of an attribute while preserving its type.


### PR DESCRIPTION
See #1591 (doesn't apparently fix all issues)

<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->
