### PR TITLE
setup_build.py: avoid absolute path

### DIFF
--- a/setup_build.py
+++ b/setup_build.py
@@ -21,7 +21,7 @@ from setup_configure import BuildConfig
 
 
 def localpath(*args):
-    return op.abspath(op.join(op.dirname(__file__), *args))
+    return op.join(*args)
 
 
 MODULES = ['defs', '_errors', '_objects', '_proxy', 'h5fd', 'h5z',


### PR DESCRIPTION
Prevent absolute path from ending up in the egg-info SOURCES.txt.

Signed-off-by: Mingli Yu <mingli.yu@windriver.com>

<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->
