### PR TITLE
Warn when swmr=True is passed with mode!='r'

### DIFF
--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -13,6 +13,7 @@
 
 import sys
 import os
+from warnings import warn
 
 from .compat import filename_decode, filename_encode
 
@@ -428,6 +429,13 @@ class File(Group):
 
             if fs_strategy and mode not in ('w', 'w-', 'x'):
                 raise ValueError("Unable to set file space strategy of an existing file")
+
+            if swmr and mode != 'r':
+                warn(
+                    "swmr=True only affects read ('r') mode. For swmr write "
+                    "mode, set f.swmr_mode = True after opening the file.",
+                    stacklevel=2,
+                )
 
             with phil:
                 fapl = make_fapl(driver, libver, rdcc_nslots, rdcc_nbytes, rdcc_w0, **kwds)


### PR DESCRIPTION
The `h5py.File(..., swmr=True)` option is only used in 'r' (read-only) mode, and currently silently ignored with any other mode. There's a separate API for starting SWMR write mode (`f.swmr_mode=True`). This is liable to cause confusion if people think they're using SWMR when they're not (as in #1807).

This adds a warning when you pass `swmr=True` and mode other than `'r'`. In the future, it may become an error, but this gives people a chance to fix their code without breaking things that currently work.