### PR TITLE
Allow H5PY_TEST_CHECK_FILTERS environment variable into tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,7 @@ changedir =
     test: {toxworkdir}
 passenv =
     H5PY_SYSTEM_LZF
+    H5PY_TEST_CHECK_FILTERS
     HDF5_DIR
     HDF5_VERSION
     HDF5_INCLUDEDIR


### PR DESCRIPTION
I just noticed that the `test_filters_available` wasn't running where it was meant to on CI, and I think this was why. It's meant to verify that wheels have been built with gzip & lzf filters on all platforms.