### PR TITLE
Create appropriate exception types when the exception message has errno

### DIFF
--- a/h5py/_errors.pyx
+++ b/h5py/_errors.pyx
@@ -141,9 +141,9 @@ cdef int set_exception() except -1:
     # so that the traceback doesn't point here.
 
     m = re.search(b'errno\s*=\s*(\d+)', desc_bottom)
-    if m:
-        # An errno was found in the message. Python can automatically create
-        # the appropriate OSError subclass (e.g. FileNotFoundError) from this.
+    if m and eclass is OSError:
+        # Python can automatically create an appropriate OSError subclass
+        # (e.g. FileNotFoundError) given the POSIX errno (e.g. ENOENT)
         errno = int(m.group(1))
         PyErr_SetObject(OSError, (errno, msg.decode('utf-8', 'replace')))
     else:

--- a/h5py/_errors.pyx
+++ b/h5py/_errors.pyx
@@ -14,28 +14,28 @@ from cpython cimport PyErr_Occurred, PyErr_SetObject
 import re
 
 _minor_table = {
-    H5E_SEEKERROR:      IOError,    # Seek failed
-    H5E_READERROR:      IOError,    # Read failed
-    H5E_WRITEERROR:     IOError,    # Write failed
-    H5E_CLOSEERROR:     IOError,    # Close failed
-    H5E_OVERFLOW:       IOError,    # Address overflowed
-    H5E_FCNTL:          IOError,    # File control (fcntl) failed
+    H5E_SEEKERROR:      OSError,    # Seek failed
+    H5E_READERROR:      OSError,    # Read failed
+    H5E_WRITEERROR:     OSError,    # Write failed
+    H5E_CLOSEERROR:     OSError,    # Close failed
+    H5E_OVERFLOW:       OSError,    # Address overflowed
+    H5E_FCNTL:          OSError,    # File control (fcntl) failed
 
-    H5E_FILEEXISTS:     IOError,    # File already exists
-    H5E_FILEOPEN:       IOError,    # File already open
-    H5E_CANTCREATE:     IOError,    # Unable to create file
-    H5E_CANTOPENFILE:   IOError,    # Unable to open file
-    H5E_CANTCLOSEFILE:  IOError,    # Unable to close file
-    H5E_NOTHDF5:        IOError,    # Not an HDF5 file
+    H5E_FILEEXISTS:     OSError,    # File already exists
+    H5E_FILEOPEN:       OSError,    # File already open
+    H5E_CANTCREATE:     OSError,    # Unable to create file
+    H5E_CANTOPENFILE:   OSError,    # Unable to open file
+    H5E_CANTCLOSEFILE:  OSError,    # Unable to close file
+    H5E_NOTHDF5:        OSError,    # Not an HDF5 file
     H5E_BADFILE:        ValueError, # Bad file ID accessed
-    H5E_TRUNCATED:      IOError,    # File has been truncated
-    H5E_MOUNT:          IOError,    # File mount error
+    H5E_TRUNCATED:      OSError,    # File has been truncated
+    H5E_MOUNT:          OSError,    # File mount error
 
-    H5E_NOFILTER:       IOError,    # Requested filter is not available
-    H5E_CALLBACK:       IOError,    # Callback failed
-    H5E_CANAPPLY:       IOError,    # Error from filter 'can apply' callback
-    H5E_SETLOCAL:       IOError,    # Error from filter 'set local' callback
-    H5E_NOENCODER:      IOError,    # Filter present but encoding disabled
+    H5E_NOFILTER:       OSError,    # Requested filter is not available
+    H5E_CALLBACK:       OSError,    # Callback failed
+    H5E_CANAPPLY:       OSError,    # Error from filter 'can apply' callback
+    H5E_SETLOCAL:       OSError,    # Error from filter 'set local' callback
+    H5E_NOENCODER:      OSError,    # Filter present but encoding disabled
 
     H5E_BADATOM:        ValueError,  # Unable to find atom information (already closed?)
     H5E_BADGROUP:       ValueError,  # Unable to find ID group information
@@ -65,9 +65,9 @@ _minor_table = {
 # of the minor error codes.  If a (major, minor) entry appears here,
 # it will override any entry in the minor error table.
 _exact_table = {
-    (H5E_CACHE, H5E_BADVALUE):      IOError,  # obj create w/o write intent 1.8
-    (H5E_RESOURCE, H5E_CANTINIT):   IOError,  # obj create w/o write intent 1.6
-    (H5E_INTERNAL, H5E_SYSERRSTR):  IOError,  # e.g. wrong file permissions
+    (H5E_CACHE, H5E_BADVALUE):      OSError,  # obj create w/o write intent 1.8
+    (H5E_RESOURCE, H5E_CANTINIT):   OSError,  # obj create w/o write intent 1.6
+    (H5E_INTERNAL, H5E_SYSERRSTR):  OSError,  # e.g. wrong file permissions
     (H5E_DATATYPE, H5E_CANTINIT):   TypeError,  # No conversion path
     (H5E_DATASET, H5E_CANTINIT):    ValueError, # bad param for dataset setup
     (H5E_ARGS, H5E_CANTINIT):       TypeError,  # Illegal operation on object

--- a/h5py/_hl/attrs.py
+++ b/h5py/_hl/attrs.py
@@ -232,7 +232,7 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
                 attr = h5a.open(self._id, self._e(name))
 
                 if is_empty_dataspace(attr):
-                    raise IOError("Empty attributes can't be modified")
+                    raise OSError("Empty attributes can't be modified")
 
                 # If the input data is already an array, let HDF5 do the conversion.
                 # If it's a list or similar, don't make numpy guess a dtype for it.

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -204,7 +204,7 @@ def make_fid(name, mode, userblock_size, fapl, fcpl=None, swmr=False):
         # existing one (ACC_EXCL)
         try:
             fid = h5f.open(name, h5f.ACC_RDWR, fapl=fapl)
-        except IOError:
+        except OSError:
             fid = h5f.create(name, h5f.ACC_EXCL, fapl=fapl, fcpl=fcpl)
     else:
         raise ValueError("Invalid mode; must be one of r, r+, w, w-, x, a")

--- a/h5py/tests/test_dataset_getitem.py
+++ b/h5py/tests/test_dataset_getitem.py
@@ -77,11 +77,9 @@ class TestEmpty(TestCase):
         self.assertEqual(self.dset.nbytes, 0)
 
     def test_ellipsis(self):
-        """ Ellipsis -> ValueError """
         self.assertEqual(self.dset[...], self.empty_obj)
 
     def test_tuple(self):
-        """ () -> IOError """
         self.assertEqual(self.dset[()], self.empty_obj)
 
     def test_slice(self):

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -38,7 +38,7 @@ class TestFileOpen(TestCase):
         fname = self.mktemp()
 
         # No existing file; error
-        with pytest.raises(OSError):
+        with pytest.raises(FileNotFoundError):
             with File(fname):
                 pass
 
@@ -77,7 +77,7 @@ class TestFileOpen(TestCase):
         fid = File(fname, 'w-')
         self.assertTrue(fid)
         fid.close()
-        with self.assertRaises(IOError):
+        with self.assertRaises(FileExistsError):
             File(fname, 'w-')
 
     def test_append(self):
@@ -125,9 +125,9 @@ class TestFileOpen(TestCase):
     def test_nonexistent_file(self):
         """ Modes 'r' and 'r+' do not create files """
         fname = self.mktemp()
-        with self.assertRaises(IOError):
+        with self.assertRaises(FileNotFoundError):
             File(fname, 'r')
-        with self.assertRaises(IOError):
+        with self.assertRaises(FileNotFoundError):
             File(fname, 'r+')
 
     def test_invalid_mode(self):

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -54,10 +54,10 @@ class TestFileOpen(TestCase):
         finally:
             os.chmod(fname, stat.S_IWRITE)
 
-        # File exists but is not HDF5; raise IOError
+        # File exists but is not HDF5; raise OSError
         with open(fname, 'wb') as f:
             f.write(b'\x00')
-        with self.assertRaises(IOError):
+        with self.assertRaises(OSError):
             File(fname)
 
     def test_create(self):


### PR DESCRIPTION
We agreed with HDF group that the error message format should be stable enough for us to extract the system errno from it (https://github.com/HDFGroup/hdf5/pull/37). This means we can give nicer exceptions, e.g. `FileNotFoundError` when you try to read a file that doesn't exist:

```
In [2]: f = h5py.File('woijkjer')
---------------------------------------------------------------------------
FileNotFoundError                         Traceback (most recent call last)
<ipython-input-2-7afd330b19e3> in <module>
----> 1 f = h5py.File('woijkjer')

~/miniconda3/envs/h5py-dev/lib/python3.7/site-packages/h5py/_hl/files.py in __init__(self, name, mode, driver, libver, userblock_size, swmr, rdcc_nslots, rdcc_nbytes, rdcc_w0, track_order, fs_strategy, fs_persist, fs_threshold, **kwds)
    435                                fapl, fcpl=make_fcpl(track_order=track_order, fs_strategy=fs_strategy,
    436                                fs_persist=fs_persist, fs_threshold=fs_threshold),
--> 437                                swmr=swmr)
    438 
    439             if isinstance(libver, tuple):

~/miniconda3/envs/h5py-dev/lib/python3.7/site-packages/h5py/_hl/files.py in make_fid(name, mode, userblock_size, fapl, fcpl, swmr)
    192         if swmr and swmr_support:
    193             flags |= h5f.ACC_SWMR_READ
--> 194         fid = h5f.open(name, flags, fapl=fapl)
    195     elif mode == 'r+':
    196         fid = h5f.open(name, h5f.ACC_RDWR, fapl=fapl)

h5py/_objects.pyx in h5py._objects.with_phil.wrapper()

h5py/_objects.pyx in h5py._objects.with_phil.wrapper()

h5py/h5f.pyx in h5py.h5f.open()

FileNotFoundError: [Errno 2] Unable to open file (unable to open file: name = 'woijkjer', errno = 2, error message = 'No such file or directory', flags = 0, o_flags = 0)
```

I've only exposed the errno and the message we construct from HDF5's error stack. OSError also has a `filename` field which is meant to be the name of the file, if relevant. We could try to fill that as well, but I haven't seen it used nearly as much, and it adds complexity (e.g. undoing the quoting from the message), so I've left it out for now.

I suspect this is technically an API breaking change, as errors that people have previously caught might now be a different type which isn't caught. However, the tests didn't fail, because the most obvious cases switch from the general OSError to more specific subclasses of that. So I think it's reasonable to put it in a 3.x release.

Closes #1133.