### PR TITLE
Fix read_direct & write_direct with integer indices

### DIFF
--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -969,7 +969,7 @@ class Dataset(HLObject):
             else:
                 dest_sel = sel.select(dest.shape, dest_sel)
 
-            for mspace in dest_sel.broadcast(source_sel.mshape):
+            for mspace in dest_sel.broadcast(source_sel.array_shape):
                 self.id.read(mspace, fspace, dest, dxpl=self._dxpl)
 
     def write_direct(self, source, source_sel=None, dest_sel=None):
@@ -994,7 +994,7 @@ class Dataset(HLObject):
             else:
                 dest_sel = sel.select(self.shape, dest_sel, self)
 
-            for fspace in dest_sel.broadcast(source_sel.mshape):
+            for fspace in dest_sel.broadcast(source_sel.array_shape):
                 self.id.write(mspace, fspace, source, dxpl=self._dxpl)
 
     @with_phil

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -223,7 +223,8 @@ class TestReadDirectly:
         [
             ((100,), (100,), np.s_[0:10], np.s_[50:60]),
             ((70,), (100,), np.s_[50:60], np.s_[90:]),
-            ((30, 10), (20, 20), np.s_[:20, :], np.s_[:, :10])
+            ((30, 10), (20, 20), np.s_[:20, :], np.s_[:, :10]),
+            ((5, 7, 9), (6,), np.s_[2, :6, 3], np.s_[:]),
         ])
     def test_read_direct(self, writable_file, source_shape, dest_shape, source_sel, dest_sel):
         source_values = np.arange(np.product(source_shape), dtype="int64").reshape(source_shape)
@@ -270,7 +271,8 @@ class TestWriteDirectly:
         [
             ((100,), (100,), np.s_[0:10], np.s_[50:60]),
             ((70,), (100,), np.s_[50:60], np.s_[90:]),
-            ((30, 10), (20, 20), np.s_[:20, :], np.s_[:, :10])
+            ((30, 10), (20, 20), np.s_[:20, :], np.s_[:, :10]),
+            ((5, 7, 9), (6,), np.s_[2, :6, 3], np.s_[:]),
         ])
     def test_write_direct(self, writable_file, source_shape, dest_shape, source_sel, dest_sel):
         dset = writable_file.create_dataset('dset', dest_shape, dtype='int32', fillvalue=-1)

--- a/h5py/tests/test_h5o.py
+++ b/h5py/tests/test_h5o.py
@@ -4,18 +4,18 @@ from .common import TestCase
 from h5py import File
 
 
-class TestException(Exception):
+class SampleException(Exception):
     pass
 
 def throwing(name, obj):
     print(name, obj)
-    raise TestException("throwing exception")
+    raise SampleException("throwing exception")
 
 class TestVisit(TestCase):
     def test_visit(self):
         fname = self.mktemp()
         fid = File(fname, 'w')
         fid.create_dataset('foo', (100,), dtype='uint8')
-        with pytest.raises(TestException, match='throwing exception'):
+        with pytest.raises(SampleException, match='throwing exception'):
             fid.visititems(throwing)
         fid.close()


### PR DESCRIPTION
Thanks @bmerry for providing a simple test case for this, which I've included here.

`sel.array_shape` drops dimensions where the selection uses scalar indexing, which is what we want here. `sel.mshape` keeps those dimensions, because HDF5 has no concept of scalar indexing, so indexing `5` has to be handled more like `5:6`.

Along the way, I also renamed an exception class in the tests to squash an annoying warning (pytest was seeing the TestException class as a potential test).