### PR TITLE
Fix reading data with vlen array of fixed-length strings

### DIFF
--- a/h5py/_conv.pyx
+++ b/h5py/_conv.pyx
@@ -831,7 +831,7 @@ cdef int conv_ndarray2vlen(void* ipt,
     buf_obj0 = buf_obj[0]
     ndarray = <cnp.ndarray> buf_obj0
     len = ndarray.shape[0]
-    nbytes = len * max(H5Tget_size(outtype.id), H5Tget_size(outtype.id))
+    nbytes = len * max(H5Tget_size(outtype.id), H5Tget_size(intype.id))
 
     data = emalloc(nbytes)
 

--- a/h5py/_conv.pyx
+++ b/h5py/_conv.pyx
@@ -711,8 +711,8 @@ cdef int conv_vlen2ndarray(void* ipt,
     data = in_vlen0.ptr = in_vlen[0].ptr
 
     dims[0] = size
-    itemsize = outtype.get_size()
-    if itemsize > intype.get_size():
+    itemsize = H5Tget_size(outtype.id)
+    if itemsize > H5Tget_size(intype.id):
         data = realloc(data, itemsize * size)
     H5Tconvert(intype.id, outtype.id, size, data, NULL, H5P_DEFAULT)
 
@@ -831,7 +831,7 @@ cdef int conv_ndarray2vlen(void* ipt,
     buf_obj0 = buf_obj[0]
     ndarray = <cnp.ndarray> buf_obj0
     len = ndarray.shape[0]
-    nbytes = len * max(outtype.get_size(), intype.get_size())
+    nbytes = len * max(H5Tget_size(outtype.id), H5Tget_size(outtype.id))
 
     data = emalloc(nbytes)
 

--- a/h5py/_conv.pyx
+++ b/h5py/_conv.pyx
@@ -28,6 +28,7 @@ cfg = get_config()
 cimport numpy as cnp
 from numpy cimport npy_intp, NPY_WRITEABLE, NPY_C_CONTIGUOUS, NPY_OWNDATA
 cnp._import_array()
+import numpy as np
 
 from cpython.buffer cimport (
     PyObject_GetBuffer, PyBuffer_ToContiguous, PyBuffer_Release, PyBUF_INDIRECT
@@ -699,6 +700,7 @@ cdef int conv_vlen2ndarray(void* ipt,
         int flags = NPY_WRITEABLE | NPY_C_CONTIGUOUS | NPY_OWNDATA
         npy_intp dims[1]
         void* data
+        cdef char[:] buf
         cnp.ndarray ndarray
         PyObject* ndarray_obj
         vlen_t in_vlen0
@@ -714,7 +716,16 @@ cdef int conv_vlen2ndarray(void* ipt,
         data = realloc(data, itemsize * size)
     H5Tconvert(intype.id, outtype.id, size, data, NULL, H5P_DEFAULT)
 
-    ndarray = cnp.PyArray_SimpleNewFromData(1, dims, elem_dtype.num, data)
+    if elem_dtype.kind in b"biufcmMO":
+        # type_num is enough to create an array for these dtypes
+        ndarray = cnp.PyArray_SimpleNewFromData(1, dims, elem_dtype.type_num, data)
+    else:
+        # dtypes like string & void need a size specified, so can't be used with
+        # SimpleNewFromData. Cython doesn't expose NumPy C-API functions
+        # like NewFromDescr, so we'll construct this with a Python function.
+        buf = <char[:itemsize * size]> data
+        ndarray = np.frombuffer(buf, dtype=elem_dtype)
+
     PyArray_ENABLEFLAGS(ndarray, flags)
     ndarray_obj = <PyObject*>ndarray
 

--- a/h5py/tests/test_attrs.py
+++ b/h5py/tests/test_attrs.py
@@ -229,6 +229,15 @@ class TestVlen(BaseAttrs):
         self.f.attrs['a'] = a
         self.assertArrayEqual(self.f.attrs['a'][0], a[0])
 
+    def test_vlen_s1(self):
+        dt = h5py.vlen_dtype(np.dtype('S1'))
+        a = np.empty((1,), dtype=dt)
+        a[0] = np.array([b'a', b'b'], dtype='S1')
+
+        self.f.attrs.create('test', a)
+        self.assertArrayEqual(self.f.attrs['test'][0], a[0])
+
+
 class TestTrackOrder(BaseAttrs):
     def fill_attrs(self, track_order):
         attrs = self.f.create_group('test', track_order=track_order).attrs


### PR DESCRIPTION
I think this regressed due to #1406, where we used NumPy functions as exposed by Cython, rather than exposing them at the C level ourselves.

Closes #1817
Closes #1742