### PR TITLE
Add some missing news entries

### DIFF
--- a/news/read-vlen-array-s1.rst
+++ b/news/read-vlen-array-s1.rst
@@ -1,0 +1,30 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* Fix reading data with a datatype of variable-length arrays of fixed length
+  strings (:issue:`1817`).
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>

--- a/news/read-write-direct-w-index.rst
+++ b/news/read-write-direct-w-index.rst
@@ -1,0 +1,31 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* Fix selecting data using integer indices in :meth:`.DataSet.read_direct`
+  and :meth:`.DataSet.write_direct`.
+
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
PRs #1818 and #1819 should have had news entries, but I forgot.

I'll likely merge this myself once CI has run (not that it should affect CI).