### PR TITLE
Fail fast in dev-install.sh when build fails

### DIFF
--- a/dev-install.sh
+++ b/dev-install.sh
@@ -2,5 +2,7 @@
 # This disables the mechanisms to find and install build dependencies, so you
 # need to already have those (Cython, pkgconfig, numpy & optionally mpi4py) installed
 # in the current environment.
+set -e
+
 H5PY_SETUP_REQUIRES=0 python3 setup.py build
 python3 -m pip install . --no-build-isolation


### PR DESCRIPTION
I forgot shell scripting 101... If `setup.py build` fails, it should stop immediately, rather than trying to install with pip, which makes the primary error less obvious.