### PR TITLE
Deprecate setting default_file_mode, only allow setting to 'r'

### DIFF
--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -315,7 +315,7 @@ class File(Group):
         else:
             raise RuntimeError('SWMR support is not available in HDF5 version {}.{}.{}.'.format(*hdf5_version))
 
-    def __init__(self, name, mode=None, driver=None,
+    def __init__(self, name, mode='r', driver=None,
                  libver=None, userblock_size=None, swmr=False,
                  rdcc_nslots=None, rdcc_nbytes=None, rdcc_w0=None,
                  track_order=None, fs_strategy=None, fs_persist=False, fs_threshold=1,
@@ -424,8 +424,6 @@ class File(Group):
 
             if track_order is None:
                 track_order = h5.get_config().track_order
-            if mode is None:
-                mode = h5.get_config().default_file_mode  # default: 'r'
 
             if fs_strategy and mode not in ('w', 'w-', 'x'):
                 raise ValueError("Unable to set file space strategy of an existing file")

--- a/h5py/h5.pyx
+++ b/h5py/h5.pyx
@@ -169,13 +169,18 @@ cdef class H5PYConfig:
             return self._default_file_mode
 
         def __set__(self, val):
-            if val in {'r', 'r+', 'x', 'w-', 'w', 'a'}:
-                if val != 'r':
-                    warn("Using default_file_mode other than 'r' is deprecated. "
-                         "Pass the mode to h5py.File() instead.",
-                         category=H5pyDeprecationWarning,
-                    )
-                self._default_file_mode = val
+            if val == 'r':
+                warn(
+                    "Setting h5py.default_file_mode is deprecated. "
+                    "'r' (read-only) is the default from h5py 3.0.",
+                    category=H5pyDeprecationWarning,
+                )
+            elif val in {'r+', 'x', 'w-', 'w', 'a'}:
+                raise ValueError(
+                    "Using default_file_mode other than 'r' is no longer "
+                    "supported. Pass the mode to h5py.File() instead."
+
+                )
             else:
                 raise ValueError("Invalid mode; must be one of r, r+, w, w-, x, a")
 

--- a/news/deprecate-default-file-mode-2.rst
+++ b/news/deprecate-default-file-mode-2.rst
@@ -1,0 +1,32 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* The ``default_file_mode`` config option is deprecated, and setting it to
+  values other than 'r' (for read-only mode) is no longer allowed. Pass the
+  mode when creating a :class:`.File` object instead of setting a global
+  default.
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
This is step 2 of removing the config option added to ease the transition from 2.x to 3.x:

1. Setting the default to anything other than 'r' (which is the default since 3.0) warns (done in #1789 for h5py 3.2)
2. Setting the default to 'r' warns, and to anything else is an error (this PR)
3. Remove the default_file_mode option

We added the option (and indicated that the default would change) in 2.10 (released September 2019). The default changed to 'r' in 3.0 (October 2020). The warning for setting the default to modes other than 'r' was added in 3.2 (March 2021).

I'm provisionally marking this for 3.3, but I'm happy to leave it longer if people prefer. We could also start error-ing on modes other than r but leave the warning on setting the default to r for later.
