### PR TITLE
Update cibuildwheel to 1.10.0

### DIFF
--- a/ci/azure-pipelines-wheels.yml
+++ b/ci/azure-pipelines-wheels.yml
@@ -33,7 +33,7 @@ steps:
 
 - script: |
     python -m pip install --upgrade pip
-    pip install cibuildwheel==1.6.0
+    pip install cibuildwheel==1.10.0
   displayName: 'Install cibuildwheel'
 
 - script: env

--- a/ci/azure-pipelines-wheels.yml
+++ b/ci/azure-pipelines-wheels.yml
@@ -31,7 +31,8 @@ steps:
       echo ##vso[task.setvariable variable=ZLIB_ROOT]$(build.BinariesDirectory)\zlib-msvc-x64\build\native
     displayName: 'Install nuget dependencies'
 
-- script: |
+- bash: |
+    set -o errexit
     python -m pip install --upgrade pip
     pip install cibuildwheel==1.10.0
   displayName: 'Install cibuildwheel'
@@ -51,7 +52,8 @@ steps:
         ci/get_hdf5_if_needed.sh
       displayName: 'Ensure HDF5'
 
-- script: |
+- bash: |
+    set -o errexit
     cibuildwheel --print-build-identifiers
     cibuildwheel --output-dir wheelhouse .
     python ci/bundle_hdf5_whl.py wheelhouse


### PR DESCRIPTION
I noticed while preparing 3.2 that there have been a few releases of cibuildwheel since we configured it. I don't think we've had any major problems with the wheels, so I finished making that release with cibuildwheel 1.6. But now I'll try using the newer version.

Changelog: https://cibuildwheel.readthedocs.io/en/stable/changelog/