### PR TITLE
Deprecate 'with dset.astype()'

### DIFF
--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -17,12 +17,14 @@ except ImportError:
     from cached_property import cached_property
 import posixpath as pp
 import sys
+from warnings import warn
 
 from threading import local
 
 import numpy
 
 from .. import h5, h5s, h5t, h5r, h5d, h5p, h5fd, h5ds, _selector
+from ..h5py_warnings import H5pyDeprecationWarning
 from .base import HLObject, phil, with_phil, Empty, find_item_type
 from . import filters
 from . import selections as sel
@@ -182,6 +184,11 @@ class AstypeWrapper(object):
 
     def __enter__(self):
         # pylint: disable=protected-access
+        warn(
+            "Using astype() as a context manager is deprecated. "
+            "Slice the returned object instead, like: ds.astype(np.int32)[:10]",
+            category=H5pyDeprecationWarning, stacklevel=2,
+        )
         self._dset._local.astype = self._dtype
         return self
 

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1456,6 +1456,8 @@ class TestAstype(BaseDataset):
         dset[...] = np.arange(100)
 
         with warnings.catch_warnings(record=True) as warn_rec:
+            warnings.simplefilter("always")
+
             with dset.astype('f8'):
                 self.assertArrayEqual(dset[...], np.arange(100, dtype='f8'))
 

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -21,12 +21,14 @@ import sys
 import numpy as np
 import platform
 import pytest
+import warnings
 
 from .common import ut, TestCase
 from .data_files import get_data_file_path
 from h5py import File, Group, Dataset
 from h5py._hl.base import is_empty_dataspace
 from h5py import h5f, h5t
+from h5py.h5py_warnings import H5pyDeprecationWarning
 import h5py
 import h5py._hl.selections as sel
 
@@ -1452,11 +1454,15 @@ class TestAstype(BaseDataset):
     def test_astype_ctx(self):
         dset = self.f.create_dataset('x', (100,), dtype='i2')
         dset[...] = np.arange(100)
-        with dset.astype('f8'):
-            self.assertArrayEqual(dset[...], np.arange(100, dtype='f8'))
 
-        with dset.astype('f4') as f4ds:
-            self.assertArrayEqual(f4ds[...], np.arange(100, dtype='f4'))
+        with warnings.catch_warnings(record=True) as warn_rec:
+            with dset.astype('f8'):
+                self.assertArrayEqual(dset[...], np.arange(100, dtype='f8'))
+
+            with dset.astype('f4') as f4ds:
+                self.assertArrayEqual(f4ds[...], np.arange(100, dtype='f4'))
+
+        assert [w.category for w in warn_rec] == [H5pyDeprecationWarning] * 2
 
     def test_astype_wrapper(self):
         dset = self.f.create_dataset('x', (100,), dtype='i2')

--- a/h5py/tests/test_dtype.py
+++ b/h5py/tests/test_dtype.py
@@ -441,8 +441,7 @@ class TestB8(TestCase):
             # read cast dset and make sure it's equal
             if dtype is None:
                 dtype = arr1.dtype
-            with dset.astype(dtype):
-                arr2 = dset[:]
+            arr2 = dset.astype(dtype)[:]
             self.assertArrayEqual(arr2, arr1.astype(dtype, copy=False))
 
             # read uncast dataset again to ensure nothing changed permanently

--- a/news/deprecate-with-astype.rst
+++ b/news/deprecate-with-astype.rst
@@ -1,0 +1,31 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* Using :meth:`.Dataset.astype` as a context manager (``with dset.astype(t):``)
+  is deprecated. Slice the object returned by astype instead
+  (``data = dset.astype(t)[:10]``). This works from h5py 3.0 onwards.
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
h5py 3.0 introduced the ability to slice an astype wrapper directly (`ds.astype(np.int32)[:]`). I'd like to remove the old pattern of using astype() as a context manager with mutable state, and get rid of the thread-local storage it requires.

Edit: I am happy if we want to give people more time to update to 3.x before adding this warning. We released 3.0 in October 2020. The 3.3 release may be around 6 months after that, depending on how eager we are to do it.