### PR TITLE
Use >= for numpy dep in SETUP_REQUIRES consistently

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ SETUP_REQUIRES = [
     "Cython >=0.29.14; python_version=='3.8'",
     "Cython >=0.29.15; python_version>='3.9'",
 ] + [
-    f"numpy =={np_min}; python_version{py_condition}"
+    f"numpy >={np_min}; python_version{py_condition}"
     for np_min, py_condition in NUMPY_MIN_VERSIONS
 ]
 


### PR DESCRIPTION
The numpy dep uses >= operator in RUN_REQUIRES but == in SETUP_REQUIRES.
This seems like a typo, so update it to use >= consistently.