### PR TITLE
Make file closing and get_obj_ids more robust

### DIFF
--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -460,19 +460,8 @@ class File(Group):
 
                 # Close file-resident objects first, then the files.
                 # Otherwise we get errors in MPI mode.
-                id_list = h5f.get_obj_ids(self.id, ~h5f.OBJ_FILE)
-                file_list = h5f.get_obj_ids(self.id, h5f.OBJ_FILE)
-
-                id_list = [x for x in id_list if h5i.get_file_id(x).id == self.id.id]
-                file_list = [x for x in file_list if h5i.get_file_id(x).id == self.id.id]
-
-                for id_ in id_list:
-                    while id_.valid:
-                        h5i.dec_ref(id_)
-
-                for id_ in file_list:
-                    while id_.valid:
-                        h5i.dec_ref(id_)
+                self.id._close_open_objects(h5f.OBJ_LOCAL | ~h5f.OBJ_FILE)
+                self.id._close_open_objects(h5f.OBJ_LOCAL | h5f.OBJ_FILE)
 
                 self.id.close()
                 _objects.nonlocal_close()

--- a/h5py/h5f.pyx
+++ b/h5py/h5f.pyx
@@ -24,6 +24,7 @@ from .h5ac cimport CacheConfig
 from .utils cimport emalloc, efree
 
 # Python level imports
+import gc
 from . import _objects
 from ._objects import phil, with_phil
 
@@ -270,11 +271,18 @@ def get_obj_ids(object where=OBJ_ALL, int types=H5F_OBJ_ALL):
         obj_list = <hid_t*>emalloc(sizeof(hid_t)*count)
 
         if count > 0: # HDF5 complains that obj_list is NULL, even if count==0
-            H5Fget_obj_ids(where_id, types, count, obj_list)
-            for i in range(count):
-                py_obj_list.append(wrap_identifier(obj_list[i]))
-                # The HDF5 function returns a borrowed reference for each hid_t.
-                H5Iinc_ref(obj_list[i])
+            # Garbage collection might dealloc a Python object & call H5Idec_ref
+            # between getting an HDF5 ID and calling H5Iinc_ref, breaking it.
+            # Disable GC until we have inc_ref'd the IDs to keep them alive.
+            gc.disable()
+            try:
+                H5Fget_obj_ids(where_id, types, count, obj_list)
+                for i in range(count):
+                    py_obj_list.append(wrap_identifier(obj_list[i]))
+                    # The HDF5 function returns a borrowed reference for each hid_t.
+                    H5Iinc_ref(obj_list[i])
+            finally:
+                gc.enable()
 
         return py_obj_list
 

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -796,3 +796,21 @@ class TestROS3:
             assert f
             assert 'mydataset' in f.keys()
             assert f["mydataset"].shape == (100,)
+
+
+def test_close_gc(writable_file):
+    # https://github.com/h5py/h5py/issues/1852
+    for i in range(100):
+        writable_file[str(i)] = []
+
+    filename = writable_file.filename
+    writable_file.close()
+
+    # Ensure that Python's garbage collection doesn't interfere with closing
+    # a file. Try a few times - the problem is not 100% consistent, but
+    # normally showed up on the 1st or 2nd iteration for me. -TAK, 2021
+    for i in range(10):
+        with h5py.File(filename, 'r') as f:
+            refs = [d.id for d in f.values()]
+            refs.append(refs)   # Make a reference cycle so GC is involved
+            del refs  # GC is likely to fire while closing the file

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -686,6 +686,28 @@ class TestCloseInvalidatesOpenObjectIDs(TestCase):
             self.assertFalse(bool(f1.id))
             self.assertFalse(bool(g1.id))
 
+    def test_close_one_handle(self):
+        fname = self.mktemp()
+        with File(fname, 'w') as f:
+            f.create_group('foo')
+
+        f1 = File(fname)
+        f2 = File(fname)
+        g1 = f1['foo']
+        g2 = f2['foo']
+        assert g1.id.valid
+        assert g2.id.valid
+        f1.close()
+        assert not g1.id.valid
+        # Closing f1 shouldn't close f2 or objects belonging to it
+        assert f2.id.valid
+        assert g2.id.valid
+
+        f2.close()
+        assert not f2.id.valid
+        assert not g2.id.valid
+
+
 
 class TestPathlibSupport(TestCase):
 

--- a/news/get-obj-ids-gc.rst
+++ b/news/get-obj-ids-gc.rst
@@ -1,0 +1,33 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* Protect :func:`h5py.h5f.get_obj_ids` against garbage collection invalidating
+  HDF5 IDs while it is retrieving them (:issue:`1852`).
+* Make file closing more robust, including when closing files while the
+  interpreter is shutting down, by using lower-level code to close HDF5 IDs
+  of objects inside the file (:issue:`1495`).
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
This now contains two related changes.

First, temporarily disable garbage collection in `h5py.h5f.get_obj_ids`, so it can't invalidate HDF5 IDs between us retrieving them and calling `H5Iinc_ref` to keep them alive. This fixes #1852.

However, `get_obj_ids` is still a fairly awkward thing to call from `File.close()` - it creates h5py ObjectID objects, which can cause problems at interpreter shutdown, and it increments HDF5 ref counts only to decrement them again. Now it also has to turn garbage collection off and on again. So I moved part of the `File.close` logic into a `FileID._close_open_objects` method, which calls the autogenerated bindings directly and avoids these complexities. This fixes #1495.