### PR TITLE
Raise ValueError when accessing a group like a dataset

### DIFF
--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -202,9 +202,6 @@ class CommonStateObject(object):
             except UnicodeEncodeError:
                 name = name.encode('utf8')
                 coding = h5t.CSET_UTF8
-            except AttributeError:
-                raise ValueError('Accessing a group expects bytes or strings, '
-                                 'not {}'.format(type(name)))
 
         if lcpl:
             return name, get_lcpl(coding)

--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -202,6 +202,9 @@ class CommonStateObject(object):
             except UnicodeEncodeError:
                 name = name.encode('utf8')
                 coding = h5t.CSET_UTF8
+            except AttributeError:
+                raise ValueError('Accessing a group expects bytes or strings, '
+                                 'not {}'.format(type(name)))
 
         if lcpl:
             return name, get_lcpl(coding)

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -284,6 +284,9 @@ class Group(HLObject, MutableMappingHDF5):
             oid = h5r.dereference(name, self.id)
             if oid is None:
                 raise ValueError("Invalid HDF5 object reference")
+        elif not isinstance(name, (bytes, str)):
+            raise TypeError("Accessing a group is done with bytes or str, "
+                            " not {}".format(type(name)))
         else:
             oid = h5o.open(self.id, self._e(name), lapl=self._lapl)
 

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -284,11 +284,11 @@ class Group(HLObject, MutableMappingHDF5):
             oid = h5r.dereference(name, self.id)
             if oid is None:
                 raise ValueError("Invalid HDF5 object reference")
-        elif not isinstance(name, (bytes, str)):
+        elif isinstance(name, (bytes, str)):
+            oid = h5o.open(self.id, self._e(name), lapl=self._lapl)
+        else:
             raise TypeError("Accessing a group is done with bytes or str, "
                             " not {}".format(type(name)))
-        else:
-            oid = h5o.open(self.id, self._e(name), lapl=self._lapl)
 
         otype = h5i.get_type(oid)
         if otype == h5i.GROUP:

--- a/h5py/tests/test_group.py
+++ b/h5py/tests/test_group.py
@@ -278,10 +278,10 @@ class TestOpen(BaseGroup):
         """ Access with non bytes or str types should raise an exception """
         self.f.create_group('group')
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             self.f[0]
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             self.f[...]
 
     # TODO: check that regionrefs also work with __getitem__

--- a/h5py/tests/test_group.py
+++ b/h5py/tests/test_group.py
@@ -274,6 +274,16 @@ class TestOpen(BaseGroup):
         with self.assertRaises(Exception):
             self.f[ref]
 
+    def test_path_type_validation(self):
+        """ Access with non bytes or str types should raise an exception """
+        self.f.create_group('group')
+
+        with self.assertRaises(ValueError):
+            self.f[0]
+
+        with self.assertRaises(ValueError):
+            self.f[...]
+
     # TODO: check that regionrefs also work with __getitem__
 
 class TestRepr(BaseGroup):

--- a/news/fix-1829.rst
+++ b/news/fix-1829.rst
@@ -1,0 +1,29 @@
+New features
+------------
+
+* Validate key types when accessing groups.
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->

Hello,
This PR aims to close #1829 , a request for clearer error messages when accessing a group with non-encodable types.  

When a group is being accessed with something else, such as `...`, then a `ValueError` is raised.  
I've added some tests in a place that seemed reasonable, but I'd need confirmation.

Thanks!
Cyril
