### PR TITLE
[DOC] - Update README link to the HDF5 website

### DIFF
--- a/.authors.yml
+++ b/.authors.yml
@@ -890,6 +890,8 @@
   github: timgates42
 - name: Thomas Donoghue
   email: tdonoghue.research@gmail.com
+  alternate_emails:
+  - tdonoghue@ucsd.edu
   num_commits: 1
   first_commit: 2021-03-15 16:31:00
   github: TomDonoghue

--- a/.authors.yml
+++ b/.authors.yml
@@ -892,7 +892,7 @@
   email: tdonoghue.research@gmail.com
   alternate_emails:
   - tdonoghue@ucsd.edu
-aliases:
+  aliases:
   - Tom Donoghue
   - Tom
   num_commits: 1

--- a/.authors.yml
+++ b/.authors.yml
@@ -888,3 +888,8 @@
   num_commits: 1
   first_commit: 2020-12-29 19:51:32
   github: timgates42
+- name: Thomas Donoghue
+  email: tdonoghue.research@gmail.com
+  num_commits: 1
+  first_commit: 2021-03-15 16:31:00
+  github: TomDonoghue

--- a/.authors.yml
+++ b/.authors.yml
@@ -892,6 +892,9 @@
   email: tdonoghue.research@gmail.com
   alternate_emails:
   - tdonoghue@ucsd.edu
+aliases:
+  - Tom Donoghue
+  - Tom
   num_commits: 1
   first_commit: 2021-03-15 16:31:00
   github: TomDonoghue

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@
 
 HDF5 for Python
 ===============
-`h5py` is a thin, pythonic wrapper around the `HDF5 <https://support.hdfgroup.org/HDF5/>`_, which runs on Python 3 (3.6+).
+`h5py` is a thin, pythonic wrapper around `HDF5 <https://portal.hdfgroup.org/>`_, which runs on Python 3 (3.6+).
 
 Websites
 --------

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,8 @@
 
 HDF5 for Python
 ===============
-`h5py` is a thin, pythonic wrapper around `HDF5 <https://portal.hdfgroup.org/>`_, which runs on Python 3 (3.6+).
+`h5py` is a thin, pythonic wrapper around `HDF5 <https://portal.hdfgroup.org/display/HDF5/>`_,
+which runs on Python 3 (3.6+).
 
 Websites
 --------


### PR DESCRIPTION
This is a quick update to the link to HDF5 which is in the README. 

The current link (https://support.hdfgroup.org/HDF5/) is to an old / no longer supported website. 
I think this link should now go to here: https://portal.hdfgroup.org/

Assuming this update to the link is desired, this PR does so. 