### PR TITLE
TST: Skip problematic datatypes based on their length

### DIFF
--- a/h5py/tests/test_dtype.py
+++ b/h5py/tests/test_dtype.py
@@ -13,8 +13,6 @@ except ImportError:
 
 from .common import ut, TestCase
 
-UNSUPPORTED_LONG_DOUBLE = ('i386', 'i486', 'i586', 'i686', 'ppc64le')
-
 
 class TestVlen(TestCase):
 
@@ -289,13 +287,9 @@ class TestOffsets(TestCase):
                      if (np.issubdtype(f, np.floating) or
                          np.issubdtype(f, np.complexfloating)))
 
-        if platform.machine() in UNSUPPORTED_LONG_DOUBLE:
-            dtype_dset_map = {str(j): d
-                              for j, d in enumerate(dtypes)
-                              if d not in (np.float128, np.complex256)}
-        else:
-            dtype_dset_map = {str(j): d
-                              for j, d in enumerate(dtypes)}
+        dtype_dset_map = {str(j): d
+                          for j, d in enumerate(dtypes)
+                          if d().nbytes in [4, 8, 16, 32]}
 
         fname = self.mktemp()
 


### PR DESCRIPTION
Filter datatypes for tests based on their length rather than keeping
a list of illegal platform+type combinations.  This is more robust
than the previous solution and fixes the test failures with new numpy
versions (1.19.5 is the oldest I have tested) that declare 'float96'
and 'complex192' on i686 rather than 'float128' and 'complex256'.

This fixes the following test failure:

    E       AttributeError: module 'numpy' has no attribute 'float128'

plus, later on (again):

    E   TypeError: Illegal length 24 for complex dtype
