### PR TITLE
Have codecov wait before computing final coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,3 +3,9 @@ coverage:
     project:
       default:
         threshold: 0.5%
+  notify:
+    after_n_builds: 10
+# do not notify until at least 5 builds have been uploaded from the CI pipeline
+# you can also set after_n_builds on comments independently
+comment:
+  after_n_builds: 10


### PR DESCRIPTION
I think the problem with codecov is it does not wait for a sufficient number of the CI jobs to send results before setting the status. I've put 10 (jobs) as the number, we may want to increase it (depending on what's counted, there may be ~20 jobs), but lets see how this goes.
