### PR TITLE
Add bug demo scripts

### DIFF
--- a/other/unterm-generator.py
+++ b/other/unterm-generator.py
@@ -1,0 +1,15 @@
+"""Demonstrated an error garbage collecting an h5py object at Python shutdown
+
+https://github.com/h5py/h5py/issues/1495
+"""
+
+import h5py
+
+def yield_groups(filename):
+    with h5py.File(filename, 'r') as fh:
+        for group in fh:
+            yield group
+
+filename = "file_with_10_groups.hdf5"
+grp_generator = yield_groups(filename)
+next(grp_generator)

--- a/other/vlen_leak.py
+++ b/other/vlen_leak.py
@@ -40,7 +40,7 @@ def make_data(kind):
     if kind is bytes:
         s = b"xx"
     else:
-        s = b"xx".decode('utf8')
+        s = "xx"
 
     dt = h5py.vlen_dtype(kind)
     data = np.array([s*100 for idx in range(1000)])
@@ -80,6 +80,6 @@ if __name__ == '__main__':
     ds_leak()
     print("Unicode test")
     print("============")
-    make_data(unicode)
+    make_data(str)
     attr_leak()
     ds_leak()


### PR DESCRIPTION
I've had this scripts from issue #1495 ~~and #1852~~ hanging around locally, and I only just noticed that there's already a small collection of similar bug-reproduction scripts in `other/`. The bug is fixed now,  but I think it's good to keep the script around to investigate possible similar problems.

This relates to an error on interpreter shutdown, so it's not easy to turn into an automated test.

Edit: I had added a script for #1852 as well, but then I realised I had already turned the same logic into a test, so I removed it again.