### PR TITLE
Add default cast from H5T_NATIVE_B8 to uint8

### DIFF
--- a/.authors.yml
+++ b/.authors.yml
@@ -898,3 +898,8 @@
   num_commits: 1
   first_commit: 2021-03-15 16:31:00
   github: TomDonoghue
+- name: Samuel Dowling
+  email: samuel.dowling@protonmail.com
+  num_commits: 1
+  first_commit: 2021-05-11 10:15:56
+  github: samuel-emrys

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -15,6 +15,7 @@ Fully supported types:
 =========================           ============================================    ================================
 Type                                Precisions                                      Notes
 =========================           ============================================    ================================
+Bitfield                            1, 2, 4 or 8 byte, BE/LE                        Read as unsigned integers
 Integer                             1, 2, 4 or 8 byte, BE/LE, signed/unsigned
 Float                               2, 4, 8, 12, 16 byte, BE/LE
 Complex                             8 or 16 byte, BE/LE                             Stored as HDF5 struct

--- a/h5py/_conv.pyx
+++ b/h5py/_conv.pyx
@@ -972,7 +972,8 @@ cpdef int unregister_converters() except -1:
     H5Tunregister(H5T_PERS_HARD, "boolenum2b8", -1, -1, boolenum2b8)
     H5Tunregister(H5T_PERS_HARD, "b82boolenum", -1, -1, b82boolenum)
 
-    H5Tunregister(H5T_PERS_HARD, "uint2bitfield", -1, -1, uint2bitfield)
-    H5Tunregister(H5T_PERS_HARD, "bitfield2uint", -1, -1, bitfield2uint)
+    # Pass an empty string to unregister all methods that use these functions
+    H5Tunregister(H5T_PERS_HARD, "", -1, -1, uint2bitfield)
+    H5Tunregister(H5T_PERS_HARD, "", -1, -1, bitfield2uint)
 
     return 0

--- a/h5py/_conv.pyx
+++ b/h5py/_conv.pyx
@@ -860,14 +860,14 @@ cdef herr_t boolenum2b8(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata,
     return 0
 
 # =============================================================================
-# B8 to UINT8 routines
+# BITFIELD to UINT routines
 
-cdef herr_t b82uint8(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata,
+cdef herr_t bitfield2uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata,
                      size_t nl, size_t buf_stride, size_t bkg_stride, void *buf_i,
                      void *bkg_i, hid_t dxpl) except -1:
     return 0
 
-cdef herr_t uint82b8(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata,
+cdef herr_t uint2bitfield(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata,
                      size_t nl, size_t buf_stride, size_t bkg_stride, void *buf_i,
                      void *bkg_i, hid_t dxpl) except -1:
     return 0
@@ -915,8 +915,29 @@ cpdef int register_converters() except -1:
     H5Tregister(H5T_PERS_HARD, "boolenum2b8", boolenum, H5T_NATIVE_B8, boolenum2b8)
     H5Tregister(H5T_PERS_HARD, "b82boolenum", H5T_NATIVE_B8, boolenum, b82boolenum)
 
-    H5Tregister(H5T_PERS_HARD, "uint82b8", H5T_NATIVE_UINT8, H5T_NATIVE_B8, uint82b8)
-    H5Tregister(H5T_PERS_HARD, "b82uint8", H5T_NATIVE_B8, H5T_NATIVE_UINT8, b82uint8)
+    H5Tregister(H5T_PERS_HARD, "uint82b8", H5T_STD_U8BE, H5T_STD_B8BE, uint2bitfield)
+    H5Tregister(H5T_PERS_HARD, "b82uint8", H5T_STD_B8BE, H5T_STD_U8BE, bitfield2uint)
+
+    H5Tregister(H5T_PERS_HARD, "uint82b8", H5T_STD_U8LE, H5T_STD_B8LE, uint2bitfield)
+    H5Tregister(H5T_PERS_HARD, "b82uint8", H5T_STD_B8LE, H5T_STD_U8LE, bitfield2uint)
+
+    H5Tregister(H5T_PERS_HARD, "uint162b16", H5T_STD_U16BE, H5T_STD_B16BE, uint2bitfield)
+    H5Tregister(H5T_PERS_HARD, "b162uint16", H5T_STD_B16BE, H5T_STD_U16BE, bitfield2uint)
+
+    H5Tregister(H5T_PERS_HARD, "uint162b16", H5T_STD_U16LE, H5T_STD_B16LE, uint2bitfield)
+    H5Tregister(H5T_PERS_HARD, "b162uint16", H5T_STD_B16LE, H5T_STD_U16LE, bitfield2uint)
+
+    H5Tregister(H5T_PERS_HARD, "uint322b32", H5T_STD_U32BE, H5T_STD_B32BE, uint2bitfield)
+    H5Tregister(H5T_PERS_HARD, "b322uint32", H5T_STD_B32BE, H5T_STD_U32BE, bitfield2uint)
+
+    H5Tregister(H5T_PERS_HARD, "uint322b32", H5T_STD_U32LE, H5T_STD_B32LE, uint2bitfield)
+    H5Tregister(H5T_PERS_HARD, "b322uint32", H5T_STD_B32LE, H5T_STD_U32LE, bitfield2uint)
+
+    H5Tregister(H5T_PERS_HARD, "uint642b64", H5T_STD_U64BE, H5T_STD_B64BE, uint2bitfield)
+    H5Tregister(H5T_PERS_HARD, "b642uint64", H5T_STD_B64BE, H5T_STD_U64BE, bitfield2uint)
+
+    H5Tregister(H5T_PERS_HARD, "uint642b64", H5T_STD_U64LE, H5T_STD_B64LE, uint2bitfield)
+    H5Tregister(H5T_PERS_HARD, "b642uint64", H5T_STD_B64LE, H5T_STD_U64LE, bitfield2uint)
 
     H5Tregister(H5T_PERS_SOFT, "vlen2str", vlstring, pyobj, vlen2str)
     H5Tregister(H5T_PERS_SOFT, "str2vlen", pyobj, vlstring, str2vlen)
@@ -951,7 +972,7 @@ cpdef int unregister_converters() except -1:
     H5Tunregister(H5T_PERS_HARD, "boolenum2b8", -1, -1, boolenum2b8)
     H5Tunregister(H5T_PERS_HARD, "b82boolenum", -1, -1, b82boolenum)
 
-    H5Tunregister(H5T_PERS_HARD, "uint82b8", -1, -1, uint82b8)
-    H5Tunregister(H5T_PERS_HARD, "b82uint8", -1, -1, b82uint8)
+    H5Tunregister(H5T_PERS_SOFT, "uint2bitfield", -1, -1, uint2bitfield)
+    H5Tunregister(H5T_PERS_SOFT, "bitfield2uint", -1, -1, bitfield2uint)
 
     return 0

--- a/h5py/_conv.pyx
+++ b/h5py/_conv.pyx
@@ -972,7 +972,7 @@ cpdef int unregister_converters() except -1:
     H5Tunregister(H5T_PERS_HARD, "boolenum2b8", -1, -1, boolenum2b8)
     H5Tunregister(H5T_PERS_HARD, "b82boolenum", -1, -1, b82boolenum)
 
-    H5Tunregister(H5T_PERS_SOFT, "uint2bitfield", -1, -1, uint2bitfield)
-    H5Tunregister(H5T_PERS_SOFT, "bitfield2uint", -1, -1, bitfield2uint)
+    H5Tunregister(H5T_PERS_HARD, "uint2bitfield", -1, -1, uint2bitfield)
+    H5Tunregister(H5T_PERS_HARD, "bitfield2uint", -1, -1, bitfield2uint)
 
     return 0

--- a/h5py/api_types_hdf5.pxd
+++ b/h5py/api_types_hdf5.pxd
@@ -594,6 +594,9 @@ cdef extern from "hdf5.h":
   # --- Predefined datatypes --------------------------------------------------
 
   cdef hid_t H5T_NATIVE_B8
+  cdef hid_t H5T_NATIVE_B16
+  cdef hid_t H5T_NATIVE_B32
+  cdef hid_t H5T_NATIVE_B64
   cdef hid_t H5T_NATIVE_CHAR
   cdef hid_t H5T_NATIVE_SCHAR
   cdef hid_t H5T_NATIVE_UCHAR

--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -159,6 +159,17 @@ STD_I16BE = lockid(H5T_STD_I16BE)
 STD_I32BE = lockid(H5T_STD_I32BE)
 STD_I64BE = lockid(H5T_STD_I64BE)
 
+# Bitfields
+STD_B8LE = lockid(H5T_STD_B8LE)
+STD_B16LE = lockid(H5T_STD_B16LE)
+STD_B32LE = lockid(H5T_STD_B32LE)
+STD_B64LE = lockid(H5T_STD_B64LE)
+
+STD_B8BE = lockid(H5T_STD_B8BE)
+STD_B16BE = lockid(H5T_STD_B16BE)
+STD_B32BE = lockid(H5T_STD_B32BE)
+STD_B64BE = lockid(H5T_STD_B64BE)
+
 # Unsigned integers
 STD_U8LE  = lockid(H5T_STD_U8LE)
 STD_U16LE = lockid(H5T_STD_U16LE)
@@ -171,12 +182,16 @@ STD_U32BE = lockid(H5T_STD_U32BE)
 STD_U64BE = lockid(H5T_STD_U64BE)
 
 # Native types by bytesize
+NATIVE_B8 = lockid(H5T_NATIVE_B8)
 NATIVE_INT8 = lockid(H5T_NATIVE_INT8)
 NATIVE_UINT8 = lockid(H5T_NATIVE_UINT8)
+NATIVE_B16 = lockid(H5T_NATIVE_B16)
 NATIVE_INT16 = lockid(H5T_NATIVE_INT16)
 NATIVE_UINT16 = lockid(H5T_NATIVE_UINT16)
+NATIVE_B32 = lockid(H5T_NATIVE_B32)
 NATIVE_INT32 = lockid(H5T_NATIVE_INT32)
 NATIVE_UINT32 = lockid(H5T_NATIVE_UINT32)
+NATIVE_B64 = lockid(H5T_NATIVE_B64)
 NATIVE_INT64 = lockid(H5T_NATIVE_INT64)
 NATIVE_UINT64 = lockid(H5T_NATIVE_UINT64)
 NATIVE_FLOAT = lockid(H5T_NATIVE_FLOAT)
@@ -766,21 +781,6 @@ cdef class TypeBitfieldID(TypeID):
     """
         HDF5 bitfield type
     """
-    @with_phil
-    def get_sign(self):
-        """() => INT sign
-
-        Get the "signedness" of the datatype; one of:
-
-        SGN_NONE
-            Unsigned
-
-        SGN_2
-            Signed 2's complement
-        """
-
-        # This will always return SGN_NONE to cast bitfield types to unsigned integer
-        return SGN_NONE
 
     @with_phil
     def get_order(self):
@@ -797,7 +797,7 @@ cdef class TypeBitfieldID(TypeID):
 
         # Translation function for bitfield types
         return np.dtype( _order_map[self.get_order()] +
-                         _sign_map[self.get_sign()] + str(self.get_size()) )
+                         'u' + str(self.get_size()) )
 
 
 cdef class TypeReferenceID(TypeID):

--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -764,7 +764,14 @@ cdef class TypeBitfieldID(TypeID):
     """
         HDF5 bitfield type
     """
-    pass
+    cdef object py_dtype(self):
+        if H5Tequal(self.id, H5T_NATIVE_B8):
+            return np.dtype("u1") # Cast to np.uint8
+        else:
+            raise TypeError(
+                "No NumPy equivelant for {classname} exists".format(
+                classname=self.__class__.__name__)
+            )
 
 cdef class TypeReferenceID(TypeID):
 

--- a/h5py/tests/test_dtype.py
+++ b/h5py/tests/test_dtype.py
@@ -386,7 +386,7 @@ class TestDateTime(TestCase):
                     self.assertEqual(arr.dtype, dset.dtype)
 
 @ut.skipUnless(tables is not None, 'tables is required')
-class TestB8(TestCase):
+class TestBitfield(TestCase):
 
     """
     Test H5T_NATIVE_B8 reading
@@ -466,6 +466,7 @@ class TestB8(TestCase):
 
     def _test_b8(self, arr1, expected_default_cast_dtype, cast_dtype=None):
         path = self.mktemp()
+
         with tables.open_file(path, 'w') as f:
             if arr1.dtype.names:
                 f.create_table('/', 'test', obj=arr1)
@@ -491,6 +492,23 @@ class TestB8(TestCase):
             with dset.astype(cast_dtype):
                 arr3 = dset[:]
             self.assertArrayEqual(arr3, arr1.astype(cast_dtype, copy=False))
+
+    def test_b16_uint16(self):
+        arr1 = np.array(np.arange(10), dtype=np.dtype(np.uint16))
+        path = self.mktemp()
+        with h5py.File(path, 'w') as f:
+            space = h5py.h5s.create_simple(arr1.shape)
+            dset_id = h5py.h5d.create(f.id, b'test', h5py.h5t.STD_B16LE, space)
+            dset = h5py.Dataset(dset_id)
+            dset[:] = arr1
+
+        with h5py.File(path, 'r') as f:
+            dset = f['test']
+            arr2 = dset[:]
+            self.assertArrayEqual(
+                arr2,
+                arr1.astype(np.dtype(np.uint16), copy=False)
+            )
 
 def test_opaque(writable_file):
     # opaque without an h5py tag corresponds to numpy void dtypes

--- a/h5py/tests/test_dtype.py
+++ b/h5py/tests/test_dtype.py
@@ -394,23 +394,59 @@ class TestB8(TestCase):
 
     def test_b8_bool(self):
         arr1 = np.array([False, True], dtype=bool)
-        self._test_b8(arr1)
-        self._test_b8(arr1, dtype=np.uint8)
+        self._test_b8(
+            arr1,
+            expected_default_cast_dtype=np.uint8
+        )
+        self._test_b8(
+            arr1,
+            expected_default_cast_dtype=np.uint8,
+            cast_dtype=np.uint8
+        )
 
     def test_b8_bool_compound(self):
         arr1 = np.array([(False,), (True,)], dtype=np.dtype([('x', '?')]))
-        self._test_b8(arr1)
-        self._test_b8(arr1, dtype=np.dtype([('x', 'u1')]))
+        self._test_b8(
+            arr1,
+            expected_default_cast_dtype=np.dtype([('x', 'u1')])
+        )
+        self._test_b8(
+            arr1,
+            expected_default_cast_dtype=np.dtype([('x', 'u1')]),
+            cast_dtype=np.dtype([('x', 'u1')])
+        )
 
     def test_b8_bool_compound_nested(self):
         arr1 = np.array(
             [(True, (True, False)), (True, (False, True))],
             dtype=np.dtype([('x', '?'), ('y', [('a', '?'), ('b', '?')])]),
         )
-        self._test_b8(arr1)
         self._test_b8(
             arr1,
-            dtype=np.dtype([('x', 'u1'), ('y', [('a', 'u1'), ('b', 'u1')])]),
+            expected_default_cast_dtype=np.dtype(
+                [('x', 'u1'), ('y', [('a', 'u1'), ('b', 'u1')])]
+            )
+        )
+        self._test_b8(
+            arr1,
+            expected_default_cast_dtype=np.dtype(
+                [('x', 'u1'), ('y', [('a', 'u1'), ('b', 'u1')])]
+            ),
+            cast_dtype=np.dtype([('x', 'u1'), ('y', [('a', 'u1'), ('b', 'u1')])]),
+        )
+
+    def test_b8_bool_compound_mixed_types(self):
+        arr1 = np.array(
+            [(True, 0.5), (False, 0.2)], dtype=np.dtype([('x','?'), ('y', '<f8')])
+        )
+        self._test_b8(
+            arr1,
+            expected_default_cast_dtype=np.dtype([('x', 'u1'), ('y', '<f8')])
+        )
+        self._test_b8(
+            arr1,
+            expected_default_cast_dtype=np.dtype([('x', 'u1'), ('y', '<f8')]),
+            cast_dtype=np.dtype([('x', 'u1'), ('y', '<f8')])
         )
 
     def test_b8_bool_array(self):
@@ -418,13 +454,17 @@ class TestB8(TestCase):
             [((True, True, False),), ((True, False, True),)],
             dtype=np.dtype([('x', ('?', (3,)))]),
         )
-        self._test_b8(arr1)
         self._test_b8(
             arr1,
-            dtype=np.dtype([('x', ('?', (3,)))]),
+            expected_default_cast_dtype=np.dtype([('x', ('u1', (3,)))])
+        )
+        self._test_b8(
+            arr1,
+            expected_default_cast_dtype=np.dtype([('x', ('u1', (3,)))]),
+            cast_dtype=np.dtype([('x', ('?', (3,)))]),
         )
 
-    def _test_b8(self, arr1, dtype=None):
+    def _test_b8(self, arr1, expected_default_cast_dtype, cast_dtype=None):
         path = self.mktemp()
         with tables.open_file(path, 'w') as f:
             if arr1.dtype.names:
@@ -435,25 +475,22 @@ class TestB8(TestCase):
         with h5py.File(path, 'r') as f:
             dset = f['test']
 
-            # read uncast dset to make sure it raises as before
-            with self.assertRaises(
-                TypeError, msg='No NumPy equivalent for TypeBitfieldID exists'
-            ):
-                dset[:]
+            # This should do an implicit uint8 cast
+            # Expect that the "No NumPy equivalent for TypeBitfieldID exists"
+            # error is not thrown.
+            arr2 = dset[:]
+
+            self.assertArrayEqual(
+                arr2,
+                arr1.astype(expected_default_cast_dtype, copy=False)
+            )
 
             # read cast dset and make sure it's equal
-            if dtype is None:
-                dtype = arr1.dtype
-            with dset.astype(dtype):
-                arr2 = dset[:]
-            self.assertArrayEqual(arr2, arr1.astype(dtype, copy=False))
-
-            # read uncast dataset again to ensure nothing changed permanently
-            with self.assertRaises(
-                TypeError, msg='No NumPy equivalent for TypeBitfieldID exists'
-            ):
-                dset[:]
-
+            if cast_dtype is None:
+                cast_dtype = arr1.dtype
+            with dset.astype(cast_dtype):
+                arr3 = dset[:]
+            self.assertArrayEqual(arr3, arr1.astype(cast_dtype, copy=False))
 
 def test_opaque(writable_file):
     # opaque without an h5py tag corresponds to numpy void dtypes

--- a/h5py/tests/test_dtype.py
+++ b/h5py/tests/test_dtype.py
@@ -494,7 +494,7 @@ class TestBitfield(TestCase):
             self.assertArrayEqual(arr3, arr1.astype(cast_dtype, copy=False))
 
     def test_b16_uint16(self):
-        arr1 = np.array(np.arange(10), dtype=np.dtype(np.uint16))
+        arr1 = np.arange(10, dtype=np.uint16)
         path = self.mktemp()
         with h5py.File(path, 'w') as f:
             space = h5py.h5s.create_simple(arr1.shape)
@@ -504,11 +504,7 @@ class TestBitfield(TestCase):
 
         with h5py.File(path, 'r') as f:
             dset = f['test']
-            arr2 = dset[:]
-            self.assertArrayEqual(
-                arr2,
-                arr1.astype(np.dtype(np.uint16), copy=False)
-            )
+            self.assertArrayEqual(dset[:], arr1)
 
 def test_opaque(writable_file):
     # opaque without an h5py tag corresponds to numpy void dtypes

--- a/news/1258-default-cast-b8.rst
+++ b/news/1258-default-cast-b8.rst
@@ -1,7 +1,7 @@
 New features
 ------------
 
-* H5T_NATIVE_B8 types will now be cast to ``numpy.uint8`` by default
+* H5T_BITFIELD types will now be cast to their ``numpy.uint`` equivelant by default
   (:issue:`1258`). This means that no knowledge of mixed type compound dataset
   schemas is required to read these types, and can simply be read as follows:
 

--- a/news/1258-default-cast-b8.rst
+++ b/news/1258-default-cast-b8.rst
@@ -1,7 +1,7 @@
 New features
 ------------
 
-* H5T_BITFIELD types will now be cast to their ``numpy.uint`` equivelant by default
+* H5T_BITFIELD types will now be cast to their ``numpy.uint`` equivalent by default
   (:issue:`1258`). This means that no knowledge of mixed type compound dataset
   schemas is required to read these types, and can simply be read as follows:
 
@@ -9,12 +9,11 @@ New features
 
      arr = dset[:]
 
-  Alternatively, these types can still be cast to ``numpy.bool`` explicitly:
+  Alternatively, 8-bit bitfields can still be cast to booleans explicitly:
 
   .. code::
 
-     with dset.astype(numpy.bool):
-        arr = dset[:]
+     arr = dset.astype(numpy.bool_)[:]
 
 Deprecations
 ------------

--- a/news/1258-default-cast-b8.rst
+++ b/news/1258-default-cast-b8.rst
@@ -1,0 +1,42 @@
+New features
+------------
+
+* H5T_NATIVE_B8 types will now be cast to ``numpy.uint8`` by default
+  (:issue:`1258`). This means that no knowledge of mixed type compound dataset
+  schemas is required to read these types, and can simply be read as follows:
+
+  .. code::
+
+     arr = dset[:]
+
+  Alternatively, these types can still be cast to ``numpy.bool`` explicitly:
+
+  .. code::
+
+     with dset.astype(numpy.bool):
+        arr = dset[:]
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
This adds a default cast from H5T_NATIVE_B8 to uint8. The motivation for doing this to rectify an issue where reading mixed-type compound datasets containing a bitfield as follows:

```
import h5py
h5_file = h5py.File('BigDataFile.h5', 'r')
dset = h5_file.get('/Base/GroupA')
data = dset[:]
```

would result in an error message `TypeError: No NumPy equivalent for TypeBitfieldID exists`. To rectify this, explicit specification of the `dtype` was required:

```
import h5py
h5_file = h5py.File('BigDataFile.h5', 'r')

dset = h5_file.get('/Base/GroupA')
dt = [('Time', '<f8'), ('SubsetA', [('DataA1', '?'), ('DataA2', '<f8')])]
with dset.astype(dt):
    data = dset[:]
```

Knowledge and pre-specification of the schema may not always be possible, especially in large datasets. The change that this pull request introduces is the ability to import mixed-type compound datasets without requiring the user to know the schema of that dataset using the following method:

```
import h5py
h5_file = h5py.File('BigDataFile.h5', 'r')
dset = h5_file.get('/Base/GroupA')
data = dset[:]
```

Since the default cast is to `numpy.uint8`, this retains all of the original bit information necessary to perform an explicit cast to another type if required, for example `numpy.bool`.

Comments are welcome, this is my first time working with the h5py source code.

Relates to #821, Relates to #641, Closes #1258 