### PR TITLE
Improve errors when opening files in append mode

### DIFF
--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -205,7 +205,7 @@ def make_fid(name, mode, userblock_size, fapl, fcpl=None, swmr=False):
         # existing one (ACC_EXCL)
         try:
             fid = h5f.open(name, h5f.ACC_RDWR, fapl=fapl)
-        except OSError:
+        except FileNotFoundError:
             fid = h5f.create(name, h5f.ACC_EXCL, fapl=fapl, fcpl=fcpl)
     else:
         raise ValueError("Invalid mode; must be one of r, r+, w, w-, x, a")

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -98,6 +98,10 @@ class TestFileOpen(TestCase):
         finally:
             fid.close()
 
+        os.chmod(fname, stat.S_IREAD)  # Make file read-only
+        with pytest.raises(PermissionError):
+            File(fname, 'a')
+
     def test_readonly(self):
         """ Mode 'r' opens file in readonly mode """
         fname = self.mktemp()

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -99,8 +99,12 @@ class TestFileOpen(TestCase):
             fid.close()
 
         os.chmod(fname, stat.S_IREAD)  # Make file read-only
-        with pytest.raises(PermissionError):
-            File(fname, 'a')
+        try:
+            with pytest.raises(PermissionError):
+                File(fname, 'a')
+        finally:
+            # Make it writable again so it can be deleted on Windows
+            os.chmod(fname, stat.S_IREAD | stat.S_IWRITE)
 
     def test_readonly(self):
         """ Mode 'r' opens file in readonly mode """

--- a/news/append-filenotfound.rst
+++ b/news/append-filenotfound.rst
@@ -1,0 +1,30 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* Trying to open a file in append mode (``'a'``) should now give clearer
+  error messages when the file exists but can't be opened.
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
'Append mode' is an h5py addition which tries to open an existing file (read+write), and falls back to creating a new file. With this change, it will only create a new file when opening the file fails with FileNotFoundError (Posix errno 'ENOENT'). This should mean clearer errors if e.g. a read-only file exists. It depends on #1815, retrieving the errno from HDF5 error messages.

There is a minor risk of breaking code if it depends on getting specific errors which have changed. But we only raised specific subtypes of OSError from 3.2 anyway, so it's not a big risk.