### PR TITLE
Use manylinux image from Github container registry instead of Dockerhub

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
     vmImage: ubuntu-16.04
   variables:
     CIBW_BUILD: cp3[789]-manylinux_x86_64
-    CIBW_MANYLINUX_X86_64_IMAGE: docker.io/h5py/manylinux2010_x86_64-hdf5
+    CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/h5py/manylinux2010_x86_64-hdf5
     # Include less debugging info for smaller wheels (default is -g2)
     CIBW_ENVIRONMENT: "CFLAGS=-g1"
   steps:


### PR DESCRIPTION
Dockerhub is ending free builds, and this is one less service to manage.

See https://github.com/h5py/hdf5-manylinux/issues/1 for more discussion.