### PR TITLE
Improvements to assembling virtual datasets

### DIFF
--- a/docs/high/group.rst
+++ b/docs/high/group.rst
@@ -427,6 +427,26 @@ Reference
        :param fillvalue:
            The value to use where there is no data.
 
+    .. method:: build_virtual_dataset()
+
+       Assemble a virtual dataset in this group.
+
+       This is used as a context manager::
+
+           with f.build_virtual_dataset('virt', (10, 1000), np.uint32) as layout:
+               layout[0] = h5py.VirtualSource('foo.h5', 'data', (1000,))
+
+       Inside the context, you populate a :class:`VirtualLayout` object.
+       The file is only modified when you leave the context, and if there's
+       no error.
+
+       :param str name: Name of the dataset (absolute or relative)
+       :param tuple shape: Shape of the dataset
+       :param dtype: A numpy dtype for data read from the virtual dataset
+       :param tuple maxshape: Maximum dimensions if the dataset can grow
+           (optional). Use None for unlimited dimensions.
+       :param fillvalue: The value used where no data is available.
+
     .. attribute:: attrs
 
         :ref:`attributes` for this group.

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -142,34 +142,6 @@ def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
     return dset_id
 
 
-def make_new_virtual_dset(parent, shape, sources, dtype, name=None,
-                          maxshape=None, fillvalue=None):
-    """ Return a new low-level dataset identifier for a virtual dataset """
-
-    # create the creation property list
-    dcpl = h5p.create(h5p.DATASET_CREATE)
-    if fillvalue is not None:
-        dcpl.set_fill_value(numpy.array([fillvalue]))
-
-    if maxshape is not None:
-        maxshape = tuple(m if m is not None else h5s.UNLIMITED for m in maxshape)
-
-    virt_dspace = h5s.create_simple(shape, maxshape)
-
-    for vspace, fpath, dset, src_dspace in sources:
-        dcpl.set_virtual(vspace, fpath, dset, src_dspace)
-
-    if isinstance(dtype, Datatype):
-        # Named types are used as-is
-        tid = dtype.id
-    else:
-        dtype = numpy.dtype(dtype)
-        tid = h5t.py_create(dtype, logical=1)
-
-    return h5d.create(parent.id, name=name, tid=tid, space=virt_dspace,
-                      dcpl=dcpl)
-
-
 class AstypeWrapper(object):
     """Wrapper to convert data on reading from a dataset.
     """

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -18,7 +18,7 @@ import numpy
 
 from .compat import filename_decode, filename_encode
 
-from .. import h5, h5g, h5i, h5o, h5r, h5t, h5l, h5p, h5s, h5d
+from .. import h5, h5g, h5i, h5o, h5r, h5t, h5l, h5p
 from . import base
 from .base import HLObject, MutableMappingHDF5, phil, with_phil
 from . import dataset

--- a/h5py/_hl/vds.py
+++ b/h5py/_hl/vds.py
@@ -29,7 +29,6 @@ class VDSmap(namedtuple('VDSmap', ('vspace', 'file_name',
     '''
 
 
-
 vds_support = False
 hdf5_version = version.hdf5_version_tuple[0:3]
 

--- a/h5py/_hl/vds.py
+++ b/h5py/_hl/vds.py
@@ -194,7 +194,7 @@ class VirtualLayout(object):
             return b'.'
         return filename_encode(src_filename)
 
-    def get_dcpl(self, dst_filename=None):
+    def get_dcpl(self, dst_filename):
         """Get the property list containing virtual dataset mappings
 
         If the destination filename wasn't known when the VirtualLayout was

--- a/news/vds-set-virtual-sooner.rst
+++ b/news/vds-set-virtual-sooner.rst
@@ -1,0 +1,34 @@
+New features
+------------
+
+* A new :meth:`Group.build_virtual_dataset` method acting as a context manager
+  to assemble virtual datasets.
+* If the source and target of a virtual dataset mapping have different numbers
+  of points, an error should now be thrown when you make the mapping in the
+  :class:`VirtualLayout`, rather than later when writing this into the file.
+  This should make it easier to find the source of such errors.
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
The core of this is that VirtualLayout contains and modifies a Dataset Creation Property List (DCPL). This combines two goals: failing faster when virtual dataset mappings don't have the right number of points (#1776) and reducing memory use by not duplicating all the HDF5 identifiers to store them in our own list before adding them to an HDF5 property list.

There's a wrinkle: we want to translate source filenames matching the destination file to `'.'` (#1546), but with the existing API for creating virtual datasets doesn't know the destination filename until after we have made the mappings in VirtualLayout. There's a new option to give the name up front. If that isn't used, VirtualLayout keeps a set of source filenames, and will transfer the mappings to a new property list if necessary when creating the virtual dataset.

A new API falls out of this rather naturally:

```python
with f.build_virtual_dataset('virt', (10, 1000), np.uint32) as layout:
    layout[0] = h5py.VirtualSource('foo.h5', 'data', (1000,))
```

You get a `VirtualLayout` object at the start of the context, and leaving the context writes it into the file.

Closes #1865
Closes #1863
Closes #1776