### PR TITLE
Except OSError for certain drivers when creating a file with "a"

### DIFF
--- a/.authors.yml
+++ b/.authors.yml
@@ -908,3 +908,8 @@
   num_commits: 1
   first_commit: 2021-04-12 10:48:16
   github: mgorny
+- name: Simone Bacchio
+  email: s.bacchio@gmail.com
+  num_commits: 5
+  first_commit: 2021-07-07 15:52:51
+  github: sbacchio

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -209,7 +209,18 @@ def make_fid(name, mode, userblock_size, fapl, fcpl=None, swmr=False):
         # existing one (ACC_EXCL)
         try:
             fid = h5f.open(name, h5f.ACC_RDWR, fapl=fapl)
-        except FileNotFoundError:
+        # Not all drivers raise FileNotFoundError (commented those that do not)
+        except FileNotFoundError if fapl.get_driver() in (
+            h5fd.SEC2,
+            # h5fd.STDIO,
+            # h5fd.CORE,
+            h5fd.FAMILY,
+            h5fd.WINDOWS,
+            # h5fd.MPIO,
+            # h5fd.MPIPOSIX,
+            h5fd.fileobj_driver,
+            h5fd.ROS3D if ros3 else -1,
+        ) else OSError:
             fid = h5f.create(name, h5f.ACC_EXCL, fapl=fapl, fcpl=fcpl)
     else:
         raise ValueError("Invalid mode; must be one of r, r+, w, w-, x, a")

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -784,7 +784,6 @@ class TestMPI(object):
         """ Testing creation of file with append """
         from mpi4py import MPI
 
-        if os.path.exists(mpi_file_name): os.remove(mpi_file_name)
         with File(mpi_file_name, 'a', driver='mpio', comm=MPI.COMM_WORLD) as f:
             assert f
             assert f.driver == 'mpio'

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -240,10 +240,22 @@ class TestDrivers(TestCase):
         self.assertEqual(fid.driver, 'stdio')
         fid.close()
 
+        # Testing creation with append flag
+        fid = File(self.mktemp(), 'a', driver='stdio')
+        self.assertTrue(fid)
+        self.assertEqual(fid.driver, 'stdio')
+        fid.close()
+
     @ut.skipUnless(os.name == 'posix', "Sec2 driver is supported on posix")
     def test_sec2(self):
         """ Sec2 driver is supported on posix """
         fid = File(self.mktemp(), 'w', driver='sec2')
+        self.assertTrue(fid)
+        self.assertEqual(fid.driver, 'sec2')
+        fid.close()
+
+        # Testing creation with append flag
+        fid = File(self.mktemp(), 'a', driver='sec2')
         self.assertTrue(fid)
         self.assertEqual(fid.driver, 'sec2')
         fid.close()
@@ -256,6 +268,12 @@ class TestDrivers(TestCase):
         self.assertEqual(fid.driver, 'core')
         fid.close()
         self.assertFalse(os.path.exists(fname))
+
+        # Testing creation with append flag
+        fid = File(self.mktemp(), 'a', driver='core')
+        self.assertTrue(fid)
+        self.assertEqual(fid.driver, 'core')
+        fid.close()
 
     def test_backing(self):
         """ Core driver saves to file when backing store used """
@@ -759,6 +777,15 @@ class TestMPI(object):
         from mpi4py import MPI
 
         with File(mpi_file_name, 'w', driver='mpio', comm=MPI.COMM_WORLD) as f:
+            assert f
+            assert f.driver == 'mpio'
+
+    def test_mpio_append(self, mpi_file_name):
+        """ Testing creation of file with append """
+        from mpi4py import MPI
+
+        if os.path.exists(mpi_file_name): os.remove(mpi_file_name)
+        with File(mpi_file_name, 'a', driver='mpio', comm=MPI.COMM_WORLD) as f:
             assert f
             assert f.driver == 'mpio'
 

--- a/news/PR1922.rst
+++ b/news/PR1922.rst
@@ -1,0 +1,4 @@
+Bug fixes
+---------
+
+* Fix bug introduced in version 3.3 that did not allow the creation of files using the flag "a" for certain drivers (e.g. mpiio, core and stdio)


### PR DESCRIPTION
This PR is in response to issues #1916 and #1920 and partially reverts the changes introduced by PR #1902