### PR TITLE
Convert cpdef local variables to cdef

### DIFF
--- a/h5py/h5pl.pyx
+++ b/h5py/h5pl.pyx
@@ -62,8 +62,8 @@ IF HDF5_VERSION >= (1, 10, 1):
         Get the directory path at the given index (starting from 0) in the
         plugin search path. Returns a Python bytes object.
         """
-        cpdef size_t n
-        cpdef char* buf = NULL
+        cdef size_t n
+        cdef char* buf = NULL
 
         n = H5PLget(index, NULL, 0)
         buf = <char*>emalloc(sizeof(char)*(n + 1))
@@ -78,6 +78,6 @@ IF HDF5_VERSION >= (1, 10, 1):
 
         Get the number of directories currently in the plugin search path.
         """
-        cpdef unsigned int n = 0
+        cdef unsigned int n = 0
         H5PLsize(&n)
         return n

--- a/news/no-local-cpdef.rst
+++ b/news/no-local-cpdef.rst
@@ -1,0 +1,29 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* Fix an error building with Cython 3.0 alpha 8 (``cpdef`` inside functions).
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
cpdef is meaningless here, because they're local variables, not exposed outside those functions. Hopefully this fixes the Cython failures on PR #1922.