### PR TITLE
readme: replace google group with the HDF forum

### DIFF
--- a/.authors.yml
+++ b/.authors.yml
@@ -908,3 +908,5 @@
   num_commits: 1
   first_commit: 2021-04-12 10:48:16
   github: mgorny
+- name: Filipe Laíns
+  email: lains@riseup.net

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Reporting bugs
 --------------
 
 Open a bug at https://github.com/h5py/h5py/issues.  For general questions, ask
-on the list (https://groups.google.com/d/forum/h5py).
+on the HDF forum (https://forum.hdfgroup.org/c/hdf-tools/h5py).
 
 .. _`Continuum Anaconda`: http://continuum.io/downloads
 .. _`Enthought Canopy`: https://www.enthought.com/products/canopy/


### PR DESCRIPTION
The Google group is locked and the discussions have moved to the HDF
forum.

https://groups.google.com/g/h5py/c/9Eoz3vqlPZs

Signed-off-by: Filipe Laíns <lains@riseup.net>