### PR TITLE
test_dtype: fix a numpy warning

### DIFF
--- a/h5py/tests/test_dtype.py
+++ b/h5py/tests/test_dtype.py
@@ -287,7 +287,7 @@ class TestOffsets(TestCase):
             self.assertArrayEqual(fd['data'], data)
 
     def test_float_round_tripping(self):
-        dtypes = set(f for f in np.typeDict.values()
+        dtypes = set(f for f in np.sctypeDict.values()
                      if (np.issubdtype(f, np.floating) or
                          np.issubdtype(f, np.complexfloating)))
 


### PR DESCRIPTION
DeprecationWarning: `np.typeDict` is a deprecated alias for `np.sctypeDict`.

According to the changelog, [this has been a deprecated alias for 14 years](https://numpy.org/devdocs/release/1.21.0-notes.html#np-typedict-has-been-formally-deprecated).
