### PR TITLE
fix typo in hard link example

### DIFF
--- a/.authors.yml
+++ b/.authors.yml
@@ -915,3 +915,5 @@
   github: sbacchio
 - name: Filipe Laíns
   email: lains@riseup.net
+- name: Fred Douglis
+  email: fdouglis@perspectalabs.com

--- a/docs/high/group.rst
+++ b/docs/high/group.rst
@@ -106,7 +106,7 @@ made to the object::
 Note that this is `not` a copy of the dataset!  Like hard links in a UNIX file
 system, objects in an HDF5 file can be stored in multiple groups::
 
-    >>> f["other name"] == f["name"]
+    >>> grp["other name"] == grp["name"]
     True
 
 


### PR DESCRIPTION
<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->
This is a trivial change per my comment in the [forum](https://forum.hdfgroup.org/t/typo-in-h5py-group-documentation/8815/2).  It looks like it referenced the file `f` rather than the `group` object.  