### PR TITLE
Build Windows & Mac wheels with HDF5 1.12.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ jobs:
   pool:
     vmImage: vs2017-win2016
   variables:
-    HDF5_VERSION: 1.12.0
+    HDF5_VERSION: 1.12.1
     HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
     HDF5_VSVERSION: "15-64"
     CIBW_BUILD: cp3[789]-win_amd64
@@ -54,7 +54,7 @@ jobs:
     vmImage: macOS-10.15
   variables:
     MACOSX_DEPLOYMENT_TARGET: 10.9
-    HDF5_VERSION: 1.12.0
+    HDF5_VERSION: 1.12.1
     HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
     CIBW_BUILD: cp3[789]-macosx_x86_64
   steps:

--- a/news/wheels-hdf5-1.12.1.rst
+++ b/news/wheels-hdf5-1.12.1.rst
@@ -1,0 +1,29 @@
+New features
+------------
+
+* The pre-built wheels now bundle HDF5 1.12.1.
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
Linux wheels are already using 1.12.1, from our [hdf5-manylinux](https://github.com/h5py/hdf5-manylinux) Docker images.