### PR TITLE
Add HDF5 1.12.1 file locking low-level API to PropFAID

### DIFF
--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -308,6 +308,8 @@ hdf5:
   herr_t    H5Pget_mdc_config(hid_t plist_id, H5AC_cache_config_t *config_ptr)
   herr_t    H5Pset_mdc_config(hid_t plist_id, H5AC_cache_config_t *config_ptr)
   1.8.9 herr_t H5Pset_file_image(hid_t plist_id, void *buf_ptr, size_t buf_len)
+  1.12.1 herr_t H5Pget_file_locking(hid_t fapl_id, hbool_t *use_file_locking, hbool_t *ignore_when_disabled)
+  1.12.1 herr_t H5Pset_file_locking(hid_t fapl_id, hbool_t use_file_locking, hbool_t ignore_when_disabled)
 
   # Dataset creation
   herr_t        H5Pset_layout(hid_t plist, int layout)

--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -308,8 +308,11 @@ hdf5:
   herr_t    H5Pget_mdc_config(hid_t plist_id, H5AC_cache_config_t *config_ptr)
   herr_t    H5Pset_mdc_config(hid_t plist_id, H5AC_cache_config_t *config_ptr)
   1.8.9 herr_t H5Pset_file_image(hid_t plist_id, void *buf_ptr, size_t buf_len)
+  1.10.7-1.10.99 herr_t H5Pget_file_locking(hid_t fapl_id, hbool_t *use_file_locking, hbool_t *ignore_when_disabled)
   1.12.1 herr_t H5Pget_file_locking(hid_t fapl_id, hbool_t *use_file_locking, hbool_t *ignore_when_disabled)
+  1.10.7-1.10.99 herr_t H5Pset_file_locking(hid_t fapl_id, hbool_t use_file_locking, hbool_t ignore_when_disabled)
   1.12.1 herr_t H5Pset_file_locking(hid_t fapl_id, hbool_t use_file_locking, hbool_t ignore_when_disabled)
+
 
   # Dataset creation
   herr_t        H5Pset_layout(hid_t plist, int layout)

--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -1342,6 +1342,31 @@ cdef class PropFAID(PropInstanceID):
             finally:
                 PyBuffer_Release(&buf)
 
+    IF HDF5_VERSION >= (1, 12, 1):
+
+        @with_phil
+        def get_file_locking(self):
+            """ () => (BOOL, BOOL)
+
+            Return file locking information as a 2-tuple of boolean:
+            (use_file_locking, ignore_when_disabled)
+            """
+            cdef hbool_t use_file_locking = 0
+            cdef hbool_t ignore_when_disabled = 0
+
+            H5Pget_file_locking(self.id, &use_file_locking, &ignore_when_disabled)
+            return use_file_locking, ignore_when_disabled
+
+        @with_phil
+        def set_file_locking(self, bint use_file_locking, bint ignore_when_disabled):
+            """ (BOOL use_file_locking, BOOL ignore_when_disabled)
+
+            Set HDF5 file locking behavior.
+            Warning: This setting is overridden by the HDF5_USE_FILE_LOCKING environment variable.
+            """
+            H5Pset_file_locking(
+                self.id, <hbool_t>use_file_locking, <hbool_t>ignore_when_disabled)
+
 
 # Link creation
 cdef class PropLCID(PropCreateID):

--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -1342,7 +1342,7 @@ cdef class PropFAID(PropInstanceID):
             finally:
                 PyBuffer_Release(&buf)
 
-    IF HDF5_VERSION >= (1, 12, 1):
+    IF HDF5_VERSION >= (1, 12, 1) or (HDF5_VERSION[:2] == (1, 10) and HDF5_VERSION[2] >= 7):
 
         @with_phil
         def get_file_locking(self):

--- a/h5py/tests/test_h5p.py
+++ b/h5py/tests/test_h5p.py
@@ -91,6 +91,18 @@ class TestFA(TestCase):
         self.assertEqual((threshold, alignment),
                          falist.get_alignment())
 
+    @ut.skipIf(version.hdf5_version_tuple < (1, 12, 1),
+               'Requires HDF5 1.12.1 or later')
+    def test_set_file_locking(self):
+        '''test get/set file locking'''
+        falist = h5p.create(h5p.FILE_ACCESS)
+        use_file_locking = False
+        ignore_when_disabled = False
+
+        falist.set_file_locking(use_file_locking, ignore_when_disabled)
+        self.assertEqual((use_file_locking, ignore_when_disabled),
+                         falist.get_file_locking())
+
 
 class TestPL(TestCase):
     def test_obj_track_times(self):

--- a/h5py/tests/test_h5p.py
+++ b/h5py/tests/test_h5p.py
@@ -91,8 +91,10 @@ class TestFA(TestCase):
         self.assertEqual((threshold, alignment),
                          falist.get_alignment())
 
-    @ut.skipIf(version.hdf5_version_tuple < (1, 12, 1),
-               'Requires HDF5 1.12.1 or later')
+    @ut.skipUnless(
+        version.hdf5_version_tuple >= (1, 12, 1) or
+        (version.hdf5_version_tuple[:2] == (1, 10) and version.hdf5_version_tuple[2] >= 7),
+        'Requires HDF5 1.12.1 or later or 1.10.x >= 1.10.7')
     def test_set_file_locking(self):
         '''test get/set file locking'''
         falist = h5p.create(h5p.FILE_ACCESS)

--- a/news/file-locking.rst
+++ b/news/file-locking.rst
@@ -1,0 +1,4 @@
+Exposing HDF5 functions
+-----------------------
+
+* `H5Pset_file_locking` and `H5Pget_file_locking` (for HDF5 >= 1.12.1)

--- a/news/file-locking.rst
+++ b/news/file-locking.rst
@@ -1,4 +1,4 @@
 Exposing HDF5 functions
 -----------------------
 
-* `H5Pset_file_locking` and `H5Pget_file_locking` (for HDF5 >= 1.12.1)
+* `H5Pset_file_locking` and `H5Pget_file_locking` (for HDF5 >= 1.12.1 or 1.10.x >= 1.10.7)


### PR DESCRIPTION
This PR adds low level wrappers and minimal tests for: 
- [H5Pset_file_locking](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FILE_LOCKING) 
- [H5Pget_file_locking](https://portal.hdfgroup.org/display/HDF5/H5P_GET_FILE_LOCKING)

It is enabled for HDF5 >= 1.12.1.

Actually, those 2 functions are also available in HDF5 v1.10.7, but not in v1.12.0 and I don't see how to express this in `api_functions.txt`.

Related to #1950
