### PR TITLE
Add `File` argument to select HDF5 file locking behaviour

### DIFF
--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -133,8 +133,9 @@ def make_fapl(driver, libver, rdcc_nslots, rdcc_nbytes, rdcc_w0, locking=None, *
     plist.set_cache(*cache_settings)
 
     if locking is not None:
-        if hdf5_version < (1, 12, 1):
-            raise ValueError("HDF version 1.12.1 or greater required for file locking.")
+        if hdf5_version < (1, 12, 1) and (hdf5_version[:2] != (1, 10) or hdf5_version[2] < 7):
+            raise ValueError(
+                "HDF version >= 1.12.1 or 1.10.x >= 1.10.7 required for file locking.")
 
         if locking in ("false", False):
             plist.set_file_locking(False, ignore_when_disabled=False)
@@ -426,7 +427,7 @@ class File(Group):
             None                Use HDF5 defaults
             Warning: The HDF5_USE_FILE_LOCKING environment variable can override
             this parameter.
-            Only available with HDF5 >= 1.12.1.
+            Only available with HDF5 >= 1.12.1 or 1.10.x >= 1.10.7.
         Additional keywords
             Passed on to the selected file driver.
 
@@ -441,8 +442,9 @@ class File(Group):
             raise ValueError(
                 "h5py was built without ROS3 support, can't use ros3 driver")
 
-        if locking is not None and hdf5_version < (1, 12, 1):
-            raise ValueError("HDF version 1.12.1 or greater required for file locking.")
+        if locking is not None and hdf5_version < (1, 12, 1) and (
+                hdf5_version[:2] != (1, 10) or hdf5_version[2] < 7):
+            raise ValueError("HDF version >= 1.12.1 or 1.10.x >= 1.10.7 required for file locking.")
 
         if isinstance(name, _objects.ObjectID):
             if fs_strategy:

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -421,8 +421,8 @@ class File(Group):
             value is 1.
         locking
             The file locking behavior. Defined as:
-            "false" (or False)  Disable file locking
-            "true" (or True)    Enable file locking
+            False (or "false")  Disable file locking
+            True (or "true")    Enable file locking
             "best-effort"       Enable file locking but ignores some errors
             None                Use HDF5 defaults
             Warning: The HDF5_USE_FILE_LOCKING environment variable can override

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -347,6 +347,7 @@ class File(Group):
                  libver=None, userblock_size=None, swmr=False,
                  rdcc_nslots=None, rdcc_nbytes=None, rdcc_w0=None,
                  track_order=None, fs_strategy=None, fs_persist=False, fs_threshold=1,
+                 locking=None,
                  **kwds):
         """Create a new file object.
 
@@ -417,6 +418,15 @@ class File(Group):
             The smallest free-space section size that the free space manager
             will track.  Only allowed when creating a new file.  The default
             value is 1.
+        locking
+            The file locking behavior. Defined as:
+            "false" (or False)  Disable file locking
+            "true" (or True)    Enable file locking
+            "best-effort"       Enable file locking but ignores some errors
+            None                Use HDF5 defaults
+            Warning: The HDF5_USE_FILE_LOCKING environment variable can override
+            this parameter.
+            Only available with HDF5 >= 1.12.1.
         Additional keywords
             Passed on to the selected file driver.
 
@@ -430,6 +440,9 @@ class File(Group):
         if driver == 'ros3' and not ros3:
             raise ValueError(
                 "h5py was built without ROS3 support, can't use ros3 driver")
+
+        if locking is not None and hdf5_version < (1, 12, 1):
+            raise ValueError("HDF version 1.12.1 or greater required for file locking.")
 
         if isinstance(name, _objects.ObjectID):
             if fs_strategy:
@@ -464,7 +477,7 @@ class File(Group):
                 )
 
             with phil:
-                fapl = make_fapl(driver, libver, rdcc_nslots, rdcc_nbytes, rdcc_w0, **kwds)
+                fapl = make_fapl(driver, libver, rdcc_nslots, rdcc_nbytes, rdcc_w0, locking, **kwds)
                 fid = make_fid(name, mode, userblock_size,
                                fapl, fcpl=make_fcpl(track_order=track_order, fs_strategy=fs_strategy,
                                fs_persist=fs_persist, fs_threshold=fs_threshold),

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -444,7 +444,7 @@ class File(Group):
 
         if locking is not None and hdf5_version < (1, 12, 1) and (
                 hdf5_version[:2] != (1, 10) or hdf5_version[2] < 7):
-            raise ValueError("HDF version >= 1.12.1 or 1.10.x >= 1.10.7 required for file locking.")
+            raise ValueError("HDF version >= 1.12.1 or 1.10.x >= 1.10.7 required for file locking options.")
 
         if isinstance(name, _objects.ObjectID):
             if fs_strategy:

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -841,8 +841,10 @@ class TestSWMRMode(TestCase):
         fid.close()
 
 
-@pytest.mark.skipif(h5py.version.hdf5_version_tuple < (1, 12, 1),
-                    reason="Requires HDF5 1.12.1 or later")
+@pytest.mark.skipif(
+    h5py.version.hdf5_version_tuple < (1, 12, 1) and (
+    h5py.version.hdf5_version_tuple[:2] != (1, 10) or h5py.version.hdf5_version_tuple[2] < 7),
+    reason="Requires HDF5 >= 1.12.1 or 1.10.x >= 1.10.7")
 @pytest.mark.skipif("HDF5_USE_FILE_LOCKING" in os.environ,
                     reason="HDF5_USE_FILE_LOCKING env. var. is set")
 def test_file_locking(tmp_path):
@@ -864,8 +866,10 @@ def test_file_locking(tmp_path):
             pass
 
 
-@pytest.mark.skipif(h5py.version.hdf5_version_tuple < (1, 12, 1),
-                    reason="Requires HDF5 1.12.1 or later")
+@pytest.mark.skipif(
+    h5py.version.hdf5_version_tuple < (1, 12, 1) and (
+    h5py.version.hdf5_version_tuple[:2] != (1, 10) or h5py.version.hdf5_version_tuple[2] < 7),
+    reason="Requires HDF5 >= 1.12.1 or 1.10.x >= 1.10.7")
 @pytest.mark.skipif("HDF5_USE_FILE_LOCKING" in os.environ,
                     reason="HDF5_USE_FILE_LOCKING env. var. is set")
 def test_file_locking_multiprocess(tmp_path):

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -18,7 +18,8 @@ import os
 import stat
 import pickle
 import tempfile
-from sys import platform
+import subprocess
+import sys
 
 from .common import ut, TestCase, UNICODE_FILENAMES, closed_tempfile
 from h5py import File
@@ -838,6 +839,59 @@ class TestSWMRMode(TestCase):
         # This setter should affect both fid and group member file attribute
         assert fid.swmr_mode == g.file.swmr_mode == True
         fid.close()
+
+
+@pytest.mark.skipif(h5py.version.hdf5_version_tuple < (1, 12, 1),
+                    reason="Requires HDF5 1.12.1 or later")
+@pytest.mark.skipif("HDF5_USE_FILE_LOCKING" in os.environ,
+                    reason="HDF5_USE_FILE_LOCKING env. var. is set")
+def test_file_locking(tmp_path):
+    """Test file locking option"""
+    fname = tmp_path / "test.h5"
+
+    with h5py.File(fname, mode="w", locking=True) as f:
+        f.flush()
+
+        # Opening same file in same process without locking is expected to fail
+        with pytest.raises(OSError):
+            with h5py.File(fname, mode="r", locking=False) as h5f_read:
+                pass
+
+        with h5py.File(fname, mode="r", locking=True) as h5f_read:
+            pass
+
+        with h5py.File(fname, mode="r", locking='best-effort') as h5f_read:
+            pass
+
+
+@pytest.mark.skipif(h5py.version.hdf5_version_tuple < (1, 12, 1),
+                    reason="Requires HDF5 1.12.1 or later")
+@pytest.mark.skipif("HDF5_USE_FILE_LOCKING" in os.environ,
+                    reason="HDF5_USE_FILE_LOCKING env. var. is set")
+def test_file_locking_multiprocess(tmp_path):
+    """Test file locking option from different concurrent processes"""
+    fname = tmp_path / "test.h5"
+
+    def open_in_subprocess(filename, mode, locking):
+        """Try to open HDF5 file a subprocess and return CompletedProcess"""
+        process = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                f"import h5py; f = h5py.File('{str(filename)}', mode='{mode}', locking={locking})",
+            ],
+            capture_output=True)
+        return process.returncode == 0 and not process.stderr
+
+
+    with h5py.File(fname, mode="w", locking=True) as f:
+        f.flush()
+
+        # Opening again with locking is expected to fail
+        assert not open_in_subprocess(fname, mode="r", locking=True)
+
+        # Opening again without locking is expected to work
+        assert open_in_subprocess(fname, mode="r", locking=False) is True
 
 
 # unittest doesn't work with pytest fixtures (and possibly other features),

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -895,7 +895,7 @@ def test_file_locking_multiprocess(tmp_path):
         assert not open_in_subprocess(fname, mode="r", locking=True)
 
         # Opening again without locking is expected to work
-        assert open_in_subprocess(fname, mode="r", locking=False) is True
+        assert open_in_subprocess(fname, mode="r", locking=False)
 
 
 # unittest doesn't work with pytest fixtures (and possibly other features),

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -868,6 +868,13 @@ class TestFileLocking:
             with h5py.File(fname, mode="r", locking='best-effort') as h5f_read:
                 pass
 
+    def test_unsupported_locking(self, tmp_path):
+        """Test with erroneous file locking value"""
+        fname = tmp_path / "test.h5"
+        with pytest.raises(ValueError):
+            with h5py.File(fname, mode="r", locking='unsupported-value') as h5f_read:
+                pass
+
     def test_multiprocess(self, tmp_path):
         """Test file locking option from different concurrent processes"""
         fname = tmp_path / "test.h5"

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -847,62 +847,58 @@ class TestSWMRMode(TestCase):
     reason="Requires HDF5 >= 1.12.1 or 1.10.x >= 1.10.7")
 @pytest.mark.skipif("HDF5_USE_FILE_LOCKING" in os.environ,
                     reason="HDF5_USE_FILE_LOCKING env. var. is set")
-def test_file_locking(tmp_path):
-    """Test file locking option"""
-    fname = tmp_path / "test.h5"
+class TestFileLocking:
+    """Test h5py.File file locking option"""
 
-    with h5py.File(fname, mode="w", locking=True) as f:
-        f.flush()
+    def test_reopen(self, tmp_path):
+        """Test file locking when opening twice the same file"""
+        fname = tmp_path / "test.h5"
 
-        # Opening same file in same process without locking is expected to fail
-        with pytest.raises(OSError):
-            with h5py.File(fname, mode="r", locking=False) as h5f_read:
+        with h5py.File(fname, mode="w", locking=True) as f:
+            f.flush()
+
+            # Opening same file in same process without locking is expected to fail
+            with pytest.raises(OSError):
+                with h5py.File(fname, mode="r", locking=False) as h5f_read:
+                    pass
+
+            with h5py.File(fname, mode="r", locking=True) as h5f_read:
                 pass
 
-        with h5py.File(fname, mode="r", locking=True) as h5f_read:
-            pass
+            with h5py.File(fname, mode="r", locking='best-effort') as h5f_read:
+                pass
 
-        with h5py.File(fname, mode="r", locking='best-effort') as h5f_read:
-            pass
+    def test_multiprocess(self, tmp_path):
+        """Test file locking option from different concurrent processes"""
+        fname = tmp_path / "test.h5"
 
+        def open_in_subprocess(filename, mode, locking):
+            """Try to open HDF5 file a subprocess and return CompletedProcess"""
+            escaped_filename = "\\\\".join(str(filename).split("\\"))
+            h5py_import_dir = pathlib.Path(h5py.__file__).parent.parent
+            escaped_h5py_import_dir = "\\\\".join(str(h5py_import_dir).split("\\"))
 
-@pytest.mark.skipif(
-    h5py.version.hdf5_version_tuple < (1, 12, 1) and (
-    h5py.version.hdf5_version_tuple[:2] != (1, 10) or h5py.version.hdf5_version_tuple[2] < 7),
-    reason="Requires HDF5 >= 1.12.1 or 1.10.x >= 1.10.7")
-@pytest.mark.skipif("HDF5_USE_FILE_LOCKING" in os.environ,
-                    reason="HDF5_USE_FILE_LOCKING env. var. is set")
-def test_file_locking_multiprocess(tmp_path):
-    """Test file locking option from different concurrent processes"""
-    fname = tmp_path / "test.h5"
-
-    def open_in_subprocess(filename, mode, locking):
-        """Try to open HDF5 file a subprocess and return CompletedProcess"""
-        escaped_filename = "\\\\".join(str(filename).split("\\"))
-        h5py_import_dir = pathlib.Path(h5py.__file__).parent.parent
-        escaped_h5py_import_dir = "\\\\".join(str(h5py_import_dir).split("\\"))
-
-        process = subprocess.run(
-            [
-                sys.executable,
-                "-c",
-                f"""
+            process = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    f"""
 import sys
 sys.path.insert(0, '{escaped_h5py_import_dir}')
 import h5py
 f = h5py.File('{escaped_filename}', mode='{mode}', locking={locking})
-                """,
-            ],
-            capture_output=True)
-        return process.returncode == 0 and not process.stderr
+                    """,
+                ],
+                capture_output=True)
+            return process.returncode == 0 and not process.stderr
 
-    # Create test file
-    with h5py.File(fname, mode="w", locking=True) as f:
-        f["data"] = 1
+        # Create test file
+        with h5py.File(fname, mode="w", locking=True) as f:
+            f["data"] = 1
 
-    with h5py.File(fname, mode="r", locking=False) as f:
-        # Opening in write mode with locking is expected to work
-        assert open_in_subprocess(fname, mode="w", locking=True)
+        with h5py.File(fname, mode="r", locking=False) as f:
+            # Opening in write mode with locking is expected to work
+            assert open_in_subprocess(fname, mode="w", locking=True)
 
 
 # unittest doesn't work with pytest fixtures (and possibly other features),

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -879,11 +879,19 @@ def test_file_locking_multiprocess(tmp_path):
     def open_in_subprocess(filename, mode, locking):
         """Try to open HDF5 file a subprocess and return CompletedProcess"""
         escaped_filename = "\\\\".join(str(filename).split("\\"))
+        h5py_import_dir = pathlib.Path(h5py.__file__).parent.parent
+        escaped_h5py_import_dir = "\\\\".join(str(h5py_import_dir).split("\\"))
+
         process = subprocess.run(
             [
                 sys.executable,
                 "-c",
-                f"import h5py; f = h5py.File('{escaped_filename}', mode='{mode}', locking={locking})",
+                f"""
+import sys
+sys.path.insert(0, '{escaped_h5py_import_dir}')
+import h5py
+f = h5py.File('{escaped_filename}', mode='{mode}', locking={locking})
+                """,
             ],
             capture_output=True)
         return process.returncode == 0 and not process.stderr

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -880,10 +880,8 @@ class TestFileLocking:
         fname = tmp_path / "test.h5"
 
         def open_in_subprocess(filename, mode, locking):
-            """Try to open HDF5 file a subprocess and return CompletedProcess"""
-            escaped_filename = "\\\\".join(str(filename).split("\\"))
-            h5py_import_dir = pathlib.Path(h5py.__file__).parent.parent
-            escaped_h5py_import_dir = "\\\\".join(str(h5py_import_dir).split("\\"))
+            """Open HDF5 file in a subprocess and return True on success"""
+            h5py_import_dir = str(pathlib.Path(h5py.__file__).parent.parent)
 
             process = subprocess.run(
                 [
@@ -891,9 +889,9 @@ class TestFileLocking:
                     "-c",
                     f"""
 import sys
-sys.path.insert(0, '{escaped_h5py_import_dir}')
+sys.path.insert(0, {h5py_import_dir!r})
 import h5py
-f = h5py.File('{escaped_filename}', mode='{mode}', locking={locking})
+f = h5py.File({str(filename)!r}, mode={mode!r}, locking={locking})
                     """,
                 ],
                 capture_output=True)

--- a/news/hl-file-locking.rst
+++ b/news/hl-file-locking.rst
@@ -1,0 +1,4 @@
+New features
+------------
+
+* Added `locking` `File` argument to select HDF5 file locking behavior.


### PR DESCRIPTION
This PR builds on PR  #1951 and proposes the possibly more controversial integration of file locking in the high level API.

This PR proposes to add a `locking` argument to the already long list of `h5py.File` arguments in order to select the file locking behaviour.

It turned out that there is currently 3 file locking behaviours provided by HDF5 v1.12.1 (and 1.10.7) that can be set through the `HDF5_USE_FILE_LOCKING` env. var. and `H5Pset_file_locking` function:
- Disable file locking: `HDF5_USE_FILE_LOCKING=FALSE` and `H5Pset_file_locking(use_file_locking=False, ignore_when_disabled=False)`
- Enable file locking: `HDF5_USE_FILE_LOCKING=TRUE` and `H5Pset_file_locking(use_file_locking=True, ignore_when_disabled=False)`
- Enable file locking but ignores error if HDF5 detects that file locking was disable on the file system: `HDF5_USE_FILE_LOCKING=BEST_EFFORT` and `H5Pset_file_locking(use_file_locking=True, ignore_when_disabled=True)`

I support all 3 (+HDF5 default) by accepting `None` (default), `bool` and `str` as `locking` value , I'd take any better solution.
Maybe only providing `BEST_EFFORT` (`locking=True`) and `FALSE` (locking=`False`) is enough? In this case, `locking` would be `True`, `False` or `None`.

If the `locking` argument (or something similar) does not make it into `File`, it would be good to at least have it in `make_fapl`.
In this case, unless I misunderstood something, it would be possible to create a `File` object by giving it a `fid` created with `make_fid`, `make_facl` and `make_fcpl`, though less convenient.

related to #1950