### PR TITLE
PR to make Numpy / h5py comparisons commutative in __eq__ and __neq__

### DIFF
--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -348,7 +348,7 @@ class HLObject(CommonStateObject):
     def __eq__(self, other):
         if hasattr(other, 'id'):
             return self.id == other.id
-        return False
+        return NotImplemented
 
     @with_phil
     def __ne__(self, other):

--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -350,13 +350,6 @@ class HLObject(CommonStateObject):
             return self.id == other.id
         return NotImplemented
 
-    @with_phil
-    def __ne__(self, other):
-        eq = self.__eq__(other)
-        if type(eq) == 'bool':
-            return not eq
-        return NotImplemented
-
     def __bool__(self):
         with phil:
             return bool(self.id)

--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -352,7 +352,10 @@ class HLObject(CommonStateObject):
 
     @with_phil
     def __ne__(self, other):
-        return not self.__eq__(other)
+        eq = self.__eq__(other)
+        if type(eq) == 'bool':
+            return not eq
+        return NotImplemented
 
     def __bool__(self):
         with phil:

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1756,7 +1756,7 @@ class TestCommutative(BaseDataset):
 
         # grab a value from the elements, ie dset[0]
         # check that mask arrays are commutative wrt ==, !=
-        val = np.float32(dset[0])
+        val = np.float64(dset[0])
 
         assert np.all((val == dset) == (dset == val))
         assert np.all((val != dset) == (dset != val))

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1742,12 +1742,12 @@ def test_allow_unknown_filter(writable_file):
 
 class TestCommutative(BaseDataset):
     """
-    Test the symmetry of operators, at least with the numpy types. 
+    Test the symmetry of operators, at least with the numpy types.
     Issue: https://github.com/h5py/h5py/issues/1947
     """
     def test_numpy_commutative(self,):
         """
-        Create a h5py dataset and convert to numpy. 
+        Create a h5py dataset and convert to numpy.
 
         Check that it returns symmetric response to == and !=
         """
@@ -1772,7 +1772,7 @@ class TestCommutative(BaseDataset):
 
     def test_basetype_commutative(self,):
         """
-        Create a h5py dataset and check basetype compatibility. 
+        Create a h5py dataset and check basetype compatibility.
         Check that it returns correct result
         """
         shape = (100,1)

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1745,14 +1745,42 @@ class TestCommutative(BaseDataset):
     Test the symmetry of operators, at least with the numpy types. 
     Issue: https://github.com/h5py/h5py/issues/1947
     """
-    def test_commutative(self,):
+    def test_numpy_commutative(self,):
         """
-        Create a h5py dataset and convert to numpy. Check that it returns correct result
+        Create a h5py dataset and convert to numpy. 
+
+        Check that it returns symmetric response to == and !=
         """
         shape = (100,1)
-        dset = self.f.create_dataset("test", shape, dtype=float)
-        # dset[:] = np.random.random(100)
+        dset = self.f.create_dataset("test", shape, dtype=float,
+                                     data=np.random.rand(*shape))
 
-        # check that mask arrays are symmetric
+        # grab a value from the elements, ie dset[0]
+        # check that mask arrays are commutative wrt ==, !=
         val = dset[0]
+
         assert np.all((val == dset) == (dset == val))
+        assert np.all((val != dset) == (dset != val))
+
+        # generate sample not in the dset, ie max(dset)+delta
+        # check that mask arrays are commutative wrt ==, !=
+        delta = 0.001
+        nval = np.nanmax(dset)+delta
+
+        assert np.all((nval == dset) == (dset == nval))
+        assert np.all((nval != dset) == (dset != nval))
+
+    def test_basetype_commutative(self,):
+        """
+        Create a h5py dataset and check basetype compatibility. 
+        Check that it returns correct result
+        """
+        shape = (100,1)
+        dset = self.f.create_dataset("test", shape, dtype=float,
+                                     data=np.random.rand(*shape))
+
+        # generate float type, sample float(0.)
+        # check that operation is symmetric (but potentially meaningless)
+        val = float(0.)
+        assert (val == dset) == (dset == val)
+        assert (val != dset) == (dset != val)

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1738,3 +1738,21 @@ def test_allow_unknown_filter(writable_file):
         allow_unknown_filter=True
     )
     assert str(fake_filter_id) in ds._filters
+
+
+class TestCommutative(BaseDataset):
+    """
+    Test the symmetry of operators, at least with the numpy types. 
+    Issue: https://github.com/h5py/h5py/issues/1947
+    """
+    def test_commutative(self,):
+        """
+        Create a h5py dataset and convert to numpy. Check that it returns correct result
+        """
+        shape = (100,1)
+        dset = self.f.create_dataset("test", shape, dtype=float)
+        # dset[:] = np.random.random(100)
+
+        # check that mask arrays are symmetric
+        val = dset[0]
+        assert np.all((val == dset) == (dset == val))

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1747,8 +1747,7 @@ class TestCommutative(BaseDataset):
     """
     def test_numpy_commutative(self,):
         """
-        Create a h5py dataset and convert to numpy.
-
+        Create a h5py dataset, extract one element convert to numpy
         Check that it returns symmetric response to == and !=
         """
         shape = (100,1)
@@ -1757,7 +1756,7 @@ class TestCommutative(BaseDataset):
 
         # grab a value from the elements, ie dset[0]
         # check that mask arrays are commutative wrt ==, !=
-        val = dset[0]
+        val = np.float32(dset[0])
 
         assert np.all((val == dset) == (dset == val))
         assert np.all((val != dset) == (dset != val))
@@ -1773,7 +1772,8 @@ class TestCommutative(BaseDataset):
     def test_basetype_commutative(self,):
         """
         Create a h5py dataset and check basetype compatibility.
-        Check that it returns correct result
+        Check that operation is symmetric, even if it is potentially
+        not meaningful.
         """
         shape = (100,1)
         dset = self.f.create_dataset("test", shape, dtype=float,

--- a/news/numpy_operators_communitive.rst
+++ b/news/numpy_operators_communitive.rst
@@ -1,0 +1,9 @@
+New features
+------------
+
+* Numpy / h5py comparisons will be commutative in __eq__ and __neq__. This extends masking functionality, and enhances the compatibility of the two types.
+
+Bug fixes
+---------
+
+* Numpy typing for __eq__ and __neq__ will now be used when h5py cannot duck-type datasets

--- a/news/numpy_operators_communitive.rst
+++ b/news/numpy_operators_communitive.rst
@@ -1,9 +1,4 @@
-New features
-------------
-
-* Numpy / h5py comparisons will be commutative in __eq__ and __neq__. This extends masking functionality, and enhances the compatibility of the two types.
-
 Bug fixes
 ---------
 
-* Numpy typing for __eq__ and __neq__ will now be used when h5py cannot duck-type datasets
+* dataset == array now behaves the same way as array == dataset - the HDF5 dataset is read and NumPy makes a boolean array


### PR DESCRIPTION
Numpy / h5py types are often compatible, this pull request extends the ```==``` and ```!=``` functionality. In the Numpy special case this enables masking operations  with Numpy arrays and H5py datasets, so that they are commutative.

This pull request is related to the issue https://github.com/h5py/h5py/issues/1947.

Before opening a pull request, please:

[x] Run simple static checks with `tox -e pre-commit`
[o] Run the tests with e.g. `tox -e py37-test-deps`
[x] Run the tests with e.g. `tox -e py39-test-deps`
