### PR TITLE
Disable dataset timestamps by default

### DIFF
--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -38,7 +38,7 @@ MPI = h5.get_config().mpi
 def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
                   chunks=None, compression=None, shuffle=None,
                   fletcher32=None, maxshape=None, compression_opts=None,
-                  fillvalue=None, scaleoffset=None, track_times=None,
+                  fillvalue=None, scaleoffset=None, track_times=False,
                   external=None, track_order=None, dcpl=None,
                   allow_unknown_filter=False):
     """ Return a new low-level dataset identifier """
@@ -115,7 +115,7 @@ def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
 
     if track_times in (True, False):
         dcpl.set_obj_track_times(track_times)
-    elif track_times is not None:
+    else:
         raise TypeError("track_times must be either True or False")
     if track_order is True:
         dcpl.set_attr_creation_order(

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -113,6 +113,9 @@ def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
         fillvalue = numpy.array(fillvalue)
         dcpl.set_fill_value(fillvalue)
 
+    if track_times is None:
+        # In case someone explicitly passes None for the default
+        track_times = False
     if track_times in (True, False):
         dcpl.set_obj_track_times(track_times)
     else:

--- a/news/default-no-timestamps.rst
+++ b/news/default-no-timestamps.rst
@@ -1,0 +1,31 @@
+New features
+------------
+
+* Datasets are now created without timestamps by default, making it easier to
+  create more consistent files. Pass ``track_times=True`` to
+  :meth:`.Group.create_dataset` to add timestamps again.
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
Closes #1953 (see discussion there).

I've allowed for passing `track_times=None` explicitly, with the same behaviour as not passing it at all. I'm not sure anyone actually needs that, but it's possible some wrapper library has None as its own default, and it's easy to handle it.