### PR TITLE
Add the `__reversed__` method to `Group` and its mapping views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ MANIFEST
 .coverage
 .coverage_dir
 coverage.xml
+.vscode/
+.mypy_cache/
 
 # Rever
 rever/

--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -385,6 +385,9 @@ class KeysViewHDF5(KeysView):
     def __str__(self):
         return "<KeysViewHDF5 {}>".format(list(self))
 
+    def __reversed__(self):
+        yield from reversed(self._mapping)
+
     __repr__ = __str__
 
 class ValuesViewHDF5(ValuesView):
@@ -408,6 +411,11 @@ class ValuesViewHDF5(ValuesView):
             for key in self._mapping:
                 yield self._mapping.get(key)
 
+    def __reversed__(self):
+        with phil:
+            for key in reversed(self._mapping):
+                yield self._mapping.get(key)
+
 
 class ItemsViewHDF5(ItemsView):
 
@@ -425,6 +433,11 @@ class ItemsViewHDF5(ItemsView):
     def __iter__(self):
         with phil:
             for key in self._mapping:
+                yield (key, self._mapping.get(key))
+
+    def __reversed__(self):
+        with phil:
+            for key in reversed(self._mapping):
                 yield (key, self._mapping.get(key))
 
 

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -454,6 +454,12 @@ class Group(HLObject, MutableMappingHDF5):
             yield self._d(x)
 
     @with_phil
+    def __reversed__(self):
+        """ Iterate over member names in reverse order. """
+        for x in self.id.__reversed__():
+            yield self._d(x)
+
+    @with_phil
     def __contains__(self, name):
         """ Test if a member name exists """
         return self._e(name) in self.id

--- a/h5py/h5g.pyx
+++ b/h5py/h5g.pyx
@@ -92,14 +92,16 @@ cdef class GroupIter:
     cdef unsigned long nobjs
     cdef GroupID grp
     cdef list names
+    cdef bint reversed
 
 
-    def __init__(self, GroupID grp not None):
+    def __init__(self, GroupID grp not None, bint reversed=False):
 
         self.idx = 0
         self.grp = grp
         self.nobjs = grp.get_num_objs()
         self.names = []
+        self.reversed = reversed
 
 
     def __iter__(self):
@@ -125,6 +127,8 @@ cdef class GroupIter:
 
             self.grp.links.iterate(self.names.append,
                                    idx_type=idx_type)
+            if self.reversed:
+                self.names.reverse()
 
         retval = self.names[self.idx]
         self.idx += 1
@@ -473,6 +477,10 @@ cdef class GroupID(ObjectID):
         with phil:
             return GroupIter(self)
 
+    def __reversed__(self):
+        """ Return an iterator over group member names in reverse order. """
+        with phil:
+            return GroupIter(self, reversed=True)
 
     def __len__(self):
         """ Number of group members """

--- a/h5py/tests/test_group.py
+++ b/h5py/tests/test_group.py
@@ -436,21 +436,29 @@ class TestTrackOrder(BaseGroup):
     def test_track_order(self):
         g = self.f.create_group('order', track_order=True)  # creation order
         self.populate(g)
-        self.assertEqual(list(g),
-                         [str(i) for i in range(100)])
+
+        ref = [str(i) for i in range(100)]
+        self.assertEqual(list(g), ref)
+        self.assertEqual(list(reversed(g)), list(reversed(ref)))
 
     def test_no_track_order(self):
         g = self.f.create_group('order', track_order=False)  # name alphanumeric
         self.populate(g)
-        self.assertEqual(list(g),
-                         sorted([str(i) for i in range(100)]))
+
+        ref = [str(i) for i in range(100)]
+        ref.sort()
+        self.assertEqual(list(g), ref)
+        self.assertEqual(list(reversed(g)), list(reversed(ref)))
 
 class TestPy3Dict(BaseMapping):
 
     def test_keys(self):
         """ .keys provides a key view """
         kv = getattr(self.f, 'keys')()
-        self.assertSameElements(list(kv), self.groups)
+        ref = self.groups
+        self.assertSameElements(list(kv), ref)
+        self.assertSameElements(list(reversed(kv)), list(reversed(ref)))
+
         for x in self.groups:
             self.assertIn(x, kv)
         self.assertEqual(len(kv), len(self.groups))
@@ -458,7 +466,10 @@ class TestPy3Dict(BaseMapping):
     def test_values(self):
         """ .values provides a value view """
         vv = getattr(self.f, 'values')()
-        self.assertSameElements(list(vv), [self.f.get(x) for x in self.groups])
+        ref = [self.f.get(x) for x in self.groups]
+        self.assertSameElements(list(vv), ref)
+        self.assertSameElements(list(reversed(vv)), list(reversed(ref)))
+
         self.assertEqual(len(vv), len(self.groups))
         for x in self.groups:
             self.assertIn(self.f.get(x), vv)
@@ -466,7 +477,10 @@ class TestPy3Dict(BaseMapping):
     def test_items(self):
         """ .items provides an item view """
         iv = getattr(self.f, 'items')()
-        self.assertSameElements(list(iv), [(x,self.f.get(x)) for x in self.groups])
+        ref = [(x,self.f.get(x)) for x in self.groups]
+        self.assertSameElements(list(iv), ref)
+        self.assertSameElements(list(reversed(iv)), list(reversed(ref)))
+
         self.assertEqual(len(iv), len(self.groups))
         for x in self.groups:
             self.assertIn((x, self.f.get(x)), iv)

--- a/h5py/tests/test_group.py
+++ b/h5py/tests/test_group.py
@@ -445,8 +445,7 @@ class TestTrackOrder(BaseGroup):
         g = self.f.create_group('order', track_order=False)  # name alphanumeric
         self.populate(g)
 
-        ref = [str(i) for i in range(100)]
-        ref.sort()
+        ref = sorted([str(i) for i in range(100)])
         self.assertEqual(list(g), ref)
         self.assertEqual(list(reversed(g)), list(reversed(ref)))
 

--- a/news/reversed.rst
+++ b/news/reversed.rst
@@ -1,7 +1,7 @@
 New features
 ------------
 
-The ``__reversed__`` method has been added to the following iterables:
+The built-in ``reversed()`` function now works with the following iterables:
 * `GroupID`
 * `Group`
 * `KeysViewHDF5`

--- a/news/reversed.rst
+++ b/news/reversed.rst
@@ -1,0 +1,9 @@
+New features
+------------
+
+The ``__reversed__`` method has been added to the following iterables:
+* `GroupID`
+* `Group`
+* `KeysViewHDF5`
+* `ValuesViewHDF5`
+* `ItemsViewHDF5`


### PR DESCRIPTION
closes https://github.com/h5py/h5py/issues/1962

Prompted by the recent introduction of `dict.__reversed__`, this PR adds the `__revered__` method 
to `Group`, `GroupID` and the various mapping views.
The implementation makes heavy usage of the existing `__iter__` code (see the `GroupIter` class).
