### PR TITLE
Enable HDF5 page buffering

### DIFF
--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -166,6 +166,10 @@ hdf5:
   # SWMR functions
   1.9.178   herr_t H5Fstart_swmr_write(hid_t file_id)
 
+  # Page Buffering functions
+  1.10.1 herr_t    H5Freset_page_buffering_stats(hid_t file_id)
+  1.10.1 herr_t    H5Fget_page_buffering_stats(hid_t file_id, unsigned *accesses, unsigned *hits, unsigned *misses, unsigned *evictions, unsigned *bypasses)
+
   # === H5FD - Virtual File Layer =========================================================
 
   hid_t     H5FDregister(H5FD_class_t *cls_ptr)
@@ -283,6 +287,8 @@ hdf5:
   herr_t    H5Pget_istore_k(hid_t plist, unsigned int *ik)
   1.10.1 herr_t    H5Pset_file_space_strategy(hid_t fcpl, H5F_fspace_strategy_t strategy, hbool_t persist, hsize_t threshold)
   1.10.1 herr_t    H5Pget_file_space_strategy(hid_t fcpl, H5F_fspace_strategy_t *strategy, hbool_t *persist, hsize_t *threshold)
+  1.10.1 herr_t    H5Pset_file_space_page_size(hid_t plist_id, hsize_t fsp_size)
+  1.10.1 herr_t    H5Pget_file_space_page_size(hid_t plist_id, hsize_t *fsp_size)
 
   # File access
   herr_t    H5Pset_fclose_degree(hid_t fapl_id, H5F_close_degree_t fc_degree)
@@ -308,6 +314,8 @@ hdf5:
   herr_t    H5Pget_mdc_config(hid_t plist_id, H5AC_cache_config_t *config_ptr)
   herr_t    H5Pset_mdc_config(hid_t plist_id, H5AC_cache_config_t *config_ptr)
   1.8.9 herr_t H5Pset_file_image(hid_t plist_id, void *buf_ptr, size_t buf_len)
+  1.10.1 herr_t H5Pset_page_buffer_size(hid_t plist_id, size_t buf_size, unsigned min_meta_per, unsigned min_raw_per)
+  1.10.1 herr_t H5Pget_page_buffer_size(hid_t plist_id, size_t *buf_size, unsigned *min_meta_per, unsigned *min_raw_per)
   1.10.7-1.10.99 herr_t H5Pget_file_locking(hid_t fapl_id, hbool_t *use_file_locking, hbool_t *ignore_when_disabled)
   1.12.1 herr_t H5Pget_file_locking(hid_t fapl_id, hbool_t *use_file_locking, hbool_t *ignore_when_disabled)
   1.10.7-1.10.99 herr_t H5Pset_file_locking(hid_t fapl_id, hbool_t use_file_locking, hbool_t ignore_when_disabled)


### PR DESCRIPTION
This PR implements the page buffering feature explained in #1965. The added low-level API functions are:
* page buffer size set and get;
* file space page size set and get (this was somehow missed when `fs_strategy` & friends were implemented);
* reset and get page buffer statistics.

Setting file space page or page buffer size are added to `File.__init__()` as named arguments and then passed to `make_fcpl()` and `make_fapl()`, respectively.

Get/reset page buffer statistics are not added to the high-level API because this is not something of interest to typical users. Page buffer statistics is returned as a named tuple of two named tuples. An example:

    PageBufferStats(
        meta=MetaStats(accesses=155, hits=147, misses=8, evictions=8, bypasses=0), 
        raw=RawStats(accesses=98, hits=20, misses=31, evictions=28, bypasses=47)
    )

I'll add tests once the above additions are finalized.