### PR TITLE
FIX: memory leak in fast-reader Reader.read

### DIFF
--- a/h5py/_selector.pyx
+++ b/h5py/_selector.pyx
@@ -359,11 +359,13 @@ cdef class Reader:
             buf = PyArray_DATA(arr)
 
             mspace = H5Screate_simple(self.selector.rank, mshape, NULL)
-            H5Dread(self.dataset, self.h5_memory_datatype.id, mspace,
-                    self.selector.space, H5P_DEFAULT, buf)
-
         finally:
             efree(mshape)
+
+        try:
+            H5Dread(self.dataset, self.h5_memory_datatype.id, mspace,
+                    self.selector.space, H5P_DEFAULT, buf)
+        finally:
             H5Sclose(mspace)
 
         if arr.ndim == 0:


### PR DESCRIPTION
Previously we were creating but never destroying memory space objects.  This
changes the code to reuse the `SpaceID` class which will take care of making
the c level lifeccyle track the Python level life cycle.

This bug was exposed by fixing a different bug in #1944 that prevented this
code from ever being run.

Closes #1975

@takluyver @aragilar I think we need to get this in and do a 3.4.1 or pull the fast reader code out and do a 3.4.1
