### PR TITLE
Use windows-2019 environment on Azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
 
 - job: 'windows_wheels'
   pool:
-    vmImage: vs2017-win2016
+    vmImage: windows-2019
   variables:
     HDF5_VERSION: 1.12.1
     HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
@@ -162,7 +162,7 @@ jobs:
 
 - job: 'Windows'
   pool:
-    vmImage: vs2017-win2016
+    vmImage: windows-2019
   strategy:
     matrix:
     # -deps : test with default (latest) versions of dependencies
@@ -213,7 +213,7 @@ jobs:
 - job: 'test_windows_wheels'
   dependsOn: windows_wheels
   pool:
-    vmImage: vs2017-win2016
+    vmImage: windows-2019
   variables:
     H5PY_TEST_CHECK_FILTERS: 1
 


### PR DESCRIPTION
I got warnings on #1973 saying that:

> The windows-2016 environment will be deprecated on November 15, 2021, and removed on March 15, 2022. Migrate to windows-latest instead. For more details see https://github.com/actions/virtual-environments/issues/4312

I favour specifying a particular environment rather than whatever `-latest` is. At the moment `-2019` is the same as `-latest`, and `-2022` is in beta. [Azure pipelines docs](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml)