### PR TITLE
Build Python 3.10 wheels for Mac

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,7 +56,7 @@ jobs:
     MACOSX_DEPLOYMENT_TARGET: 10.9
     HDF5_VERSION: 1.12.1
     HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
-    CIBW_BUILD: cp3{7,8,9}-macosx_x86_64
+    CIBW_BUILD: cp3{7,8,9,10}-macosx_x86_64
   steps:
     - template: ci/azure-pipelines-wheels.yml
       parameters:
@@ -311,6 +311,10 @@ jobs:
         python.version: '3.9'
         TOXENV: py39-test-deps,py39-test-mindeps,py39-test-deps-pre
         WHL_FILE: h5py*-cp39-*.whl
+      py310:
+        python.version: '3.10'
+        TOXENV: py310-test-deps,py310-test-mindeps,py310-test-deps-pre
+        WHL_FILE: h5py*-cp310-*.whl
 
   steps:
     - template: ci/azure-pipelines-test-wheels.yml

--- a/tox.ini
+++ b/tox.ini
@@ -22,10 +22,7 @@ deps =
     # TODO: update once Cython has a wheel for Python 3.10
     py310-mindeps: cython==0.29.24
 
-    py37-mindeps: numpy==1.14.5
-    py38-mindeps: numpy==1.17.5
-    py39-mindeps: numpy==1.19.3
-    py310-mindeps: numpy==1.21.3
+    mindeps: oldest-supported-numpy
 
     mpi4py: mpi4py>=3.0.2
 


### PR DESCRIPTION
This was removed from PR #1973 because it wasn't working. Unless it mysteriously starts working again, I'm probably going to leave it to Mac users to figure out, because I don't know how to investigate.