### PR TITLE
Switch to use oldest_supported_numpy for build-time requirements

### DIFF
--- a/news/oldest-supported-numpy.rst
+++ b/news/oldest-supported-numpy.rst
@@ -1,0 +1,31 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* h5py now requires the ``oldest-supported-numpy`` package at build time,
+  instead of maintaining its own list of the oldest supported NumPy versions.
+  The effect should be similar, but hopefully more reliable.
+
+Development
+-----------
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
 # Further build requirements - like numpy & cython - come from setup.py via
 # the PEP 517 interface.
-requires = ["setuptools", "wheel"]
+requires = ["setuptools", "wheel", "oldest-supported-numpy"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,13 @@
 [build-system]
 # Further build requirements - like numpy & cython - come from setup.py via
 # the PEP 517 interface.
-requires = ["setuptools", "wheel", "oldest-supported-numpy"]
+requires = [
+    "setuptools",
+    "wheel",
+    "oldest-supported-numpy",
+    "pkgconfig",
+    "Cython >=0.29; python_version<'3.8'",
+    "Cython >=0.29.14; python_version=='3.8'",
+    "Cython >=0.29.15; python_version>='3.9'",
+]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -37,17 +37,13 @@ RUN_REQUIRES = [
     "numpy >=1.14.5",
 ]
 
-# these are required to build h5py
+# Packages needed to build h5py (in addition to static list in pyproject.toml)
 # For packages we link to (numpy, mpi4py), we build against the oldest
 # supported version; h5py wheels should then work with newer versions of these.
 # Downstream packagers - e.g. Linux distros - can safely build with newer
 # versions.
-SETUP_REQUIRES = [
-    'pkgconfig',
-    "Cython >=0.29; python_version<'3.8'",
-    "Cython >=0.29.14; python_version=='3.8'",
-    "Cython >=0.29.15; python_version>='3.9'",
-]
+# TODO: setup_requires is deprecated in setuptools.
+SETUP_REQUIRES = []
 
 if setup_configure.mpi_enabled():
     RUN_REQUIRES.append('mpi4py >=3.0.2')

--- a/setup.py
+++ b/setup.py
@@ -49,10 +49,7 @@ SETUP_REQUIRES = [
     "Cython >=0.29; python_version<'3.8'",
     "Cython >=0.29.14; python_version=='3.8'",
     "Cython >=0.29.15; python_version>='3.9'",
-] # + [
-#     f"numpy =={np_min}; python_version{py_condition}"
-#     for np_min, py_condition in NUMPY_MIN_VERSIONS
-# ]
+]
 
 if setup_configure.mpi_enabled():
     RUN_REQUIRES.append('mpi4py >=3.0.2')

--- a/setup.py
+++ b/setup.py
@@ -49,10 +49,10 @@ SETUP_REQUIRES = [
     "Cython >=0.29; python_version<'3.8'",
     "Cython >=0.29.14; python_version=='3.8'",
     "Cython >=0.29.15; python_version>='3.9'",
-] + [
-    f"numpy =={np_min}; python_version{py_condition}"
-    for np_min, py_condition in NUMPY_MIN_VERSIONS
-]
+] # + [
+#     f"numpy =={np_min}; python_version{py_condition}"
+#     for np_min, py_condition in NUMPY_MIN_VERSIONS
+# ]
 
 if setup_configure.mpi_enabled():
     RUN_REQUIRES.append('mpi4py >=3.0.2')

--- a/setup.py
+++ b/setup.py
@@ -24,19 +24,17 @@ import setup_build, setup_configure
 
 VERSION = '3.5.0'
 
-# Minimum supported versions of Numpy & Cython depend on the Python version
-NUMPY_MIN_VERSIONS = [
-    # Numpy    Python
-    ('1.14.5', "=='3.7'"),
-    ('1.17.5', "=='3.8'"),
-    ('1.19.3', "=='3.9'"),
-    ('1.21.3', ">='3.10'"),
-]
 
 # these are required to use h5py
-RUN_REQUIRES = ["cached-property; python_version<'3.8'"] + [
-    f"numpy >={np_min}; python_version{py_condition}"
-    for np_min, py_condition in NUMPY_MIN_VERSIONS
+RUN_REQUIRES = [
+    "cached-property; python_version<'3.8'",
+    # We only really aim to support NumPy & Python combinations for which
+    # there are wheels on PyPI (e.g. NumPy >=1.17.5 for Python 3.8).
+    # But we don't want to duplicate the information in oldest-supported-numpy
+    # here, and if you can build an older NumPy on a newer Python, h5py probably
+    # works (assuming you build it from source too).
+    # NumPy 1.14.5 is the first with wheels for Python 3.7, our minimum Python.
+    "numpy >=1.14.5",
 ]
 
 # these are required to build h5py

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,8 @@
 """
 
 from setuptools import Extension, setup
-from distutils.cmd import Command
 import sys
 import os
-import os.path as op
 
 # Newer packaging standards may recommend removing the current dir from the
 # path, add it back if needed.


### PR DESCRIPTION
<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->

This should fix #1934 . `pip install h5py` is currently broken on arm64 Macs because h5py requests to build with an old version of NumPy that can't compile from source on arm64 Macs. While this has been fixed in [NumPy 1.21](https://github.com/numpy/numpy/pull/18900) and [1.20](https://github.com/numpy/numpy/pull/18923), the [devs say](https://github.com/numpy/numpy/issues/18160#issuecomment-959272955) they will not be making another release of NumPy 1.19.

The NumPy devs I spoke with recommended [oldest_supported_numpy](https://github.com/scipy/oldest-supported-numpy), which lets us easily specify build-time requirements that are aware of platform specific requirements. I have tested this on my own arm64 Mac, and I can now build locally.

This PR moves the build time NumPy requirements out of `SETUP_REQUIRES` in setup.py and into the build-system requires in `pyproject.toml`. Based on the oldest_supported_numpy [documentation](https://github.com/scipy/oldest-supported-numpy#can-i-use-this-if-my-package-requires-a-recent-version-of-numpy), I believe this shouldn't cause issues even if h5py requests a newer version at runtime.

`tox -e pre-commit` and `tox -e py39-test-deps` both pass.

Closes #1836