### PR TITLE
Don't install Cython for mindeps test runs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,12 +16,6 @@ deps =
     py39-deps: numpy>=1.19.3
     py310-deps: numpy>=1.21.3
 
-    py37-mindeps: cython==0.29
-    py38-mindeps: cython==0.29.14
-    py39-mindeps: cython==0.29.15
-    # TODO: update once Cython has a wheel for Python 3.10
-    py310-mindeps: cython==0.29.24
-
     py37-mindeps: numpy==1.14.5
     py38-mindeps: numpy==1.17.5
     py39-mindeps: numpy==1.19.3


### PR DESCRIPTION
Since we have a `pyproject.toml` file, pip will build h5py in an isolated build environment by default, and install Cython & other build dependencies there. It doesn't look like Tox overrides that - I used the `-v` flag to see how it calls pip, and there's a call like:

```
.../python -m pip install --no-deps -U .tox/.tmp/package/1/h5py-3.5.0.tar.gz >.tox/py310-test-deps/log/py310-test-deps-4.log
```

i.e. the `--no-build-isolation` flag is not used. So the version of Cython which tox installs into the test environment is irrelevant.

We could probably work out some way to keep testing with the oldest Cython we claim to support. But build isolation also makes this less important, because in most scenarios h5py will now be built with the newest available Cython by default. So I'd like to take the opportunity to simplify (& hopefully speed up) the tests a little bit.