### PR TITLE
Correct docs: rdcc_nslots is per dataset

### DIFF
--- a/docs/high/file.rst
+++ b/docs/high/file.rst
@@ -325,7 +325,7 @@ chunk cache*.
   closer to 0, and if the application does not, the value should be set closer
   to 1.
 * ``rdcc_nslots`` is the number of chunk slots in
-  the cache for this entire file.  In order to allow the chunks to be looked up
+  the cache for each dataset.  In order to allow the chunks to be looked up
   quickly in cache, each chunk is assigned a unique hash value that is used to
   look up the chunk.  The cache contains a simple array of pointers to chunks,
   which is called a hash table.  A chunk's hash value is simply the index into


### PR DESCRIPTION
@ajelenak while we're looking at chunk cache parameters, can you confirm this? The HDF5 docs (e.g. [H5Pset_chunk_cache](https://portal.hdfgroup.org/display/HDF5/H5P_SET_CHUNK_CACHE)) seem clear that this `rdcc_nslots` is per dataset, I was only hesitating because h5py's docs say confidently that it's for the entire file, and I don't where that comes from.

Closes #1869.