### PR TITLE
Explicit configuration for Readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,13 @@
+version: 2  # Required
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
+sphinx:
+   configuration: docs/conf.py
+
+python:
+   install:
+   - requirements: docs/requirements-rtd.txt

--- a/docs/requirements-rtd.txt
+++ b/docs/requirements-rtd.txt
@@ -1,0 +1,3 @@
+sphinx==4.3.0
+sphinx_rtd_theme==1.0.0
+readthedocs-sphinx-search==0.1.1


### PR DESCRIPTION
I just noticed RTD builds have been failing (old version of Sphinx was being used alongside a new docutils. This should fix it, by upgrading to the latest Sphinx.

I've also enabled pull request integration on RTD, so we should get a status for this.