### PR TITLE
Refine how aarch64 wheels are named for upload to anaconda.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,4 +70,4 @@ after_success:
   # ANACONDA_ORG_UPLOAD_TOKEN is a secret token
   # used in Travis CI config, originally
   # generated at anaconda.org for scipy-wheels-nightly (cron jobs).
-    - if [[ $CIBW_ARCHS == aarch64 && "$TRAVIS_EVENT_TYPE" == "cron" ]]; then bash ci/upload_wheels.sh; fi
+    - if [[ $CIBW_ARCHS == aarch64 ]]; then bash ci/upload_wheels.sh; fi

--- a/ci/upload_wheels.sh
+++ b/ci/upload_wheels.sh
@@ -7,12 +7,14 @@ if [[ "$TRAVIS_EVENT_TYPE" != "cron" && -z "$TRAVIS_TAG" ]] ; then
 fi
 
 # rename wheels if not on a tag
-# inserting short commit hash as build tag in wheel filename
+# inserting commit count & hash from git describe
 # e.g. h5py-3.3.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl to
-#   h5py-3.3.0-0e2d161a0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+#   h5py-3.3.0-3-g4320f2ea-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
 if [[ -z "$TRAVIS_TAG" ]] ; then
-  # build tag has to start with a decimal digit, so prefix 0 on commit hash
-  build_tag="0$(git rev-parse --short=8 HEAD)"
+  descr=$(git describe --tags)
+  descr=${descr#*-}  # Chop off tag (should be version number)
+  build_tag=${descr//-/_}  # Convert - to _ for build tag
+  echo "Setting build tag to ${build_tag}"
   for whl in "${TRAVIS_BUILD_DIR}"/wheelhouse/h5py-*.whl; do
     newname=$(echo "$whl" | sed "s/\(h5py-[0-9][0-9]*[.[0-9]*]*-\)\(cp*\)/\1${build_tag}-\2/")
      if [ "$newname" != "$whl" ]; then

--- a/ci/upload_wheels.sh
+++ b/ci/upload_wheels.sh
@@ -1,17 +1,27 @@
 ANACONDA_ORG="scipy-wheels-nightly";
 pip install git+https://github.com/Anaconda-Server/anaconda-client;
 
-# rename wheels
-# appending timestamp to wheels package name
-# e.g. h5py-3.3.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl to h5py-3.3.0-20211004151033-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-for whl in ${TRAVIS_BUILD_DIR}/wheelhouse/h5py-*.whl; do
-	newname=$(echo "$whl" | sed "s/\(h5py-[0-9][0-9]*[.[0-9]*]*-\)\(cp*\)/\1$(date '+%Y%m%d%H%M%S')-\2/")
-   if [ "$newname" != "$whl" ]; then
-       mv $whl $newname
-   fi
-done
+if [[ "$TRAVIS_EVENT_TYPE" != "cron" && -z "$TRAVIS_TAG" ]] ; then
+  echo "Not uploading wheels (build not for cron or git tag)"
+  exit 0
+fi
+
+# rename wheels if not on a tag
+# inserting short commit hash as build tag in wheel filename
+# e.g. h5py-3.3.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl to
+#   h5py-3.3.0-0e2d161a0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+if [[ -z "$TRAVIS_TAG" ]] ; then
+  # build tag has to start with a decimal digit, so prefix 0 on commit hash
+  build_tag="0$(git rev-parse --short=8 HEAD)"
+  for whl in "${TRAVIS_BUILD_DIR}"/wheelhouse/h5py-*.whl; do
+    newname=$(echo "$whl" | sed "s/\(h5py-[0-9][0-9]*[.[0-9]*]*-\)\(cp*\)/\1${build_tag}-\2/")
+     if [ "$newname" != "$whl" ]; then
+         mv "$whl" "$newname"
+     fi
+  done
+fi
 
 # upload wheels
 if [[ -n "${ANACONDA_ORG_UPLOAD_TOKEN}" ]] ; then
-   anaconda -t ${ANACONDA_ORG_UPLOAD_TOKEN} upload --force -u ${ANACONDA_ORG} ${TRAVIS_BUILD_DIR}/wheelhouse/h5py-*.whl;
+   anaconda -t ${ANACONDA_ORG_UPLOAD_TOKEN} upload -u ${ANACONDA_ORG} "${TRAVIS_BUILD_DIR}"/wheelhouse/h5py-*.whl;
 fi;


### PR DESCRIPTION
When pushing a tag, upload a wheel without inserting a build tag in the name; we can collect these and conveniently re-upload them to PyPI.

When adding a build tag for wheels built by cron jobs, use the git commit hash instead of a timestamp. This should avoid uploading a duplicate file if there are no changes since the last one - the upload will fail because the file already exists. On the other hand, it means the build tags are no longer ordered. We may be able to do something smarter with `git describe` if that's a concern.