### PR TITLE
Use pre-commit.ci for pre-commit CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,6 @@ repos:
     rev: "0.39"
     hooks:
     -   id: check-manifest
+
+ci:
+    autoupdate_schedule: monthly

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ jobs:
   pool:
     vmImage: ubuntu-20.04
   variables:
-    TOXENV: docs,checkreadme,pre-commit,rever
+    TOXENV: docs,checkreadme,rever
   steps:
     - task: UsePythonVersion@0
       inputs:


### PR DESCRIPTION
https://pre-commit.ci/ is a CI service specific to `pre-commit`. It's meant to be faster than running pre-commit in regular CI (because it can do shared caching), and it can also commit changes directly rather than failing until contributors make them.

I've enabled it for this repo, so it should run on this PR.