### PR TITLE
Don't re-enable garbage collection if it was disabled before

### DIFF
--- a/h5py/_objects.pyx
+++ b/h5py/_objects.pyx
@@ -119,11 +119,13 @@ def nonlocal_close():
 
     # create a cached list of ids whilst the gc is disabled to avoid hitting
     # the cyclic gc while iterating through the registry dict
+    gc_was_enabled = gc.isenabled()
     gc.disable()
     try:
         reg_ids = list(registry)
     finally:
-        gc.enable()
+        if gc_was_enabled:
+            gc.enable()
 
     for python_id in reg_ids:
         ref = registry.get(python_id)

--- a/h5py/h5f.pyx
+++ b/h5py/h5f.pyx
@@ -283,6 +283,7 @@ def get_obj_ids(object where=OBJ_ALL, int types=H5F_OBJ_ALL):
             # Garbage collection might dealloc a Python object & call H5Idec_ref
             # between getting an HDF5 ID and calling H5Iinc_ref, breaking it.
             # Disable GC until we have inc_ref'd the IDs to keep them alive.
+            gc_was_enabled = gc.isenabled()
             gc.disable()
             try:
                 H5Fget_obj_ids(where_id, types, count, obj_list)
@@ -291,7 +292,8 @@ def get_obj_ids(object where=OBJ_ALL, int types=H5F_OBJ_ALL):
                     # The HDF5 function returns a borrowed reference for each hid_t.
                     H5Iinc_ref(obj_list[i])
             finally:
-                gc.enable()
+                if gc_was_enabled:
+                    gc.enable()
 
         return py_obj_list
 

--- a/news/gc-check-reenable.rst
+++ b/news/gc-check-reenable.rst
@@ -1,0 +1,30 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* Closing a file or calling ``get_obj_ids()`` no longer re-enables Python
+  garbage collection if it was previously disabled.
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
As @martindurant pointed out on #2019, we disable the garbage collector and then re-enable, assuming that it was enabled before. If someone explicitly disables it, we should skip re-enabling it.

We only do this in 2 places so far, so I didn't bother with an abstraction for it.