### PR TITLE
MAINT: use super() as described by PEP 3135

### DIFF
--- a/examples/swmr_multiprocess.py
+++ b/examples/swmr_multiprocess.py
@@ -24,7 +24,7 @@ from multiprocessing import Process, Event
 
 class SwmrReader(Process):
     def __init__(self, event, fname, dsetname, timeout = 2.0):
-        super(SwmrReader, self).__init__()
+        super().__init__()
         self._event = event
         self._fname = fname
         self._dsetname = dsetname
@@ -54,7 +54,7 @@ class SwmrReader(Process):
 
 class SwmrWriter(Process):
     def __init__(self, event, fname, dsetname):
-        super(SwmrWriter, self).__init__()
+        super().__init__()
         self._event = event
         self._fname = fname
         self._dsetname = dsetname

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -586,7 +586,7 @@ class Dataset(HLObject):
         """
         if not isinstance(bind, h5d.DatasetID):
             raise ValueError("%s is not a DatasetID" % bind)
-        super(Dataset, self).__init__(bind)
+        super().__init__(bind)
 
         self._dcpl = self.id.get_create_plist()
         self._dxpl = h5p.create(h5p.DATASET_XFER)

--- a/h5py/_hl/datatype.py
+++ b/h5py/_hl/datatype.py
@@ -40,7 +40,7 @@ class Datatype(HLObject):
         """
         if not isinstance(bind, TypeID):
             raise ValueError("%s is not a TypeID" % bind)
-        super(Datatype, self).__init__(bind)
+        super().__init__(bind)
 
     @with_phil
     def __repr__(self):

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -511,7 +511,7 @@ class File(Group):
             else:
                 self._libver = (libver, 'latest')
 
-        super(File, self).__init__(fid)
+        super().__init__(fid)
 
     def close(self):
         """ Close the file.  All open objects become invalid """

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -37,7 +37,7 @@ class Group(HLObject, MutableMappingHDF5):
         with phil:
             if not isinstance(bind, h5g.GroupID):
                 raise ValueError("%s is not a GroupID" % bind)
-            super(Group, self).__init__(bind)
+            super().__init__(bind)
 
 
     _gcpl_crt_order = h5p.create(h5p.GROUP_CREATE)

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -435,7 +435,7 @@ class TestNewLibver(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestNewLibver, cls).setUpClass()
+        super().setUpClass()
 
         # Current latest library bound label
         if h5py.version.hdf5_version_tuple < (1, 11, 4):

--- a/h5py/tests/test_slicing.py
+++ b/h5py/tests/test_slicing.py
@@ -321,7 +321,7 @@ class TestFieldNames(BaseSlicing):
 class TestMultiBlockSlice(BaseSlicing):
 
     def setUp(self):
-        super(TestMultiBlockSlice, self).setUp()
+        super().setUp()
         self.arr = np.arange(10)
         self.dset = self.f.create_dataset('x', data=self.arr)
 


### PR DESCRIPTION
This PR refactors `super()` to be simpler, as described by [PEP 3135](https://www.python.org/dev/peps/pep-3135/) and approved in 2007 for Python 3.0.

The "old" convention (e.g. `super(C, self)`) was only required to support Python 2.
