### PR TITLE
MAINT: Python3 classes do not need to inherit from object

### DIFF
--- a/api_gen.py
+++ b/api_gen.py
@@ -28,7 +28,7 @@ import re
 import os.path as op
 
 
-class Line(object):
+class Line:
 
     """
         Represents one line from the api_functions.txt file.
@@ -164,7 +164,7 @@ from ._errors cimport set_exception, set_default_error_handler
 """
 
 
-class LineProcessor(object):
+class LineProcessor:
 
     def run(self):
 

--- a/examples/threading_example.py
+++ b/examples/threading_example.py
@@ -106,7 +106,7 @@ class ComputeThread(threading.Thread):
 
         self.eventcall()
 
-class ComputeWidget(object):
+class ComputeWidget:
 
     """
         Responsible for input widgets, and starting new computation threads.
@@ -209,7 +209,7 @@ class ComputeWidget(object):
         self.suggest = (self.suggest+1)%len(suggestions)
 
 
-class ViewWidget(object):
+class ViewWidget:
 
     """
         Draws images using the datasets recorded in the HDF5 file.  Also

--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -152,7 +152,7 @@ def is_empty_dataspace(obj):
     return False
 
 
-class CommonStateObject(object):
+class CommonStateObject:
 
     """
         Mixin class that allows sharing information between objects which
@@ -225,7 +225,7 @@ class CommonStateObject(object):
         return name
 
 
-class _RegionProxy(object):
+class _RegionProxy:
 
     """
         Proxy object which handles region references.
@@ -478,7 +478,7 @@ class MutableMappingHDF5(MappingHDF5, MutableMapping):
     pass
 
 
-class Empty(object):
+class Empty:
 
     """
         Proxy object to represent empty/null dataspaces (a.k.a H5S_NULL).

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -147,7 +147,7 @@ def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
     return dset_id
 
 
-class AstypeWrapper(object):
+class AstypeWrapper:
     """Wrapper to convert data on reading from a dataset.
     """
     def __init__(self, dset, dtype):
@@ -249,7 +249,7 @@ def readtime_dtype(basetype, names):
 
 
 if MPI:
-    class CollectiveContext(object):
+    class CollectiveContext:
 
         """ Manages collective I/O in MPI mode """
 
@@ -267,7 +267,7 @@ if MPI:
             self._dset._dxpl.set_dxpl_mpio(h5fd.MPIO_INDEPENDENT)
 
 
-class ChunkIterator(object):
+class ChunkIterator:
     """
     Class to iterate through list of chunks of a given dataset
     """

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -625,7 +625,7 @@ class Group(HLObject, MutableMappingHDF5):
         return r
 
 
-class HardLink(object):
+class HardLink:
 
     """
         Represents a hard link in an HDF5 file.  Provided only so that
@@ -635,7 +635,7 @@ class HardLink(object):
     pass
 
 
-class SoftLink(object):
+class SoftLink:
 
     """
         Represents a symbolic ("soft") link in an HDF5 file.  The path
@@ -655,7 +655,7 @@ class SoftLink(object):
         return '<SoftLink to "%s">' % self.path
 
 
-class ExternalLink(object):
+class ExternalLink:
 
     """
         Represents an HDF5 external link.  Paths may be absolute or relative.

--- a/h5py/_hl/selections.py
+++ b/h5py/_hl/selections.py
@@ -82,7 +82,7 @@ def select(shape, args, dataset=None):
     return selector.make_selection(args)
 
 
-class Selection(object):
+class Selection:
 
     """
         Base class for HDF5 dataspace selections.  Subclasses support the

--- a/h5py/_hl/selections2.py
+++ b/h5py/_hl/selections2.py
@@ -71,7 +71,7 @@ def read_selections_scalar(dsid, args):
 
     return out_shape, source_space
 
-class ScalarReadSelection(object):
+class ScalarReadSelection:
 
     """
         Implements slicing for scalar datasets.

--- a/h5py/_hl/vds.py
+++ b/h5py/_hl/vds.py
@@ -69,7 +69,7 @@ def _convert_space_for_key(space, key):
         space.select_hyperslab(start, count, stride, block)
 
 
-class VirtualSource(object):
+class VirtualSource:
     """Source definition for virtual data sets.
 
     Instantiate this class to represent an entire source dataset, and then
@@ -143,7 +143,7 @@ class VirtualSource(object):
         _convert_space_for_key(tmp.sel.id, key)
         return tmp
 
-class VirtualLayout(object):
+class VirtualLayout:
     """Object for building a virtual dataset.
 
     Instantiate this class to define a virtual dataset, assign to slices of it

--- a/h5py/_selector.pyx
+++ b/h5py/_selector.pyx
@@ -374,7 +374,7 @@ cdef class Reader:
             return arr
 
 
-class MultiBlockSlice(object):
+class MultiBlockSlice:
     """
         A conceptual extension of the built-in slice object to allow selections
         using start, stride, count and block.

--- a/h5py/h5.pyx
+++ b/h5py/h5.pyx
@@ -27,7 +27,7 @@ NUMPY_VERSION_COMPILED_AGAINST = NUMPY_BUILD_VERSION
 CYTHON_VERSION_COMPILED_WITH = CYTHON_BUILD_VERSION
 
 
-class ByteStringContext(object):
+class ByteStringContext:
 
     def __init__(self):
         self._readbytes = False

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -824,7 +824,7 @@ class TestPickle(TestCase):
 # unittest doesn't work with pytest fixtures (and possibly other features),
 # hence no subclassing TestCase
 @pytest.mark.mpi
-class TestMPI(object):
+class TestMPI:
     def test_mpio(self, mpi_file_name):
         """ MPIO driver and options """
         from mpi4py import MPI

--- a/h5py/tests/test_vds/test_highlevel_vds.py
+++ b/h5py/tests/test_vds/test_highlevel_vds.py
@@ -64,7 +64,7 @@ Unit test for the high level vds interface for excalibur
 https://support.hdfgroup.org/HDF5/docNewFeatures/VDS/HDF5-VDS-requirements-use-cases-2014-12-10.pdf
 '''
 
-class ExcaliburData(object):
+class ExcaliburData:
     FEM_PIXELS_PER_CHIP_X = 256
     FEM_PIXELS_PER_CHIP_Y = 256
     FEM_CHIPS_PER_STRIPE_X = 8

--- a/h5py/tests/test_vds/test_lowlevel_vds.py
+++ b/h5py/tests/test_vds/test_lowlevel_vds.py
@@ -87,7 +87,7 @@ https://support.hdfgroup.org/HDF5/docNewFeatures/VDS/HDF5-VDS-requirements-use-c
 '''
 
 
-class ExcaliburData(object):
+class ExcaliburData:
     FEM_PIXELS_PER_CHIP_X = 256
     FEM_PIXELS_PER_CHIP_Y = 256
     FEM_CHIPS_PER_STRIPE_X = 8


### PR DESCRIPTION
See this [Q/A](https://stackoverflow.com/questions/4015417/why-do-python-classes-inherit-object) for a background on `class Foo(object):` vs `class Foo:`.

In summary, only Python 2 required inheriting from `object`, but this is no longer necessary with Python 3 (and the docs don't use that style [here](https://docs.python.org/3/tutorial/classes.html) or [here](https://docs.python.org/3/howto/descriptor.html)). This PR keeps the base classes a bit tidier and quicker to identify.

Edits were automated using:

    git ls-files -z | xargs -0 sed -i -re 's/class (.*)\(object\):/class \1:/g'