### PR TITLE
Fix dll path on Cygwin.

### DIFF
--- a/setup_configure.py
+++ b/setup_configure.py
@@ -200,14 +200,16 @@ class HDF5LibWrapper:
         if sys.platform.startswith('darwin'):
             default_path = 'libhdf5.dylib'
             regexp = re.compile(r'^libhdf5.dylib')
-        elif sys.platform.startswith('win') or \
-            sys.platform.startswith('cygwin'):
+        elif sys.platform.startswith('win'):
             default_path = 'hdf5.dll'
             regexp = re.compile(r'^hdf5.dll')
             if sys.version_info >= (3, 8):
                 # To overcome "difficulty" loading the library on windows
                 # https://bugs.python.org/issue42114
                 load_kw['winmode'] = 0
+        elif sys.platform.startswith('cygwin'):
+            default_path = 'cyghdf5-200.dll'
+            regexp = re.compile(r'^cyghdf5-\d+.dll$')
         else:
             default_path = 'libhdf5.so'
             regexp = re.compile(r'^libhdf5.so')


### PR DESCRIPTION
Cygwin uses [a `cyg${libname}-${SOVERSION}.dll` naming scheme for shared libraries](https://cygwin.com/cgi-bin2/package-cat.cgi?file=x86_64%2Flibhdf5_200%2Flibhdf5_200-1.12.1-1&grep=libhdf5), rather than the lib${libname}.so.${SOVERSION} of linux or the ${libname}.dll that is apparently used on Windows.  This patch assumes the shared library name is used by `dlopen` or similar, because [the import library used for normal linking uses a `lib${libname}.dll.a` naming scheme](https://cygwin.com/cgi-bin2/package-cat.cgi?file=x86_64%2Flibhdf5-devel%2Flibhdf5-devel-1.12.1-1&grep=libhdf5).

Fixes #1240 for use on Cygwin.

<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->
