### PR TITLE
Support setting the data alignment within the HDF5 file

### DIFF
--- a/docs/high/file.rst
+++ b/docs/high/file.rst
@@ -367,6 +367,24 @@ chunk cache*.
 Chunks and caching are described in greater detail in the `HDF5 documentation
 <https://portal.hdfgroup.org/display/HDF5/Chunking+in+HDF5>`_.
 
+.. _file_alignment:
+
+Data alignment
+--------------
+
+When creating datasets within files, it may be advantageous to align the offset
+within the file itself. This can help optimize read and write times if the data
+become aligned with the underlying hardware, or may help with parallelism with
+MPI. Unfortunately, aligning small variables to large blocks can leave alot of
+empty space in a file. To this effect, application developers are left with two
+options to tune the alignment of data within their file.  The two variables
+``alignment_threshold`` and ``alignment_interval``  in the :class:`File`
+constructor help control the threshold in bytes where the data alignment policy
+takes effect and the alignment in bytes within the file. The alignment is
+measured from the end of the user block.
+
+For more information, see the official HDF5 documentation `H5P_SET_ALIGNMENT
+<https://portal.hdfgroup.org/display/HDF5/H5P_SET_ALIGNMENT>`_.
 
 Reference
 ---------
@@ -418,6 +436,13 @@ Reference
     :param fs_threshold: The smallest free-space section size that the free
             space manager will track. Only allowed when creating a new file.
             The default is 1.
+    :param alignment_threshold: Together with ``alignment_interval``, this
+            property ensures that any file object greater than or equal
+            in size to the alignement threshold (in bytes) will be
+            aligned on an address which is a multiple of alignment interval.
+    :param alignment_interval: This property should be used in conjunction with
+            ``alignment_threshold``. See the description above. For more
+            details, see :ref:`file_alignment`.
     :param kwds:    Driver-specific keywords; see :ref:`file_driver`.
 
     .. method:: __bool__()

--- a/h5py/tests/test_file_alignment.py
+++ b/h5py/tests/test_file_alignment.py
@@ -1,0 +1,103 @@
+import h5py
+from .common import TestCase
+
+
+def is_aligned(dataset, offset=4096):
+    # Here we check if the dataset is aligned
+    return dataset.id.get_offset() % offset == 0
+
+
+def dataset_name(i):
+    return f"data{i:03}"
+
+
+class TestFileAlignment(TestCase):
+    """
+        Ensure that setting the file alignment has the desired effect
+        in the internal structure.
+    """
+    def test_no_alignment_set(self):
+        fname = self.mktemp()
+        # 881 is a prime number, so hopefully this help randomize the alignment
+        # enough
+        # A nice even number might give a pathological case where
+        # While we don't want the data to be aligned, it ends up aligned...
+        shape = (881,)
+
+        with h5py.File(fname, 'w') as h5file:
+            # Create up to 1000 datasets
+            # At least one of them should be misaligned.
+            # While this isn't perfect, it seems that there
+            # The case where 1000 datasets get created is one where the data
+            # is aligned. Therefore, during correct operation, this test is
+            # expected to finish quickly
+            for i in range(1000):
+                dataset = h5file.create_dataset(
+                    dataset_name(i), shape, dtype='uint8')
+                # Assign data so that the dataset is instantiated in
+                # the file
+                dataset[...] = i
+                if not is_aligned(dataset):
+                    # Break early asserting that the file is not aligned
+                    break
+            else:
+                raise RuntimeError("Data was all found to be aligned to 4096")
+
+    def test_alignment_set_above_threshold(self):
+        # 2022/01/19 hmaarrfk
+        # UnitTest (TestCase) doesn't play well with pytest parametrization.
+        alignment_threshold = 1000
+        alignment_interval = 4096
+
+        for shape in [
+            (1033,),  # A prime number above the thresold
+            (1000,),  # Exactly equal to the threshold
+            (1001,),  # one above the threshold
+        ]:
+            fname = self.mktemp()
+            with h5py.File(fname, 'w',
+                           alignment_threshold=alignment_threshold,
+                           alignment_interval=alignment_interval) as h5file:
+                # Create up to 1000 datasets
+                # They are all expected to be aligned
+                for i in range(1000):
+                    dataset = h5file.create_dataset(
+                        dataset_name(i), shape, dtype='uint8')
+                    # Assign data so that the dataset is instantiated in
+                    # the file
+                    dataset[...] = i
+                    assert is_aligned(dataset, offset=alignment_interval)
+
+    def test_alignment_set_below_threshold(self):
+        # 2022/01/19 hmaarrfk
+        # UnitTest (TestCase) doesn't play well with pytest parametrization.
+        alignment_threshold = 1000
+        alignment_interval = 1024
+
+        for shape in [
+            (881,),  # A prime number below the thresold
+            (999,),  # Exactly one below the threshold
+        ]:
+            fname = self.mktemp()
+            with h5py.File(fname, 'w',
+                           alignment_threshold=alignment_threshold,
+                           alignment_interval=alignment_interval) as h5file:
+                # Create up to 1000 datasets
+                # At least one of them should be misaligned.
+                # While this isn't perfect, it seems that there
+                # The case where 1000 datasets get created is one where the
+                # data is aligned. Therefore, during correct operation, this
+                # test is expected to finish quickly
+                for i in range(1000):
+                    dataset = h5file.create_dataset(
+                        dataset_name(i), shape, dtype='uint8')
+                    # Assign data so that the dataset is instantiated in
+                    # the file
+                    dataset[...] = i
+                    if not is_aligned(dataset, offset=alignment_interval):
+                        # Break early asserting that the file is not aligned
+                        break
+                else:
+                    raise RuntimeError(
+                        "Data was all found to be aligned to "
+                        f"{alignment_interval}. This is highly unlikely.")

--- a/news/enable_file_alignment.rst
+++ b/news/enable_file_alignment.rst
@@ -1,0 +1,31 @@
+New features
+------------
+
+* The ``File`` constructor contains two new parameters ``alignment_threshold``,
+  and ``alignment_interval`` controling the data alignment within the HDF5
+  file.
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->

Closes: https://github.com/h5py/h5py/issues/2034

Questions I have:
- [ ] May I simply cross-reference the HDF5 documentation? I feel like rewording is more dangerous than simply pointing the user to the right place.

TODO: add tests
- [x] Create a test that without alignment will create a datasets, then check their id offsets to ensure that at least one dataset is misaligned.
- [x] Set the property list, and then create 10 datasets, ensure they are all aligned if they are above the threshold.
- [x] Create datasets that are under the threshold, ensure at least one of them is misaligned.

The reason for the "at least one" is that one may get lucky with the alignment, though it is very improbable they they get lucky many times in a row.

Release note sample:

> New parameters are provided to the ``File`` constructor to control data alignment via the file access property lists. The new parameters, `alignment_threshold` and `alignment_interval` are passed to ``H5Pset_alignment`` during file creation and opening.