### PR TITLE
Create new attributes directly

### DIFF
--- a/h5py/tests/test_attrs.py
+++ b/h5py/tests/test_attrs.py
@@ -263,6 +263,7 @@ class TestTrackOrder(BaseAttrs):
             group.attrs[str(i)] = i
         return group
 
+    @ut.skipUnless(h5py.version.hdf5_version_tuple >= (1, 10, 6), 'HDF5 1.10.6 required')
     def test_track_order_overwrite_delete(self):
         # issue 1385
         group = self.fill_attrs2(track_order=True)  # creation order

--- a/h5py/tests/test_attrs.py
+++ b/h5py/tests/test_attrs.py
@@ -257,6 +257,24 @@ class TestTrackOrder(BaseAttrs):
         self.assertEqual(list(attrs),
                          sorted([str(i) for i in range(100)]))
 
+    def fill_attrs2(self, track_order):
+        group = self.f.create_group('test', track_order=track_order)
+        for i in range(12):
+            group.attrs[str(i)] = i
+        return group
+
+    def test_track_order_overwrite_delete(self):
+        # issue 1385
+        group = self.fill_attrs2(track_order=True)  # creation order
+        self.assertEqual(group.attrs["11"], 11)
+        # overwrite attribute
+        group.attrs['11'] = 42.0
+        self.assertEqual(group.attrs["11"], 42.0)
+        # delete attribute
+        self.assertIn('10', group.attrs)
+        del group.attrs['10']
+        self.assertNotIn('10', group.attrs)
+
 
 class TestDatatype(BaseAttrs):
 

--- a/news/create-new-attrs-directly.rst
+++ b/news/create-new-attrs-directly.rst
@@ -1,0 +1,31 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* New attributes are created directly instead via a temporary
+attribute with subsequent renaming. This fixes overwriting
+attributes with ``track_order=True``.
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>

--- a/news/create-new-attrs-directly.rst
+++ b/news/create-new-attrs-directly.rst
@@ -16,9 +16,9 @@ Exposing HDF5 functions
 Bug fixes
 ---------
 
-* New attributes are created directly instead via a temporary
-attribute with subsequent renaming. This fixes overwriting
-attributes with ``track_order=True``.
+* New attributes are created directly, instead of via a temporary
+  attribute with subsequent renaming. This fixes overwriting
+  attributes with ``track_order=True``.
 
 Building h5py
 -------------


### PR DESCRIPTION
Create new attributes directly instead via temporary attribute with subsequent rename. This fixes overwriting attributes if ``track_order=True``.

Fixes #1385 

<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->
