### PR TITLE
Fix fillvalue str

### DIFF
--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -118,8 +118,9 @@ def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
             # fake vlen dtype for fixed len string fillvalue
             # to not trigger unwanted encoding
             dtype = h5t.string_dtype(string_info.encoding)
-
-        fillvalue = numpy.array(fillvalue, dtype=dtype)
+            fillvalue = numpy.array(fillvalue, dtype=dtype)
+        else:
+            fillvalue = numpy.array(fillvalue)
         dcpl.set_fill_value(fillvalue)
 
     if track_times is None:

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -112,7 +112,7 @@ def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
         maxshape, scaleoffset, external, allow_unknown_filter)
 
     if fillvalue is not None:
-        fillvalue = numpy.array(fillvalue)
+        fillvalue = numpy.array(fillvalue, dtype=dtype)
         dcpl.set_fill_value(fillvalue)
 
     if track_times is None:

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -112,6 +112,13 @@ def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
         maxshape, scaleoffset, external, allow_unknown_filter)
 
     if fillvalue is not None:
+        # prepare string-type dtypes for fillvalue
+        string_info = h5t.check_string_dtype(dtype)
+        if string_info is not None:
+            # fake vlen dtype for fixed len string fillvalue
+            # to not trigger unwanted encoding
+            dtype = h5t.string_dtype(string_info.encoding)
+
         fillvalue = numpy.array(fillvalue, dtype=dtype)
         dcpl.set_fill_value(fillvalue)
 

--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -548,7 +548,7 @@ cdef class PropDCID(PropOCID):
             tid = py_create(value.dtype, logical=1)
             ret = H5Pget_fill_value(self.id, tid.id, &c_ptr)
             fill_value = c_ptr
-            value[0] = fill_value.decode(string_info.encoding, "surrogateescape")
+            value[0] = fill_value
             return
 
         tid = py_create(value.dtype)

--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -510,16 +510,18 @@ cdef class PropDCID(PropOCID):
 
         check_numpy_read(value, -1)
 
-        # check for vlen strings
+        # check for strings
         # create correct typeID and pointer to c_str
         string_info = check_string_dtype(value.dtype)
         if string_info is not None:
-            if string_info[0] in ["utf-8", "ascii"] and string_info[1] is None:
-                fill_value = value.item()
-                c_ptr = fill_value
-                tid = py_create(value.dtype, logical=1)
-                H5Pset_fill_value(self.id, tid.id, &c_ptr)
-                return
+            # if needed encode fill_value
+            fill_value = value.item()
+            if not isinstance(fill_value, bytes):
+                fill_value = fill_value.encode(string_info.encoding)
+            c_ptr = fill_value
+            tid = py_create(value.dtype, logical=1)
+            H5Pset_fill_value(self.id, tid.id, &c_ptr)
+            return
 
         tid = py_create(value.dtype)
         H5Pset_fill_value(self.id, tid.id, value.data)

--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -541,10 +541,10 @@ cdef class PropDCID(PropOCID):
 
         check_numpy_write(value, -1)
 
-        # check for strings
+        # check for vlen strings
         # create correct typeID and convert from c_str pointer to string
         string_info = check_string_dtype(value.dtype)
-        if string_info is not None:
+        if string_info is not None and string_info.length is None:
             tid = py_create(value.dtype, logical=1)
             ret = H5Pget_fill_value(self.id, tid.id, &c_ptr)
             fill_value = c_ptr
@@ -553,7 +553,6 @@ cdef class PropDCID(PropOCID):
 
         tid = py_create(value.dtype)
         H5Pget_fill_value(self.id, tid.id, value.data)
-
 
     @with_phil
     def fill_value_defined(self):

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1060,6 +1060,12 @@ class TestStrings(BaseDataset):
         string_info = h5py.check_string_dtype(ds.dtype)
         self.assertEqual(string_info.encoding, 'ascii')
 
+    def test_vlen_bytes_fillvalue(self):
+        """ Vlen bytes dataset handles fillvalue """
+        dt = h5py.string_dtype(encoding='ascii')
+        ds = self.f.create_dataset('x', (100,), dtype=dt, fillvalue='bar')
+        self.assertEqual(self.f['x'][0], b'bar')
+
     def test_vlen_unicode(self):
         """ Vlen unicode dataset maps to vlen utf-8 in the file """
         dt = h5py.string_dtype()
@@ -1069,6 +1075,12 @@ class TestStrings(BaseDataset):
         self.assertEqual(tid.get_cset(), h5py.h5t.CSET_UTF8)
         string_info = h5py.check_string_dtype(ds.dtype)
         self.assertEqual(string_info.encoding, 'utf-8')
+
+    def test_vlen_unicode_fillvalue(self):
+        """ Vlen unicode dataset handles fillvalue """
+        dt = h5py.string_dtype()
+        ds = self.f.create_dataset('x', (100,), dtype=dt, fillvalue='bar')
+        self.assertEqual(self.f['x'][0], b'bar')
 
     def test_fixed_ascii(self):
         """ Fixed-length bytes dataset maps to fixed-length ascii in the file

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1067,7 +1067,7 @@ class TestStrings(BaseDataset):
         ds = self.f.create_dataset('x', (100,), dtype=dt, fillvalue=fill_value)
         self.assertEqual(self.f['x'][0], fill_value)
         self.assertEqual(self.f['x'].asstr()[0], fill_value.decode())
-        self.assertEqual(self.f['x'].fillvalue, fill_value.decode())
+        self.assertEqual(self.f['x'].fillvalue, fill_value)
 
     def test_vlen_unicode(self):
         """ Vlen unicode dataset maps to vlen utf-8 in the file """
@@ -1086,7 +1086,7 @@ class TestStrings(BaseDataset):
         ds = self.f.create_dataset('x', (100,), dtype=dt, fillvalue=fill_value)
         self.assertEqual(self.f['x'][0], fill_value.encode("utf-8"))
         self.assertEqual(self.f['x'].asstr()[0], fill_value)
-        self.assertEqual(self.f['x'].fillvalue, fill_value)
+        self.assertEqual(self.f['x'].fillvalue, fill_value.encode("utf-8"))
 
     def test_fixed_ascii(self):
         """ Fixed-length bytes dataset maps to fixed-length ascii in the file

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1063,7 +1063,7 @@ class TestStrings(BaseDataset):
     def test_vlen_bytes_fillvalue(self):
         """ Vlen bytes dataset handles fillvalue """
         dt = h5py.string_dtype(encoding='ascii')
-        ds = self.f.create_dataset('x', (100,), dtype=dt, fillvalue='bar')
+        ds = self.f.create_dataset('x', (100,), dtype=dt, fillvalue='bar'.encode("ascii"))
         self.assertEqual(self.f['x'][0], b'bar')
 
     def test_vlen_unicode(self):
@@ -1079,7 +1079,7 @@ class TestStrings(BaseDataset):
     def test_vlen_unicode_fillvalue(self):
         """ Vlen unicode dataset handles fillvalue """
         dt = h5py.string_dtype()
-        ds = self.f.create_dataset('x', (100,), dtype=dt, fillvalue='bar')
+        ds = self.f.create_dataset('x', (100,), dtype=dt, fillvalue='bar'.encode("utf-8"))
         self.assertEqual(self.f['x'][0], b'bar')
 
     def test_fixed_ascii(self):

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1067,6 +1067,7 @@ class TestStrings(BaseDataset):
         ds = self.f.create_dataset('x', (100,), dtype=dt, fillvalue=fill_value)
         self.assertEqual(self.f['x'][0], fill_value)
         self.assertEqual(self.f['x'].asstr()[0], fill_value.decode())
+        self.assertEqual(self.f['x'].fillvalue, fill_value.decode())
 
     def test_vlen_unicode(self):
         """ Vlen unicode dataset maps to vlen utf-8 in the file """
@@ -1085,6 +1086,7 @@ class TestStrings(BaseDataset):
         ds = self.f.create_dataset('x', (100,), dtype=dt, fillvalue=fill_value)
         self.assertEqual(self.f['x'][0], fill_value.encode("utf-8"))
         self.assertEqual(self.f['x'].asstr()[0], fill_value)
+        self.assertEqual(self.f['x'].fillvalue, fill_value)
 
     def test_fixed_ascii(self):
         """ Fixed-length bytes dataset maps to fixed-length ascii in the file

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1063,8 +1063,10 @@ class TestStrings(BaseDataset):
     def test_vlen_bytes_fillvalue(self):
         """ Vlen bytes dataset handles fillvalue """
         dt = h5py.string_dtype(encoding='ascii')
-        ds = self.f.create_dataset('x', (100,), dtype=dt, fillvalue='bar'.encode("ascii"))
-        self.assertEqual(self.f['x'][0], b'bar')
+        fill_value = b'bar'
+        ds = self.f.create_dataset('x', (100,), dtype=dt, fillvalue=fill_value)
+        self.assertEqual(self.f['x'][0], fill_value)
+        self.assertEqual(self.f['x'].asstr()[0], fill_value.decode())
 
     def test_vlen_unicode(self):
         """ Vlen unicode dataset maps to vlen utf-8 in the file """
@@ -1079,8 +1081,10 @@ class TestStrings(BaseDataset):
     def test_vlen_unicode_fillvalue(self):
         """ Vlen unicode dataset handles fillvalue """
         dt = h5py.string_dtype()
-        ds = self.f.create_dataset('x', (100,), dtype=dt, fillvalue='bar'.encode("utf-8"))
-        self.assertEqual(self.f['x'][0], b'bar')
+        fill_value = 'bár'
+        ds = self.f.create_dataset('x', (100,), dtype=dt, fillvalue=fill_value)
+        self.assertEqual(self.f['x'][0], fill_value.encode("utf-8"))
+        self.assertEqual(self.f['x'].asstr()[0], fill_value)
 
     def test_fixed_ascii(self):
         """ Fixed-length bytes dataset maps to fixed-length ascii in the file

--- a/news/fix_fillvalue_str.rst
+++ b/news/fix_fillvalue_str.rst
@@ -1,0 +1,29 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* Enable setting of fillvalue for datasets with variable length string dtype
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
Builds on #1635, closes #941

Based on the work of @aragilar and the discussion in #941 I've added the necessary changes to get vlen string fillvalues working.

Update:

There was one test failing, but it looks like the `dtype` forwarding to `set_fill_value` make that working too. So I adapted that test. Meanwhile this is settled to prior behvior.

The changes in this PR allow string fillvalues to work for vlen strings as well as fixed size strings regardless of the encoding. One source of misunderstanding for the user could be that `bytes` and `ascii` strings have the same internal representation and will not roundtrip (since `.asstr` can't be facilitated). `fillvalue` will be returned as `bytes`. 

The following works with the current implementation.

```python
with h5py.File(f"test_xxx.h5", "w") as f:   
    dt = h5py.string_dtype()
    fill_value = 'bár'
    ds = f.create_dataset('x', (10,), dtype=dt, fillvalue=fill_value)
    assert f['x'][0] == fill_value.encode("utf-8")
    assert f['x'].asstr()[0] == fill_value
    assert f['x'].fillvalue == fill_value.encode("utf-8")

with h5py.File(f"test_xxx.h5", "w") as f:   
    dt = h5py.string_dtype("ascii")
    fill_value = b'bar'
    ds = f.create_dataset('x', (10,), dtype=dt, fillvalue=fill_value)
    assert f['x'][0] == fill_value
    assert f['x'].asstr()[0] == fill_value.decode()
    assert f['x'].fillvalue == fill_value

with h5py.File(f"test_xxx.h5", "w") as f:   
    dt = h5py.string_dtype(length=10)
    fill_value = 'bár'
    ds = f.create_dataset('x', (10,), dtype=dt, fillvalue=fill_value)
    assert f['x'][0] == fill_value.encode("utf-8")
    assert f['x'].asstr()[0] == fill_value
    assert f['x'].fillvalue == fill_value.encode("utf-8")

with h5py.File(f"test_xxx.h5", "w") as f:   
    dt = h5py.string_dtype("ascii", length=10)
    fill_value = b'bar'
    ds = f.create_dataset('x', (10,), dtype=dt, fillvalue=fill_value)
    assert f['x'][0] == fill_value
    assert f['x'].asstr()[0] == fill_value.decode("ascii")
    assert f['x'].fillvalue == fill_value
```

