### PR TITLE
Convert PR links to use :pr: role

### DIFF
--- a/docs/whatsnew/2.5.rst
+++ b/docs/whatsnew/2.5.rst
@@ -16,53 +16,33 @@ to performance and the API design.
 For more details, check out the h5py user guide:
 https://docs.h5py.org/en/latest/swmr.html
 
-SWMR support was contributed by Ulrik Pedersen (`#551`_).
+SWMR support was contributed by Ulrik Pedersen (:pr:`551`).
 
 Other changes
 -------------
 
-* Use system Cython as a fallback if `cythonize()` fails (`#541`_ by Ulrik Pedersen).
-* Use pkg-config for building/linking against hdf5 (`#505`_ by James Tocknell).
-* Disable building Cython on Travis (`#513`_ by Andrew Collette).
-* Improvements to release tarball (`#555`_, `#560`_ by Ghislain Antony
+* Use system Cython as a fallback if `cythonize()` fails (:pr:`541` by Ulrik Pedersen).
+* Use pkg-config for building/linking against hdf5 (:pr:`505` by James Tocknell).
+* Disable building Cython on Travis (:pr:`513` by Andrew Collette).
+* Improvements to release tarball (:pr:`555`, :pr:`560` by Ghislain Antony
   Vaillant).
 * h5py now has one codebase for both Python 2 and 3; 2to3 removed from setup.py
-  (`#508`_ by James Tocknell).
-* Add python 3.4 to tox (`#507`_ by James Tocknell).
-* Warn when importing from inside install dir (`#558`_ by Andrew Collette).
+  (:pr:`508` by James Tocknell).
+* Add python 3.4 to tox (:pr:`507` by James Tocknell).
+* Warn when importing from inside install dir (:pr:`558` by Andrew Collette).
 * Tweak installation docs with reference to Anaconda and other Python package
-  managers (`#546`_ by Andrew Collette).
-* Fix incompatible function pointer types (`#526`_, `#524`_ by Peter H. Li).
+  managers (:pr:`546` by Andrew Collette).
+* Fix incompatible function pointer types (:pr:`526`, :pr:`524` by Peter H. Li).
 * Add explicit `vlen is not None` check to work around
   https://github.com/numpy/numpy/issues/2190 (`#538` by Will Parkin).
 * Group and AttributeManager classes now inherit from the appropriate ABCs
-  (`#527`_ by James Tocknell).
-* Don't strip metadata from special dtypes on read (`#512`_ by Antony Lee).
-* Add 'x' mode as an alias for 'w-' (`#510`_ by Antony Lee).
-* Support dynamical loading of LZF filter plugin (`#506`_ by Peter Colberg).
-* Fix accessing attributes with array type (`#501`_ by Andrew Collette).
-* Don't leak types in enum converter (`#503`_ by Andrew Collette).
+  (:pr:`527` by James Tocknell).
+* Don't strip metadata from special dtypes on read (:pr:`512` by Antony Lee).
+* Add 'x' mode as an alias for 'w-' (:pr:`510` by Antony Lee).
+* Support dynamical loading of LZF filter plugin (:pr:`506` by Peter Colberg).
+* Fix accessing attributes with array type (:pr:`501` by Andrew Collette).
+* Don't leak types in enum converter (:pr:`503` by Andrew Collette).
 * Cython warning cleanups related to "const"
-
-.. _`#551` : https://github.com/h5py/h5py/pull/551
-.. _`#541` : https://github.com/h5py/h5py/pull/541
-.. _`#505` : https://github.com/h5py/h5py/pull/505
-.. _`#513` : https://github.com/h5py/h5py/pull/513
-.. _`#555` : https://github.com/h5py/h5py/pull/555
-.. _`#560` : https://github.com/h5py/h5py/pull/560
-.. _`#508` : https://github.com/h5py/h5py/pull/508
-.. _`#507` : https://github.com/h5py/h5py/pull/507
-.. _`#558` : https://github.com/h5py/h5py/pull/558
-.. _`#546` : https://github.com/h5py/h5py/pull/546
-.. _`#526` : https://github.com/h5py/h5py/pull/526
-.. _`#524` : https://github.com/h5py/h5py/pull/524
-.. _`#538` : https://github.com/h5py/h5py/pull/538
-.. _`#527` : https://github.com/h5py/h5py/pull/527
-.. _`#512` : https://github.com/h5py/h5py/pull/512
-.. _`#510` : https://github.com/h5py/h5py/pull/510
-.. _`#506` : https://github.com/h5py/h5py/pull/506
-.. _`#501` : https://github.com/h5py/h5py/pull/501
-.. _`#503` : https://github.com/h5py/h5py/pull/503
 
 Acknowledgements
 ----------------

--- a/docs/whatsnew/2.6.rst
+++ b/docs/whatsnew/2.6.rst
@@ -7,7 +7,7 @@ Initial support for the HDF5 Virtual Dataset API, which was introduced in
 HDF5 1.10, was added to the low-level API. Ideas and input for how this should
 work as part of the high-level interface are welcome.
 
-This work was added in `#663`_ by Aleksandar Jelenak.
+This work was added in :pr:`663` by Aleksandar Jelenak.
 
 Add MPI Collective I/O Support
 ------------------------------
@@ -15,77 +15,45 @@ Support for using MPI Collective I/O in both low-level and high-level code has
 been added. See the collective_io.py example for a simple demonstration of how
 to use MPI Collective I/O with the high level API.
 
-This work was added in `#648`_ by Jialin Liu.
+This work was added in :pr:`648` by Jialin Liu.
 
 Numerous build/testing/CI improvements
 --------------------------------------
 There were a number of improvements to the setup.py file, which should mean that
 `pip install h5py` should work in most places. Work was also done to clean up
 the current testing system, using tox is the recommended way of testing h5py
-across different Python versions. See `#576`_ by Jakob Lombacher, `#640`_ by
-Lawrence Mitchell, and `#650`_, `#651`_ and `#658`_ by James Tocknell.
+across different Python versions. See :pr:`576` by Jakob Lombacher, :pr:`640` by
+Lawrence Mitchell, and :pr:`650`, :pr:`651` and :pr:`658` by James Tocknell.
 
 Cleanup of codebase based on pylint
 -----------------------------------
 There was a large cleanup of pylint-identified problems by Andrew Collette
-(`#578`_, `#579`_).
+(:pr:`578`, :pr:`579`).
 
 Fixes to low-level API
 ----------------------
-Fixes to the typing of functions were added in `#597`_ by Ulrik Kofoed
-Pedersen, `#589`_ by Peter Chang, and `#625`_ by Spaghetti Sort. A fix for
-variable-length arrays was added in `#621`_ by Sam Mason. Fixes to compound
-types were added in `#639`_ by @nevion and `#606`_ by Yu Feng. Finally, a fix
-to type conversion was added in `#614`_ by Andrew Collette.
+Fixes to the typing of functions were added in :pr:`597` by Ulrik Kofoed
+Pedersen, :pr:`589` by Peter Chang, and :pr:`625` by Spaghetti Sort. A fix for
+variable-length arrays was added in :pr:`621` by Sam Mason. Fixes to compound
+types were added in :pr:`639` by @nevion and :pr:`606` by Yu Feng. Finally, a fix
+to type conversion was added in :pr:`614` by Andrew Collette.
 
 Documentation improvements
 --------------------------
-* Updates to FAQ by Dan Guest (`#608`_) and Peter Hill (`#607`_).
-* Updates MPI-related documentation by Jens Timmerman (`#604`_) and
-  Matthias König (`#572`_).
-* Fixes to documentation building by Ghislain Antony Vaillant (`#562`_,
-  `#561`_).
-* Update PyTables link (`#574`_ by Dominik Kriegner)
-* Add File opening modes to docstring (`#563`_ by Antony Lee)
+* Updates to FAQ by Dan Guest (:pr:`608`) and Peter Hill (:pr:`607`).
+* Updates MPI-related documentation by Jens Timmerman (:pr:`604`) and
+  Matthias König (:pr:`572`).
+* Fixes to documentation building by Ghislain Antony Vaillant (:pr:`562`,
+  :pr:`561`).
+* Update PyTables link (:pr:`574` by Dominik Kriegner)
+* Add File opening modes to docstring (:pr:`563` by Antony Lee)
 
 Other changes
 -------------
-* Add `Dataset.ndim` (`#649`_, `#660`_ by @jakirkham, `#661`_ by James Tocknell)
-* Fix import errors in IPython completer (`#605`_ by Niru Maheswaranathan)
-* Turn off error printing in new threads (`#583`_ by Andrew Collette)
-* Use item value in `KeyError` instead of error message (`#642`_ by Matthias Geier)
-
-
-.. _`#561` : https://github.com/h5py/h5py/pull/561
-.. _`#562` : https://github.com/h5py/h5py/pull/562
-.. _`#563` : https://github.com/h5py/h5py/pull/563
-.. _`#572` : https://github.com/h5py/h5py/pull/572
-.. _`#574` : https://github.com/h5py/h5py/pull/574
-.. _`#576` : https://github.com/h5py/h5py/pull/576
-.. _`#578` : https://github.com/h5py/h5py/pull/578
-.. _`#579` : https://github.com/h5py/h5py/pull/579
-.. _`#583` : https://github.com/h5py/h5py/pull/583
-.. _`#589` : https://github.com/h5py/h5py/pull/589
-.. _`#597` : https://github.com/h5py/h5py/pull/597
-.. _`#604` : https://github.com/h5py/h5py/pull/604
-.. _`#605` : https://github.com/h5py/h5py/pull/605
-.. _`#606` : https://github.com/h5py/h5py/pull/606
-.. _`#607` : https://github.com/h5py/h5py/pull/607
-.. _`#608` : https://github.com/h5py/h5py/pull/608
-.. _`#614` : https://github.com/h5py/h5py/pull/614
-.. _`#621` : https://github.com/h5py/h5py/pull/621
-.. _`#625` : https://github.com/h5py/h5py/pull/625
-.. _`#639` : https://github.com/h5py/h5py/pull/639
-.. _`#640` : https://github.com/h5py/h5py/pull/640
-.. _`#642` : https://github.com/h5py/h5py/pull/642
-.. _`#648` : https://github.com/h5py/h5py/pull/648
-.. _`#649` : https://github.com/h5py/h5py/pull/649
-.. _`#650` : https://github.com/h5py/h5py/pull/650
-.. _`#651` : https://github.com/h5py/h5py/pull/651
-.. _`#658` : https://github.com/h5py/h5py/pull/658
-.. _`#660` : https://github.com/h5py/h5py/pull/660
-.. _`#661` : https://github.com/h5py/h5py/pull/661
-.. _`#663` : https://github.com/h5py/h5py/pull/663
+* Add `Dataset.ndim` (:pr:`649`, :pr:`660` by @jakirkham, :pr:`661` by James Tocknell)
+* Fix import errors in IPython completer (:pr:`605` by Niru Maheswaranathan)
+* Turn off error printing in new threads (:pr:`583` by Andrew Collette)
+* Use item value in `KeyError` instead of error message (:pr:`642` by Matthias Geier)
 
 Acknowledgements
 ----------------

--- a/docs/whatsnew/2.7.rst
+++ b/docs/whatsnew/2.7.rst
@@ -3,90 +3,44 @@ What's new in h5py 2.7
 
 Python 3.2 is no longer supported
 ---------------------------------
-``h5py`` 2.7 drops Python 3.2 support, and testing is not longer performed on Python 3.2. The latest versions of ``pip``, ``virtualenv``, ``setuptools`` and ``numpy`` do not support Python 3.2, and dropping 3.2 allows both ``u`` and ``b`` prefixes to be used for strings. A clean up of some of the legacy code was done in `#675`_ by Andrew Collette.
+``h5py`` 2.7 drops Python 3.2 support, and testing is not longer performed on Python 3.2. The latest versions of ``pip``, ``virtualenv``, ``setuptools`` and ``numpy`` do not support Python 3.2, and dropping 3.2 allows both ``u`` and ``b`` prefixes to be used for strings. A clean up of some of the legacy code was done in :pr:`675` by Andrew Collette.
 
 Additionally, support for Python 2.6 is soon to be dropped for ``pip`` (See https://github.com/pypa/pip/issues/3955) and ``setuptools`` (See https://github.com/pypa/setuptools/issues/878), and ``numpy`` has dropped Python 2.6 also in the latest release. While ``h5py`` has not dropped Python 2.6 this release, users are strongly encouraged to move to Python 2.7 where possible.
 
 Improved testing support
 ------------------------
-There has been a major increase in the number of configurations ``h5py`` is automatically tested in, with Windows CI support added via Appveyor (`#795`_, `#798`_, `#799`_ and `#801`_ by James Tocknell) and testing of minimum requirements to ensure we still satisfy them (`#703`_ by James Tocknell). Additionally, ``tox`` was used to ensure that we don't run tests on Python versions which our dependencies have dropped or do not support (`#662`_, `#700`_ and `#733`_). Thanks to to the Appveyor support, unicode tests were made more robust (`#788`_, `#800`_ and `#804`_ by James Tocknell). Finally, other tests were improved or added where needed (`#724`_ by Matthew Brett, `#789`_, `#794`_ and `#802`_ by James Tocknell).
+There has been a major increase in the number of configurations ``h5py`` is automatically tested in, with Windows CI support added via Appveyor (:pr:`795`, :pr:`798`, :pr:`799` and :pr:`801` by James Tocknell) and testing of minimum requirements to ensure we still satisfy them (:pr:`703` by James Tocknell). Additionally, ``tox`` was used to ensure that we don't run tests on Python versions which our dependencies have dropped or do not support (:pr:`662`, :pr:`700` and :pr:`733`). Thanks to to the Appveyor support, unicode tests were made more robust (:pr:`788`, :pr:`800` and :pr:`804` by James Tocknell). Finally, other tests were improved or added where needed (:pr:`724` by Matthew Brett, :pr:`789`, :pr:`794` and :pr:`802` by James Tocknell).
 
 Improved python compatibility
 -----------------------------
-The ``ipython``/``jupyter`` completion support now has Python 3 support (`#715`_ by Joseph Kleinhenz). ``h5py`` now supports ``pathlib`` filenames (`#716`_ by James Tocknell).
+The ``ipython``/``jupyter`` completion support now has Python 3 support (:pr:`715` by Joseph Kleinhenz). ``h5py`` now supports ``pathlib`` filenames (:pr:`716` by James Tocknell).
 
 Documentation improvements
 --------------------------
-An update to the installation instructions and some whitespace cleanup was done in `#808`_ by Thomas A Caswell, and mistake in the quickstart was fixed by Joydeep Bhattacharjee in `#708`_.
+An update to the installation instructions and some whitespace cleanup was done in :pr:`808` by Thomas A Caswell, and mistake in the quickstart was fixed by Joydeep Bhattacharjee in :pr:`708`.
 
 setup.py improvements
 ---------------------
-Support for detecting the version of HDF5 via ``pkgconfig`` was added by Axel Huebl in `#734`_, and support for specifying the path to MPI-supported HDF5 was added by Axel Huebl in `#721`_. ``h5py's`` classifiers were updated to include supported python version and interpreters in `#811`_ by James Tocknell.
+Support for detecting the version of HDF5 via ``pkgconfig`` was added by Axel Huebl in :pr:`734`, and support for specifying the path to MPI-supported HDF5 was added by Axel Huebl in :pr:`721`. ``h5py's`` classifiers were updated to include supported python version and interpreters in :pr:`811` by James Tocknell.
 
 Support for additional HDF5 features added
 ------------------------------------------
-Low-level support for `HDF5 Direct Chunk Write`_ was added in `#691`_ by Simon Gregor Ebner.  Minimal support for `HDF5 File Image Operations`_ was added by Andrea Bedini in `#680`_. Ideas and opinions for further support for both `HDF5 Direct Chunk Write`_ and `HDF5 File Image Operations`_ are welcome. High-level support for reading and writing null dataspaces was added in `#664`_ by James Tocknell.
+Low-level support for `HDF5 Direct Chunk Write`_ was added in :pr:`691` by Simon Gregor Ebner.  Minimal support for `HDF5 File Image Operations`_ was added by Andrea Bedini in :pr:`680`. Ideas and opinions for further support for both `HDF5 Direct Chunk Write`_ and `HDF5 File Image Operations`_ are welcome. High-level support for reading and writing null dataspaces was added in :pr:`664` by James Tocknell.
 
 Improvements to type system
 ---------------------------
-Reading and writing of compound datatypes has improved, with support for different orderings and alignments (`#701`_ by Jonah Bernhard, `#702`_ by Caleb Morse `#738`_ by @smutch, `#765`_ by Nathan Goldbaum and `#793`_ by James Tocknell). Support for reading extended precision and non-standard floating point numbers has also been added (`#749`_, `#812`_ by Thomas A Caswell, `#787`_ by James Tocknell and `#781`_ by Martin Raspaud). Finally, compatibility improvements to ``Cython`` annotations of HDF5 types were added in `#692`_ and `#693`_ by Aleksandar Jelenak.
+Reading and writing of compound datatypes has improved, with support for different orderings and alignments (:pr:`701` by Jonah Bernhard, :pr:`702` by Caleb Morse :pr:`738` by @smutch, :pr:`765` by Nathan Goldbaum and :pr:`793` by James Tocknell). Support for reading extended precision and non-standard floating point numbers has also been added (:pr:`749`, :pr:`812` by Thomas A Caswell, :pr:`787` by James Tocknell and :pr:`781` by Martin Raspaud). Finally, compatibility improvements to ``Cython`` annotations of HDF5 types were added in :pr:`692` and :pr:`693` by Aleksandar Jelenak.
 
 Other changes
 -------------
-* Fix deprecation of ``-`` for ``numpy`` boolean arrays (`#683`_ by James Tocknell)
-* Check for duplicates in fancy index validation (`#739`_ by Sam Toyer)
-* Avoid potential race condition (`#754`_ by James Tocknell)
-* Fix inconsistency when slicing with ``numpy.array`` of shape ``(1,)`` (`#772`_ by Artsiom)
-* Use ``size_t`` to store Python object id (`#773`_ by Christoph Gohlke)
-* Avoid errors when the Python GC runs during ``nonlocal_close()`` (`#776`_ by Antoine Pitrou)
-* Move from ``six.PY3`` to ``six.PY2`` (`#686`_ by James Tocknell)
+* Fix deprecation of ``-`` for ``numpy`` boolean arrays (:pr:`683` by James Tocknell)
+* Check for duplicates in fancy index validation (:pr:`739` by Sam Toyer)
+* Avoid potential race condition (:pr:`754` by James Tocknell)
+* Fix inconsistency when slicing with ``numpy.array`` of shape ``(1,)`` (:pr:`772` by Artsiom)
+* Use ``size_t`` to store Python object id (:pr:`773` by Christoph Gohlke)
+* Avoid errors when the Python GC runs during ``nonlocal_close()`` (:pr:`776` by Antoine Pitrou)
+* Move from ``six.PY3`` to ``six.PY2`` (:pr:`686` by James Tocknell)
 
-
-.. _`#662` : https://github.com/h5py/h5py/pull/662
-.. _`#664` : https://github.com/h5py/h5py/pull/664
-.. _`#675` : https://github.com/h5py/h5py/pull/675
-.. _`#680` : https://github.com/h5py/h5py/pull/680
-.. _`#683` : https://github.com/h5py/h5py/pull/683
-.. _`#686` : https://github.com/h5py/h5py/pull/686
-.. _`#691` : https://github.com/h5py/h5py/pull/691
-.. _`#692` : https://github.com/h5py/h5py/pull/692
-.. _`#693` : https://github.com/h5py/h5py/pull/693
-.. _`#700` : https://github.com/h5py/h5py/pull/700
-.. _`#701` : https://github.com/h5py/h5py/pull/701
-.. _`#702` : https://github.com/h5py/h5py/pull/702
-.. _`#703` : https://github.com/h5py/h5py/pull/703
-.. _`#708` : https://github.com/h5py/h5py/pull/708
-.. _`#715` : https://github.com/h5py/h5py/pull/715
-.. _`#716` : https://github.com/h5py/h5py/pull/716
-.. _`#721` : https://github.com/h5py/h5py/pull/721
-.. _`#724` : https://github.com/h5py/h5py/pull/724
-.. _`#733` : https://github.com/h5py/h5py/pull/733
-.. _`#734` : https://github.com/h5py/h5py/pull/734
-.. _`#738` : https://github.com/h5py/h5py/pull/738
-.. _`#739` : https://github.com/h5py/h5py/pull/739
-.. _`#749` : https://github.com/h5py/h5py/pull/749
-.. _`#754` : https://github.com/h5py/h5py/pull/754
-.. _`#765` : https://github.com/h5py/h5py/pull/765
-.. _`#772` : https://github.com/h5py/h5py/pull/772
-.. _`#773` : https://github.com/h5py/h5py/pull/773
-.. _`#776` : https://github.com/h5py/h5py/pull/776
-.. _`#781` : https://github.com/h5py/h5py/pull/781
-.. _`#787` : https://github.com/h5py/h5py/pull/787
-.. _`#788` : https://github.com/h5py/h5py/pull/788
-.. _`#789` : https://github.com/h5py/h5py/pull/789
-.. _`#793` : https://github.com/h5py/h5py/pull/793
-.. _`#794` : https://github.com/h5py/h5py/pull/794
-.. _`#795` : https://github.com/h5py/h5py/pull/795
-.. _`#798` : https://github.com/h5py/h5py/pull/798
-.. _`#799` : https://github.com/h5py/h5py/pull/799
-.. _`#800` : https://github.com/h5py/h5py/pull/800
-.. _`#801` : https://github.com/h5py/h5py/pull/801
-.. _`#802` : https://github.com/h5py/h5py/pull/802
-.. _`#804` : https://github.com/h5py/h5py/pull/804
-.. _`#807` : https://github.com/h5py/h5py/pull/807
-.. _`#808` : https://github.com/h5py/h5py/pull/808
-.. _`#811` : https://github.com/h5py/h5py/pull/811
-.. _`#812` : https://github.com/h5py/h5py/pull/812
 .. _`HDF5 Direct Chunk Write` : https://support.hdfgroup.org/HDF5/doc/Advanced/DirectChunkWrite/
 .. _`HDF5 File Image Operations` : https://support.hdfgroup.org/HDF5/doc/Advanced/FileImageOperations/HDF5FileImageOperations.pdf
 


### PR DESCRIPTION
Sphinx has started warning for links that could use the extlinks extension (the `:pr:` role, in this case). The docs build in CI treats warnings as errors, so it has started failing. This should fix it.