### PR TITLE
Collapse nested try/except in attrs.py

### DIFF
--- a/h5py/_hl/attrs.py
+++ b/h5py/_hl/attrs.py
@@ -206,20 +206,15 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
             try:
                 if not isinstance(data, Empty):
                     attr.write(data, mtype=htype2)
+                if attr_exists:
+                    # Rename temp attribute to proper name
+                    # No atomic rename in HDF5 :(
+                    h5a.delete(self._id, self._e(name))
+                    h5a.rename(self._id, self._e(tempname), self._e(name))
             except:
                 attr.close()
                 h5a.delete(self._id, self._e(tempname))
                 raise
-            else:
-                if attr_exists:
-                    try:
-                        # No atomic rename in HDF5 :(
-                        h5a.delete(self._id, self._e(name))
-                        h5a.rename(self._id, self._e(tempname), self._e(name))
-                    except:
-                        attr.close()
-                        h5a.delete(self._id, self._e(tempname))
-                        raise
             finally:
                 attr.close()
 


### PR DESCRIPTION
I realised the second level of try/except/else in this code was unnecessary - the `else` block can be simplified to just putting the next bit of code below the first bit inside the `try`.

This should have no visible effect in the API, so I haven't added a news entry.