### PR TITLE
better error message when building from source

### DIFF
--- a/setup_configure.py
+++ b/setup_configure.py
@@ -135,7 +135,9 @@ class BuildConfig:
             if os.name != 'nt':
                 print(
                     "Building h5py requires pkg-config unless the HDF5 path "
-                    "is explicitly specified", file=sys.stderr
+                    "is explicitly specified using the environment variable HDF5_DIR. "
+                    "For more information and details, "
+                    "see https://docs.h5py.org/en/stable/build.html#custom-installation", file=sys.stderr
                 )
                 raise
 


### PR DESCRIPTION
Fixes #2052

<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->
