### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,9 @@ setup(
   maintainer_email = 'andrew.collette@gmail.com',
   license = 'BSD',
   url = 'http://www.h5py.org',
+  project_urls = {
+      'Source': 'https://github.com/h5py/h5py',
+  },
   download_url = 'https://pypi.python.org/pypi/h5py',
   packages = [
       'h5py',


### PR DESCRIPTION
<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py
-->

Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.
