### PR TITLE
Use simple cached_property with no locking

### DIFF
--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -511,3 +511,25 @@ def product(nums):
     for n in nums:
         prod *= n
     return prod
+
+
+# Simple variant of cached_property:
+# Unlike functools, this has no locking, so we don't have to worry about
+# deadlocks with phil (see issue gh-2064). Unlike cached-property on PyPI, it
+# doesn't try to import asyncio (which can be ~100 extra modules).
+# Many projects seem to have similar variants of this, often without attribution,
+# but to be cautious, this code comes from cached-property (Copyright (c) 2015,
+# Daniel Greenfeld, BSD license), where it is attributed to bottle (Copyright
+# (c) 2009-2022, Marcel Hellkamp, MIT license).
+
+class cached_property(object):
+    def __init__(self, func):
+        self.__doc__ = getattr(func, "__doc__")
+        self.func = func
+
+    def __get__(self, obj, cls):
+        if obj is None:
+            return self
+
+        value = obj.__dict__[self.func.__name__] = self.func(obj)
+        return value

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -11,10 +11,6 @@
     Implements support for high-level dataset access.
 """
 
-try:
-    from functools import cached_property
-except ImportError:
-    from cached_property import cached_property
 import posixpath as pp
 import sys
 from warnings import warn
@@ -25,7 +21,7 @@ import numpy
 
 from .. import h5, h5s, h5t, h5r, h5d, h5p, h5fd, h5ds, _selector
 from ..h5py_warnings import H5pyDeprecationWarning
-from .base import HLObject, phil, with_phil, Empty, find_item_type
+from .base import HLObject, phil, with_phil, Empty, cached_property, find_item_type
 from . import filters
 from . import selections as sel
 from . import selections2 as sel2

--- a/news/cached-property.rst
+++ b/news/cached-property.rst
@@ -1,0 +1,30 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* Fix a deadlock which was possible when the same dataset was accessed from
+  multiple threads (:issue:`2064`).
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ VERSION = '3.6.0'
 
 # these are required to use h5py
 RUN_REQUIRES = [
-    "cached-property; python_version<'3.8'",
     # We only really aim to support NumPy & Python combinations for which
     # there are wheels on PyPI (e.g. NumPy >=1.17.5 for Python 3.8).
     # But we don't want to duplicate the information in oldest-supported-numpy


### PR DESCRIPTION
Fewer locks means less space for potential deadlocks. It's possible that two threads end up calculating the same property, but they should both get the right answer, so it doesn't really matter.

We could use [cached-property](https://pypi.org/project/cached-property/) on PyPI for all Python versions, since its basic `cached_property` has no lock. But I noticed that that project also imports asyncio (to provide async cached properties), and I dislike doing lots of unnecessary imports.

Closes #2064 