### PR TITLE
Add a news stub for the Direct VFD

### DIFF
--- a/news/direct-vfd-stubs.rst
+++ b/news/direct-vfd-stubs.rst
@@ -1,0 +1,36 @@
+New features
+------------
+
+* Provide the ability to use the Direct Virtual File Driver (VFD) from
+  HDF5 (Linux only).
+  If the Direct VFD driver is present at the time of compilation, users can use the
+  Direct VFD by passing the keyword argument ``driver="direct"`` to the
+  ``h5py.File`` constructor.
+
+  To use the Direct VFD users must recompile h5py linking to a version of
+  HDF5 that enabled support for the Direct VFD at compile time.
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
@takluyver this release note is a little hard since you indicated that you didn't want to add the `--enable-direct-vfd` to your pypi releases. But here is my attempt.

https://github.com/h5py/h5py/pull/2041#issuecomment-1073773166
https://github.com/conda-forge/hdf5-feedstock/blob/main/recipe/build.sh#L12

<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->
