### PR TITLE
Use zero-ed memory when reading data

### DIFF
--- a/h5py/_hl/attrs.py
+++ b/h5py/_hl/attrs.py
@@ -73,7 +73,7 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
             shape = attr.shape + subshape   # (5, 3)
             dtype = subdtype                # 'f'
 
-        arr = numpy.ndarray(shape, dtype=dtype, order='C')
+        arr = numpy.zeros(shape, dtype=dtype, order='C')
         attr.read(arr, mtype=htype)
 
         string_info = h5t.check_string_dtype(dtype)

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -569,7 +569,7 @@ class Dataset(HLObject):
     @with_phil
     def fillvalue(self):
         """Fill value for this dataset (0 by default)"""
-        arr = numpy.ndarray((1,), dtype=self.dtype)
+        arr = numpy.zeros((1,), dtype=self.dtype)
         self._dcpl.get_fill_value(arr)
         return arr[0]
 
@@ -749,7 +749,7 @@ class Dataset(HLObject):
             if mshape is None:
                 # 0D with no data (NULL or deselected SCALAR)
                 return Empty(new_dtype)
-            out = numpy.empty(mshape, dtype=new_dtype)
+            out = numpy.zeros(mshape, dtype=new_dtype)
             if out.size == 0:
                 return out
 
@@ -764,7 +764,7 @@ class Dataset(HLObject):
             # Check 'is Ellipsis' to avoid equality comparison with an array:
             # array equality returns an array, not a boolean.
             if args == () or (len(args) == 1 and args[0] is Ellipsis):
-                return numpy.empty(self.shape, dtype=new_dtype)
+                return numpy.zeros(self.shape, dtype=new_dtype)
 
         # === Scalar dataspaces =================
 
@@ -772,9 +772,9 @@ class Dataset(HLObject):
             fspace = self.id.get_space()
             selection = sel2.select_read(fspace, args)
             if selection.mshape is None:
-                arr = numpy.ndarray((), dtype=new_dtype)
+                arr = numpy.zeros((), dtype=new_dtype)
             else:
-                arr = numpy.ndarray(selection.mshape, dtype=new_dtype)
+                arr = numpy.zeros(selection.mshape, dtype=new_dtype)
             for mspace, fspace in selection:
                 self.id.read(mspace, fspace, arr, mtype)
             if selection.mshape is None:
@@ -787,9 +787,9 @@ class Dataset(HLObject):
         selection = sel.select(self.shape, args, dataset=self)
 
         if selection.nselect == 0:
-            return numpy.ndarray(selection.array_shape, dtype=new_dtype)
+            return numpy.zeros(selection.array_shape, dtype=new_dtype)
 
-        arr = numpy.ndarray(selection.array_shape, new_dtype, order='C')
+        arr = numpy.zeros(selection.array_shape, new_dtype, order='C')
 
         # Perform the actual read
         mspace = h5s.create_simple(selection.mshape)
@@ -1010,7 +1010,7 @@ class Dataset(HLObject):
         THIS MEANS DATASETS ARE INTERCHANGEABLE WITH ARRAYS.  For one thing,
         you have to read the whole dataset every time this method is called.
         """
-        arr = numpy.empty(self.shape, dtype=self.dtype if dtype is None else dtype)
+        arr = numpy.zeros(self.shape, dtype=self.dtype if dtype is None else dtype)
 
         # Special case for (0,)*-shape datasets
         if numpy.product(self.shape, dtype=numpy.ulonglong) == 0:

--- a/h5py/_selector.pyx
+++ b/h5py/_selector.pyx
@@ -10,7 +10,7 @@ but there is no equivalent to this when selecting data in HDF5. So we store a
 separate boolean ('scalar') for each dimension to distinguish these cases.
 """
 from numpy cimport (
-    ndarray, npy_intp, PyArray_SimpleNew, PyArray_DATA, import_array,
+    ndarray, npy_intp, PyArray_ZEROS, PyArray_DATA, import_array,
     PyArray_IsNativeByteOrder,
 )
 from cpython cimport PyNumber_Index
@@ -329,7 +329,7 @@ cdef class Reader:
                     arr_shape[arr_rank] = mshape[i]
                     arr_rank += 1
 
-            arr = PyArray_SimpleNew(arr_rank, arr_shape, self.np_typenum)
+            arr = PyArray_ZEROS(arr_rank, arr_shape, self.np_typenum, 0)
             if not self.native_byteorder:
                 arr = arr.newbyteorder()
         finally:

--- a/h5py/tests/test_dataset_getitem.py
+++ b/h5py/tests/test_dataset_getitem.py
@@ -586,3 +586,16 @@ class TestVeryLargeArray(TestCase):
     @ut.skipIf(sys.maxsize < 2**31, 'Maximum integer size >= 2**31 required')
     def test_size(self):
         self.assertEqual(self.dset.size, 2**31)
+
+
+def test_read_no_fill_value(writable_file):
+    # With FILL_TIME_NEVER, HDF5 doesn't write zeros in the output array for
+    # unallocated chunks. If we read into uninitialized memory, it can appear
+    # to read random values. https://github.com/h5py/h5py/issues/2069
+    dcpl = h5py.h5p.create(h5py.h5p.DATASET_CREATE)
+    dcpl.set_chunk((1,))
+    dcpl.set_fill_time(h5py.h5d.FILL_TIME_NEVER)
+    ds = h5py.Dataset(h5py.h5d.create(
+        writable_file.id, b'a', h5py.h5t.IEEE_F64LE, h5py.h5s.create_simple((5,)), dcpl
+    ))
+    np.testing.assert_array_equal(ds[:3], np.zeros(3, np.float64))


### PR DESCRIPTION
Avoid exposing values from memory when reading from a chunked dataset with missing chunks and no fill value. This is essentially the same fix attempted in #456.

Back then, [Andrew found that](https://groups.google.com/g/h5py/c/PgmJ-R7qxqI/m/RMk6-iEfngEJ) "Unfortunately it looks like this approach doesn't work for object-based dtypes; it fills them with Python int "0"'s rather than None." This is still the case - `np.zeros(3, dtype=object)` has zeros where `np.empty(3, dtype=object)` has None. But I'm not sure when this would matter. The only cases I can see where h5py would create an object array to read into are when converting vlen data or HDF5 references, and in both cases it seems that the conversion machinery fills the array with the expected objects anyway. The tests pass, at least on my machine.

For small reads, this might be marginally slower, but for large reads there's likely to be no penalty, because the OS can do [virtual memory tricks](https://vorpus.org/blog/why-does-calloc-exist/) to avoid really allocating the memory.

Closes #455
Closes #2069