### PR TITLE
Fix Mac x86 wheel hdf5 zlib build failure

### DIFF
--- a/ci/azure-pipelines-steps.yml
+++ b/ci/azure-pipelines-steps.yml
@@ -12,7 +12,7 @@ steps:
     ${{ if eq(parameters.platform, 'windows') }}:
       key: 0 | HDF5 | "$(Agent.OS)" | "$(Agent.OSArchitecture)" | "$(HDF5_VERSION)" | "$(HDF5_VSVERSION)" | "$(HDF5_MPI)" | ci/get_hdf5_win.py
     ${{ if ne(parameters.platform, 'windows') }}:
-      key: 1 | HDF5 | "$(Agent.OS)" | "$(Agent.OSArchitecture)" | "$(HDF5_VERSION)" | "$(HDF5_MPI)" | ci/get_hdf5_if_needed.sh
+      key: 0 | HDF5 | "$(Agent.OS)" | "$(Agent.OSArchitecture)" | "$(HDF5_VERSION)" | "$(HDF5_MPI)" | ci/get_hdf5_if_needed.sh | ci/configure_hdf5_mac.sh
     path: $(HDF5_CACHE_DIR)
   condition: and(succeeded(), ne(variables['HDF5_VERSION'], ''))
 

--- a/ci/configure_hdf5_mac.sh
+++ b/ci/configure_hdf5_mac.sh
@@ -12,7 +12,7 @@ function build_zlib() {
     ZLIB_VERSION="1.2.11"
 
     pushd /tmp
-    curl -sLO https://zlib.net/zlib-$ZLIB_VERSION.tar.gz
+    curl -sLO https://zlib.net/fossils/zlib-$ZLIB_VERSION.tar.gz
     tar xzf zlib-$ZLIB_VERSION.tar.gz
     cd zlib-$ZLIB_VERSION
     ./configure --prefix="$HDF5_DIR"

--- a/ci/configure_hdf5_mac.sh
+++ b/ci/configure_hdf5_mac.sh
@@ -9,7 +9,7 @@ function set_compiler_vars() {
 
 
 function build_zlib() {
-    ZLIB_VERSION="1.2.12"
+    ZLIB_VERSION="1.2.11"
 
     pushd /tmp
     curl -sLO https://zlib.net/zlib-$ZLIB_VERSION.tar.gz


### PR DESCRIPTION
After merging https://github.com/h5py/h5py/pull/2065, which built all the wheels successfully, master failed building mac x86 wheels.

I suspect the issue is that hdf5 1.12.1 does not build with latest zlib (1.2.12). However, why did it not fail in the PR? I think because when we added the changes switching zlib version from 1.2.11 to 1.2.11, the PR didn't rebuild hdf5 but used the previously cached hdf5 build. The reason is that I didn't add the new `configure_hdf5_mac.sh` to the hash.

This add it to the hash to force a rebuild. x86 should still fail. If it does, then I'll downgrade zlib to 1.2.11 and if does build (and does not use the cache), we'll know that was the cause and will have to wait for a newer hdf5 release before we can use the latest zlib.