### PR TITLE
Fix build building MacOS zlib 1.2.12

### DIFF
--- a/ci/azure-pipelines-wheels.yml
+++ b/ci/azure-pipelines-wheels.yml
@@ -7,9 +7,9 @@ steps:
     # Increment the first number to clear the cache if you change something
     # not captured by the key, e.g. dependencies.
     ${{ if eq(parameters.platform, 'windows') }}:
-      key: 0 | HDF5 | "$(Agent.OS)" | "$(Agent.OSArchitecture)" | "$(HDF5_VERSION)" | "$(HDF5_VSVERSION)" | ci/get_hdf5_win.py
+      key: 0 | HDF5 | "$(Agent.OS)" | "$(Agent.OSArchitecture)" | "$(HDF5_VERSION)" | "$(HDF5_VSVERSION)" | "$(HDF5_MPI)" | ci/get_hdf5_win.py
     ${{ if ne(parameters.platform, 'windows') }}:
-      key: 0 | HDF5 | "$(Agent.OS)" | "$(Agent.OSArchitecture)" | "$(CIBW_ARCHS_MACOS)" | "$(HDF5_VERSION)" | ci/get_hdf5_if_needed.sh
+      key: 0 | HDF5 | "$(Agent.OS)" | "$(Agent.OSArchitecture)" | "$(CIBW_ARCHS_MACOS)" | "$(HDF5_VERSION)" | "$(HDF5_MPI)" | ci/get_hdf5_if_needed.sh | ci/configure_hdf5_mac.sh
     path: $(HDF5_CACHE_DIR)
   condition: and(succeeded(), ne(variables['HDF5_VERSION'], ''))
 

--- a/ci/configure_hdf5_mac.sh
+++ b/ci/configure_hdf5_mac.sh
@@ -9,7 +9,8 @@ function set_compiler_vars() {
 
 
 function build_zlib() {
-    ZLIB_VERSION="1.2.11"
+    ZLIB_VERSION="1.2.12"
+    export cc=$CC
 
     pushd /tmp
     curl -sLO https://zlib.net/fossils/zlib-$ZLIB_VERSION.tar.gz

--- a/ci/configure_hdf5_mac.sh
+++ b/ci/configure_hdf5_mac.sh
@@ -10,6 +10,7 @@ function set_compiler_vars() {
 
 function build_zlib() {
     ZLIB_VERSION="1.2.12"
+    # export needed to fix 1.2.12. Next release won't need the export (madler/zlib#615)
     export cc=$CC
 
     pushd /tmp


### PR DESCRIPTION
Fixes #2081. 

The issue with zlib 1.2.12 was due to https://github.com/madler/zlib/issues/615. This fixes it in the same way fixed in zlib.