### PR TITLE
Test and make wheels with HDF5 1.12.2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ jobs:
   pool:
     vmImage: windows-2019
   variables:
-    HDF5_VERSION: 1.12.1
+    HDF5_VERSION: 1.12.2
     HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
     HDF5_VSVERSION: "16-64"
     CIBW_BUILD: cp3{7,8,9,10}-win_amd64
@@ -54,7 +54,7 @@ jobs:
     vmImage: macOS-11
   variables:
     MACOSX_DEPLOYMENT_TARGET: 10.9
-    HDF5_VERSION: 1.12.1
+    HDF5_VERSION: 1.12.2
     H5PY_ROS3: '0'
     H5PY_DIRECT_VFD: '0'
     HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
@@ -121,10 +121,10 @@ jobs:
         HDF5_VERSION: 1.12.0
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         H5PY_ENFORCE_COVERAGE: yes
-      py39-deps-hdf51120:
+      py39-deps-hdf51122:
         python.version: '3.9'
         TOXENV: py39-test-deps
-        HDF5_VERSION: 1.12.0
+        HDF5_VERSION: 1.12.2
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         H5PY_ENFORCE_COVERAGE: yes
     # do mpi tests


### PR DESCRIPTION
Linux wheels should also use HDF5 1.12.2, because I updated it in the Docker images we use to build them: https://github.com/h5py/hdf5-manylinux/commit/8a6616972278f6b72de01a52ce25384d33da32fe