### PR TITLE
Add H5Pset_efile_prefix, H5Pget_efile_prefix

### DIFF
--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -172,7 +172,7 @@ def open_dset(parent, name, dapl=None, efile_prefix=None, virtual_prefix=None, *
         dapl.set_efile_prefix(efile_prefix)
 
     if virtual_prefix is not None:
-        dapl.set_efile_prefix(virtual_prefix)
+        dapl.set_virtual_prefix(virtual_prefix)
 
     dset_id = h5d.open(parent.id, name, dapl=dapl)
 

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -249,8 +249,14 @@ class Group(HLObject, MutableMappingHDF5):
             if isinstance(shape, int):
                 shape = (shape,)
 
-            dsid = dataset.open_dset(self, self._e(name), **kwds)
-            dset = dataset.Dataset(dsid)
+            try:
+                dsid = dataset.open_dset(self, self._e(name), **kwds)
+                dset = dataset.Dataset(dsid)
+            except KeyError:
+                dset = self[name]
+                raise TypeError("Incompatible object (%s) already exists" % dset.__class__.__name__)
+            except:
+                raise
 
             if not shape == dset.shape:
                 raise TypeError("Shapes do not match (existing %s vs new %s)" % (dset.shape, shape))

--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -365,6 +365,8 @@ hdf5:
   H5Z_EDC_t H5Pget_edc_check(hid_t plist)
   herr_t    H5Pset_chunk_cache( hid_t dapl_id, size_t rdcc_nslots, size_t rdcc_nbytes, double rdcc_w0 )
   herr_t    H5Pget_chunk_cache( hid_t dapl_id, size_t *rdcc_nslots, size_t *rdcc_nbytes, double *rdcc_w0 )
+  1.8.17  herr_t H5Pget_efile_prefix(hid_t dapl_id, char *prefix, ssize_t size)
+  1.8.17  herr_t H5Pset_efile_prefix(hid_t dapl_id, char *prefix)
   1.9.233 herr_t H5Pset_virtual_view(hid_t plist_id, H5D_vds_view_t view)
   1.9.233 herr_t H5Pget_virtual_view(hid_t plist_id, H5D_vds_view_t *view)
   1.9.233 herr_t H5Pset_virtual_printf_gap(hid_t plist_id, hsize_t gap_size)

--- a/h5py/h5p.pxd
+++ b/h5py/h5p.pxd
@@ -68,6 +68,7 @@ cdef class PropDXID(PropInstanceID):
 cdef class PropDAID(PropInstanceID):
     """ Dataset access property list"""
     cdef char* _virtual_prefix_buf
+    cdef char* _efile_prefix_buf
 
 # --- New in 1.8 ---
 

--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -1769,7 +1769,7 @@ cdef class PropDAID(PropInstanceID):
         H5Pget_chunk_cache(self.id, &rdcc_nslots, &rdcc_nbytes, &rdcc_w0 )
         return (rdcc_nslots,rdcc_nbytes,rdcc_w0)
 
-    if HDF5_VERSION >= (1, 8, 7):
+    if HDF5_VERSION >= (1, 8, 17):
         @with_phil
         def get_efile_prefix(self):
             """() => STR

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1869,6 +1869,9 @@ class TestVirtualPrefix(BaseDataset):
     @ut.skipIf(version.hdf5_version_tuple < (1, 10, 2),
                reason = "Virtual prefix does not exist before HDF5 version 1.10.2")
     def test_virtual_prefix_require(self):
-        dset = self.f.require_dataset('foo', (10, 3), 'f', virtual_prefix = "/path/to/virtual")
+        virtual_prefix = "/path/to/virtual"
+        dset = self.f.require_dataset('foo', (10, 3), 'f', virtual_prefix = virtual_prefix)
+        virtual_prefix_readback = pathlib.Path(dset.id.get_access_plist().get_virtual_prefix().decode()).as_posix()
+        self.assertEqual(virtual_prefix, virtual_prefix_readback)
         self.assertIsInstance(dset, Dataset)
         self.assertEqual(dset.shape, (10, 3))

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -769,7 +769,7 @@ class TestExternal(BaseDataset):
         # create a dataset in an external file and set it
         ext_file = self.mktemp()
         external = [(ext_file, 0, h5f.UNLIMITED)]
-        dset = self.f.create_dataset('foo', shape, dtype=testdata.dtype, external=external)
+        dset = self.f.create_dataset('foo', shape, dtype=testdata.dtype, external=external, efile_prefix="\${ORIGIN}")
         dset[...] = testdata
 
         assert dset.external is not None
@@ -778,6 +778,9 @@ class TestExternal(BaseDataset):
         with open(ext_file, 'rb') as fid:
             contents = fid.read()
         assert contents == testdata.tobytes()
+
+        # check efile_prefix
+        assert dset.id.get_access_plist().get_efile_prefix().decode() == "\${ORIGIN}"
 
     def test_name_str(self):
         """ External argument may be a file name str only """

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -17,6 +17,7 @@
 """
 
 import pathlib
+import os
 import sys
 import numpy as np
 import platform
@@ -785,6 +786,34 @@ class TestExternal(BaseDataset):
             efile_prefix = pathlib.Path(dset.id.get_access_plist().get_efile_prefix().decode()).as_posix()
             parent = pathlib.Path(self.f.filename).parent.as_posix()
             assert efile_prefix == parent
+
+    def test_contents_efile_prefix(self):
+        """ Create and access an external dataset using an efile_prefix"""
+
+        shape = (6, 100)
+        testdata = np.random.random(shape)
+
+        # create a dataset in an external file and set it
+        ext_file = self.mktemp()
+        external = [(os.path.basename(ext_file), 0, h5f.UNLIMITED)]
+        dset = self.f.create_dataset('foo', shape, dtype=testdata.dtype, external=external, efile_prefix=os.path.dirname(ext_file))
+        dset[...] = testdata
+
+        assert dset.external is not None
+
+        # verify file's existence, size, and contents
+        with open(ext_file, 'rb') as fid:
+            contents = fid.read()
+        assert contents == testdata.tobytes()
+
+        # check efile_prefix, only for 1.10.0 due to HDFFV-9716
+        if h5py.version.hdf5_version_tuple >= (1,10,0):
+            efile_prefix = pathlib.Path(dset.id.get_access_plist().get_efile_prefix().decode()).as_posix()
+            assert efile_prefix == os.path.dirname(ext_file)
+
+        dset2 = self.f.require_dataset('foo', shape, testdata.dtype, efile_prefix=os.path.dirname(ext_file))
+        assert dset2.external is not None
+        dset2[()] == testdata
 
     def test_name_str(self):
         """ External argument may be a file name str only """
@@ -1817,3 +1846,24 @@ class TestCommutative(BaseDataset):
         val = float(0.)
         assert (val == dset) == (dset == val)
         assert (val != dset) == (dset != val)
+
+class TestVirtualPrefix(BaseDataset):
+    """
+    Test setting virtual prefix
+    """
+    @ut.skipIf(version.hdf5_version_tuple < (1, 10, 2),
+               reason = "Virtual prefix does not exist before HDF5 version 1.10.2")
+    def test_virtual_prefix_create(self):
+        shape = (100,1)
+        virtual_prefix = "/path/to/virtual"
+        dset = self.f.create_dataset("test", shape, dtype=float,
+                                     data=np.random.rand(*shape),
+                                     virtual_prefix = virtual_prefix)
+
+        virtual_prefix_readback = pathlib.Path(dset.id.get_access_plist().get_virtual_prefix().decode()).as_posix()
+        assert virtual_prefix_readback == virtual_prefix
+
+    def test_virtual_prefix_require(self):
+        dset = self.f.require_dataset('foo', (10, 3), 'f', virtual_prefix = "/path/to/virtual")
+        self.assertIsInstance(dset, Dataset)
+        self.assertEqual(dset.shape, (10, 3))

--- a/h5py/tests/test_h5p.py
+++ b/h5py/tests/test_h5p.py
@@ -69,6 +69,31 @@ class TestDA(TestCase):
         self.assertEqual((nslots, nbytes, w0),
                          dalist.get_chunk_cache())
 
+    def test_efile_prefix(self):
+        '''test get/set efile prefix '''
+        dalist = h5p.create(h5p.DATASET_ACCESS)
+        self.assertEqual(dalist.get_efile_prefix().decode(), '')
+
+        efile_prefix = "path/to/external/dataset"
+        dalist.set_efile_prefix(efile_prefix.encode('utf-8'))
+        self.assertEqual(dalist.get_efile_prefix().decode(),
+                         efile_prefix)
+
+        efile_prefix = "${ORIGIN}"
+        dalist.set_efile_prefix(efile_prefix.encode('utf-8'))
+        self.assertEqual(dalist.get_efile_prefix().decode(),
+                         efile_prefix)
+
+    def test_virtual_prefix(self):
+        '''test get/set virtual prefix '''
+        dalist = h5p.create(h5p.DATASET_ACCESS)
+        self.assertEqual(dalist.get_virtual_prefix().decode(), '')
+
+        virtual_prefix = "path/to/virtual/dataset"
+        dalist.set_virtual_prefix(virtual_prefix.encode('utf-8'))
+        self.assertEqual(dalist.get_virtual_prefix().decode(),
+                         virtual_prefix)
+
 
 class TestFA(TestCase):
     '''

--- a/h5py/tests/test_h5p.py
+++ b/h5py/tests/test_h5p.py
@@ -69,6 +69,8 @@ class TestDA(TestCase):
         self.assertEqual((nslots, nbytes, w0),
                          dalist.get_chunk_cache())
 
+    @ut.skipIf(version.hdf5_version_tuple < (1, 8, 17),
+               'Requires HDF5 1.8.17 or later')
     def test_efile_prefix(self):
         '''test get/set efile prefix '''
         dalist = h5p.create(h5p.DATASET_ACCESS)
@@ -84,6 +86,8 @@ class TestDA(TestCase):
         self.assertEqual(dalist.get_efile_prefix().decode(),
                          efile_prefix)
 
+    @ut.skipIf(version.hdf5_version_tuple < (1, 10, 2),
+               'Requires HDF5 1.10.2 or later')
     def test_virtual_prefix(self):
         '''test get/set virtual prefix '''
         dalist = h5p.create(h5p.DATASET_ACCESS)


### PR DESCRIPTION
<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py


-->

The primary purpose of this pull request is to add `H5Pget_efile_prefix` and `H5Pset_efile_prefix` to the low level API and expose this functionality to the high level API in `create_dataset` and `require_dataset`.
* Some buffers for reading the prefix were not initialized. This pull request initializing the first byte to NUL so that an empty string is correctly returned when the prefixes are not set.

Fixes https://github.com/h5py/h5py/issues/2055

