### PR TITLE
Add aarch64 wheels for python3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,9 @@ matrix:
         - HDF5_VERSION=1.10.5
         - HDF5_DIR=$HDF5_CACHE_DIR/$HDF5_VERSION
         - H5PY_ENFORCE_COVERAGE=yes
-        - CIBW_BUILD: cp3[789]-*
+        - CIBW_BUILD: cp3*-manylinux*
         - CIBW_MANYLINUX_AARCH64_IMAGE: ghcr.io/h5py/manylinux2014_aarch64-hdf5
         - CIBW_ARCHS: aarch64
-
 before_install:
   # - export PATH=/usr/lib/ccache:$PATH
   - ccache -s
@@ -57,7 +56,7 @@ install:
     - pip install -U tox codecov virtualenv
     - ci/get_hdf5_if_needed.sh
     - ls -lRa $HDF5_CACHE_DIR
-    - if [[ $CIBW_ARCHS == aarch64 ]]; then python -m pip install cibuildwheel==1.9.0; fi
+    - if [[ $CIBW_ARCHS == aarch64 ]]; then python -m pip install cibuildwheel; fi
 
 script:
     - if [[ $CIBW_ARCHS == aarch64 ]]; then python3 -m cibuildwheel --output-dir wheelhouse; fi


### PR DESCRIPTION
h5py is a dependency for Tensorflow, and currently tensorflow python3.10 installation is failing due to the missing dependency. 
Therefore this PR addresses issue to add support and publish h5py python3.10 wheels. 
Success build: https://app.travis-ci.com/github/tbbharaj/h5py/builds/250398055

