### PR TITLE
workaround mpi4py packaging issues on py3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,7 @@ if setup_configure.mpi_enabled():
     RUN_REQUIRES.append('mpi4py >=3.0.2')
     SETUP_REQUIRES.append("mpi4py ==3.0.2; python_version<'3.8'")
     SETUP_REQUIRES.append("mpi4py ==3.0.3; python_version=='3.8.*'")
-    SETUP_REQUIRES.append("mpi4py ==3.0.3; python_version=='3.9.*'")
-    SETUP_REQUIRES.append("mpi4py ==3.1.3; python_version>='3.10'")
+    SETUP_REQUIRES.append("mpi4py ==3.1.0; python_version>='3.9'")
 
 # Set the environment variable H5PY_SETUP_REQUIRES=0 if we need to skip
 # setup_requires for any reason.

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,9 @@ SETUP_REQUIRES = []
 if setup_configure.mpi_enabled():
     RUN_REQUIRES.append('mpi4py >=3.0.2')
     SETUP_REQUIRES.append("mpi4py ==3.0.2; python_version<'3.8'")
-    SETUP_REQUIRES.append("mpi4py ==3.0.3; python_version>='3.8'")
+    SETUP_REQUIRES.append("mpi4py ==3.0.3; python_version=='3.8.*'")
+    SETUP_REQUIRES.append("mpi4py ==3.0.3; python_version=='3.9.*'")
+    SETUP_REQUIRES.append("mpi4py ==3.1.3; python_version>='3.10'")
 
 # Set the environment variable H5PY_SETUP_REQUIRES=0 if we need to skip
 # setup_requires for any reason.


### PR DESCRIPTION
Added a fix for #2100. 
Not the prettiest logic statements but this works with my py3.10 setup and should be compatible with python versions <3.10. Simple tests run fine, unfortunately `tox` testing produces errors with only py3.10.
I've added an entry note in the news folder.

<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->
