### PR TITLE
Update leftover links to the Google group

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Websites
 
 * Main website: https://www.h5py.org
 * Source code: https://github.com/h5py/h5py
-* Mailing list: https://groups.google.com/d/forum/h5py
+* Discussion forum: https://forum.hdfgroup.org/c/hdf-tools/h5py
 
 Installation
 ------------

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -7,14 +7,12 @@ scale-offset filter, came from user code contributions.
 
 Since we use GitHub, the workflow will be familiar to many people.
 If you have questions about the process or about the details of implementing
-your feature, always feel free to ask on the Google Groups list, either
-by emailing:
+your feature, feel free to ask on Github itself, or on the h5py section of the
+HDF5 forum:
 
-     h5py@googlegroups.com
+    https://forum.hdfgroup.org/c/hdf-tools/h5py
 
-or via the web interface at:
-
-    https://groups.google.com/forum/#!forum/h5py
+Posting on this forum requires registering for a free account with HDF group.
 
 Anyone can post to this list. Your first message will be approved by a
 moderator, so don't worry if there's a brief delay.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ Other resources
 ---------------
 
 * `Python and HDF5 O'Reilly book <https://shop.oreilly.com/product/0636920030249.do>`_
-* `Ask questions on the mailing list at Google Groups <http://groups.google.com/d/forum/h5py>`_
+* `Ask questions on the HDF forum <https://forum.hdfgroup.org/c/hdf-tools/h5py>`_
 * `GitHub project <https://github.com/h5py/h5py>`_
 
 

--- a/lzf/README.txt
+++ b/lzf/README.txt
@@ -76,7 +76,7 @@ filter by default.
 
 * Main web site and documentation:  http://h5py.org
 
-* mailing list:  https://groups.google.com/forum/#!forum/h5py
+* Discussion forum: https://forum.hdfgroup.org/c/hdf-tools/h5py
 
 
 History of changes


### PR DESCRIPTION
I spotted a few links to the Google group, which we've now locked in favour of the h5py page on the HDF forum.