### PR TITLE
setup: Fix hdf5 dll search in mingw

### DIFF
--- a/setup_configure.py
+++ b/setup_configure.py
@@ -224,8 +224,12 @@ class HDF5LibWrapper:
             default_path = 'libhdf5.dylib'
             regexp = re.compile(r'^libhdf5.dylib')
         elif sys.platform.startswith('win'):
-            default_path = 'hdf5.dll'
-            regexp = re.compile(r'^hdf5.dll')
+            if 'MSC' in sys.version:
+                default_path = 'hdf5.dll'
+                regexp = re.compile(r'^hdf5.dll')
+            else:
+                default_path = 'libhdf5-0.dll'
+                regexp = re.compile(r'^libhdf5-[0-9].dll')
             if sys.version_info >= (3, 8):
                 # To overcome "difficulty" loading the library on windows
                 # https://bugs.python.org/issue42114


### PR DESCRIPTION
This fixes the following error in mingw environment:
Loading library to get build settings and version: hdf5.dll
error: Unable to load dependency HDF5, make sure HDF5 is installed properly
error: Could not find module 'hdf5.dll' (or one of its dependencies).
Try using the full path with constructor syntax.

The error is fixed by checking if the python executable
is compiled in MSVC environment using sys.version. If not
then search for libhdf5-0.dll file which is the name of
hdf5 shared library in mingw environment.

<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->
