### PR TITLE
Add H5Pget_meta_block_size and H5Pset_meta_block_size support

### DIFF
--- a/docs/high/file.rst
+++ b/docs/high/file.rst
@@ -475,7 +475,7 @@ Reference
             ``alignment_threshold``. See the description above. For more
             details, see :ref:`file_alignment`.
     :param meta_block_size: Determines the current minimum size, in bytes, of
-            new metadata block allocations. See :ref:`meta_block_size`.
+            new metadata block allocations. See :ref:`file_meta_block_size`.
     :param kwds:    Driver-specific keywords; see :ref:`file_driver`.
 
     .. method:: __bool__()

--- a/docs/high/file.rst
+++ b/docs/high/file.rst
@@ -386,6 +386,21 @@ measured from the end of the user block.
 For more information, see the official HDF5 documentation `H5P_SET_ALIGNMENT
 <https://portal.hdfgroup.org/display/HDF5/H5P_SET_ALIGNMENT>`_.
 
+.. _file_meta_block_size:
+
+Meta block size
+---------------
+
+Space for meta data is allocated in blocks within the HDF5 file. The argument
+``meta_block_size`` of the :class:`File` constructor sets the minimum size of
+these blocks.  Setting a large value can consolidate meta data into a small
+number of regions. Setting a small value can reduce the overall file size,
+especially in combination with the ``libver`` option. This controls how the
+overall data and meta data are laid out within the file.
+
+For more information, see the offical HDF5 documentation `H5P_SET_META_BLOCK_SIZE
+<https://portal.hdfgroup.org/display/HDF5/H5P_SET_META_BLOCK_SIZE>`_.
+
 Reference
 ---------
 
@@ -459,6 +474,8 @@ Reference
     :param alignment_interval: This property should be used in conjunction with
             ``alignment_threshold``. See the description above. For more
             details, see :ref:`file_alignment`.
+    :param meta_block_size: Determines the current minimum size, in bytes, of
+            new metadata block allocations. See :ref:`meta_block_size`.
     :param kwds:    Driver-specific keywords; see :ref:`file_driver`.
 
     .. method:: __bool__()
@@ -512,3 +529,8 @@ Reference
     .. attribute:: userblock_size
 
         Size of user block (in bytes).  Generally 0.  See :ref:`file_userblock`.
+
+    .. attribute:: meta_block_size
+
+        Minimum size, in bytes, of metadata block allocations. Default: 2048.
+        See :ref`file_meta_block_size`.

--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -317,6 +317,8 @@ hdf5:
   void*     H5Pget_driver_info(hid_t plist_id)
   herr_t    H5Pget_mdc_config(hid_t plist_id, H5AC_cache_config_t *config_ptr)
   herr_t    H5Pset_mdc_config(hid_t plist_id, H5AC_cache_config_t *config_ptr)
+  herr_t    H5Pset_meta_block_size(hid_t fapl_id, hsize_t size)
+  herr_t    H5Pget_meta_block_size(hid_t fapl_id, hsize_t * size)
   1.8.9 herr_t H5Pset_file_image(hid_t plist_id, void *buf_ptr, size_t buf_len)
   1.10.1 herr_t H5Pset_page_buffer_size(hid_t plist_id, size_t buf_size, unsigned min_meta_per, unsigned min_raw_per)
   1.10.1 herr_t H5Pget_page_buffer_size(hid_t plist_id, size_t *buf_size, unsigned *min_meta_per, unsigned *min_raw_per)

--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -1287,6 +1287,23 @@ cdef class PropFAID(PropInstanceID):
         """
         H5Pset_libver_bounds(self.id, <H5F_libver_t>low, <H5F_libver_t>high)
 
+    @with_phil
+    def set_meta_block_size(self, size_t size):
+        """ (UINT size)
+
+        Set the current minimum size, in bytes, of new metadata block allocations.
+        """
+        H5Pset_meta_block_size(self.id, size)
+
+    @with_phil
+    def get_meta_block_size(self):
+        """ () => UINT size
+
+        Get the current minimum size, in bytes, of new metadata block allocations.
+        """
+        cdef hsize_t size
+        H5Pget_meta_block_size(self.id, &size)
+        return size
 
     @with_phil
     def get_libver_bounds(self):

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -654,7 +654,7 @@ class TestFileMetaBlockSize(TestCase):
             self.assertTrue(fid.meta_block_size) == meta_block_size
             self.assertTrue(fid["test"].id.get_offset()) == meta_block_size
 
-    @pytest.mark.skipif(h5py.version.hdf5_version_tuple < (1, 8, 0),
+    @pytest.mark.skipif(h5py.version.hdf5_version_tuple < (1, 10, 2),
                         reason="HDF5 header became smaller in version v1.8")
     def test_file_create_with_meta_block_size_libver(self):
         meta_block_size = 512

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -637,6 +637,39 @@ class TestUserblock(TestCase):
             pyfile.close()
 
 
+class TestFileMetaBlockSize(TestCase):
+
+    """
+        Feature: The minimum meta data block size can be set.
+    """
+
+    def test_file_create_with_meta_block_size(self):
+        meta_block_size = 4096
+        with File(
+            self.mktemp(), 'w',
+            meta_block_size=meta_block_size
+        ) as fid:
+            self.assertTrue(fid)
+            fid["test"] = 5
+            self.assertTrue(fid.meta_block_size) == meta_block_size
+            self.assertTrue(fid["test"].id.get_offset()) == meta_block_size
+
+    @pytest.mark.skipif(h5py.version.hdf5_version_tuple < (1, 8, 0),
+                        reason="HDF5 header became smaller in version v1.8")
+    def test_file_create_with_meta_block_size_libver(self):
+        meta_block_size = 512
+        libver = "v108"
+        with File(
+            self.mktemp(), 'w',
+            meta_block_size=meta_block_size,
+            libver=libver
+        ) as fid:
+            self.assertTrue(fid)
+            fid["test"] = 3
+            self.assertTrue(fid.meta_block_size) == meta_block_size
+            self.assertTrue(fid["test"].id.get_offset()) == meta_block_size
+
+
 class TestContextManager(TestCase):
 
     """

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -637,39 +637,6 @@ class TestUserblock(TestCase):
             pyfile.close()
 
 
-class TestFileMetaBlockSize(TestCase):
-
-    """
-        Feature: The minimum meta data block size can be set.
-    """
-
-    def test_file_create_with_meta_block_size(self):
-        meta_block_size = 4096
-        with File(
-            self.mktemp(), 'w',
-            meta_block_size=meta_block_size
-        ) as fid:
-            self.assertTrue(fid)
-            fid["test"] = 5
-            self.assertTrue(fid.meta_block_size) == meta_block_size
-            self.assertTrue(fid["test"].id.get_offset()) == meta_block_size
-
-    @pytest.mark.skipif(h5py.version.hdf5_version_tuple < (1, 10, 2),
-                        reason="HDF5 header became smaller in version v1.8")
-    def test_file_create_with_meta_block_size_libver(self):
-        meta_block_size = 512
-        libver = "v108"
-        with File(
-            self.mktemp(), 'w',
-            meta_block_size=meta_block_size,
-            libver=libver
-        ) as fid:
-            self.assertTrue(fid)
-            fid["test"] = 3
-            self.assertTrue(fid.meta_block_size) == meta_block_size
-            self.assertTrue(fid["test"].id.get_offset()) == meta_block_size
-
-
 class TestContextManager(TestCase):
 
     """

--- a/h5py/tests/test_file2.py
+++ b/h5py/tests/test_file2.py
@@ -280,10 +280,12 @@ class TestTrackOrder(TestCase):
 class TestFileMetaBlockSize(TestCase):
 
     """
-        Feature: The minimum metadata block size can be set.
+        Feature: The meta block size can be manipulated, changing how metadata
+        is aggregated and the offset of the first dataset.
     """
 
-    def test_file_create_with_meta_block_size(self):
+    def test_file_create_with_meta_block_size_4096(self):
+        # Test a large meta block size of 4 kibibytes
         meta_block_size = 4096
         with File(
             self.mktemp(), 'w',
@@ -292,13 +294,14 @@ class TestFileMetaBlockSize(TestCase):
         ) as f:
             f["test"] = 5
             self.assertEqual(f.meta_block_size, meta_block_size)
+            # Equality is expected for HDF5 1.10
             self.assertGreaterEqual(f["test"].id.get_offset(), meta_block_size)
 
-    @pytest.mark.skipif(h5py.version.hdf5_version_tuple < (1, 10, 2),
-                        reason="HDF5 header became smaller in version v1.8")
-    def test_file_create_with_meta_block_size_libver(self):
+    def test_file_create_with_meta_block_size_512(self):
+        # Test a small meta block size of 512 bytes
+        # The smallest verifiable meta_block_size is 463
         meta_block_size = 512
-        libver = "v108"
+        libver = "latest"
         with File(
             self.mktemp(), 'w',
             meta_block_size=meta_block_size,
@@ -306,4 +309,5 @@ class TestFileMetaBlockSize(TestCase):
         ) as f:
             f["test"] = 3
             self.assertEqual(f.meta_block_size, meta_block_size)
-            self.assertEqual(f["test"].id.get_offset(), meta_block_size)
+            # Equality is expected for HDF5 1.10
+            self.assertGreaterEqual(f["test"].id.get_offset(), meta_block_size)

--- a/h5py/tests/test_file2.py
+++ b/h5py/tests/test_file2.py
@@ -289,10 +289,9 @@ class TestFileMetaBlockSize(TestCase):
             self.mktemp(), 'w',
             meta_block_size=meta_block_size
         ) as f:
-            self.assertTrue(f)
             f["test"] = 5
-            self.assertTrue(f.meta_block_size) == meta_block_size
-            self.assertTrue(f["test"].id.get_offset()) == meta_block_size
+            self.assertEqual(f.meta_block_size, meta_block_size)
+            self.assertEqual(f["test"].id.get_offset(), meta_block_size)
 
     @pytest.mark.skipif(h5py.version.hdf5_version_tuple < (1, 10, 2),
                         reason="HDF5 header became smaller in version v1.8")
@@ -304,7 +303,6 @@ class TestFileMetaBlockSize(TestCase):
             meta_block_size=meta_block_size,
             libver=libver
         ) as f:
-            self.assertTrue(f)
             f["test"] = 3
-            self.assertTrue(f.meta_block_size) == meta_block_size
-            self.assertTrue(f["test"].id.get_offset()) == meta_block_size
+            self.assertEqual(f.meta_block_size, meta_block_size)
+            self.assertEqual(f["test"].id.get_offset(), meta_block_size)

--- a/h5py/tests/test_file2.py
+++ b/h5py/tests/test_file2.py
@@ -13,9 +13,11 @@
 
 import h5py
 from h5py._hl.files import _drivers
+from h5py import File
 
 from .common import ut, TestCase
 
+import pytest
 import io
 import tempfile
 import os

--- a/h5py/tests/test_file2.py
+++ b/h5py/tests/test_file2.py
@@ -287,7 +287,8 @@ class TestFileMetaBlockSize(TestCase):
         meta_block_size = 4096
         with File(
             self.mktemp(), 'w',
-            meta_block_size=meta_block_size
+            meta_block_size=meta_block_size,
+            libver="latest"
         ) as f:
             f["test"] = 5
             self.assertEqual(f.meta_block_size, meta_block_size)

--- a/h5py/tests/test_file2.py
+++ b/h5py/tests/test_file2.py
@@ -292,7 +292,7 @@ class TestFileMetaBlockSize(TestCase):
         ) as f:
             f["test"] = 5
             self.assertEqual(f.meta_block_size, meta_block_size)
-            self.assertEqual(f["test"].id.get_offset(), meta_block_size)
+            self.assertGreaterEqual(f["test"].id.get_offset(), meta_block_size)
 
     @pytest.mark.skipif(h5py.version.hdf5_version_tuple < (1, 10, 2),
                         reason="HDF5 header became smaller in version v1.8")

--- a/h5py/tests/test_file2.py
+++ b/h5py/tests/test_file2.py
@@ -311,3 +311,5 @@ class TestFileMetaBlockSize(TestCase):
             self.assertEqual(f.meta_block_size, meta_block_size)
             # Equality is expected for HDF5 1.10
             self.assertGreaterEqual(f["test"].id.get_offset(), meta_block_size)
+            # Default meta_block_size is 2048. This should fail if meta_block_size is not set.
+            self.assertLess(f["test"].id.get_offset(), meta_block_size*2)

--- a/h5py/tests/test_file2.py
+++ b/h5py/tests/test_file2.py
@@ -273,3 +273,36 @@ class TestTrackOrder(TestCase):
         self.populate(f)
         self.assertEqual(list(f),
                          sorted([str(i) for i in range(100)]))
+
+
+class TestFileMetaBlockSize(TestCase):
+
+    """
+        Feature: The minimum meta data block size can be set.
+    """
+
+    def test_file_create_with_meta_block_size(self):
+        meta_block_size = 4096
+        with File(
+            self.mktemp(), 'w',
+            meta_block_size=meta_block_size
+        ) as f:
+            self.assertTrue(f)
+            f["test"] = 5
+            self.assertTrue(f.meta_block_size) == meta_block_size
+            self.assertTrue(f["test"].id.get_offset()) == meta_block_size
+
+    @pytest.mark.skipif(h5py.version.hdf5_version_tuple < (1, 10, 2),
+                        reason="HDF5 header became smaller in version v1.8")
+    def test_file_create_with_meta_block_size_libver(self):
+        meta_block_size = 512
+        libver = "v108"
+        with File(
+            self.mktemp(), 'w',
+            meta_block_size=meta_block_size,
+            libver=libver
+        ) as f:
+            self.assertTrue(f)
+            f["test"] = 3
+            self.assertTrue(f.meta_block_size) == meta_block_size
+            self.assertTrue(f["test"].id.get_offset()) == meta_block_size

--- a/news/pr_2106_meta_block_size.rst
+++ b/news/pr_2106_meta_block_size.rst
@@ -1,0 +1,30 @@
+New features
+------------
+
+* `File` now has an `meta_block_size` argument and `meta_block_size` property. This influences how the space for meta data, including the initial header, is allocated.
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* [`H5Pset_meta_block_size`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_META_BLOCK_SIZE)
+* [`H5Pget_meta_block_size`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_META_BLOCK_SIZE)
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
Here we add support for [`H5Pget_meta_block_size`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_META_BLOCK_SIZE) and [`H5Pset_meta_block_size`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_META_BLOCK_SIZE).

`h5py.File` gets a new `meta_block_size` keyword argument that defaults to `None`.
`h5py.File` also gets a new property `meta_block_size`.

This feature sets the minimum meta block size that the HDF5 will allocate. This can be used to regularize the size of the header and the space between datasets. Setting a large meta block size can consolidate the meta data into a single large header. Setting a small meta block size can minimize the space needed for the HDF5 header.

Note that this influences a file _access_ property. The value is not stored in the file.

```python
In [1]: import h5py, os

In [2]: with h5py.File(
   ...:     "test.h5","w",
   ...: ) as h5f:
   ...:     h5f["test"] = 1
   ...:     print(h5f["test"].id.get_offset())
   ...: print(os.path.getsize("test.h5"))
2048
2056

In [4]: with h5py.File(
   ...:     "test.h5","w",
   ...:     meta_block_size=4096
   ...: ) as h5f:
   ...:     h5f["test"] = 1
   ...:     print(h5f["test"].id.get_offset())
   ...: print(os.path.getsize("test.h5"))
4096
4104

In [6]: with h5py.File(
   ...:     "test.h5","w",
   ...:     libver="v108",
   ...:     meta_block_size=512
   ...: ) as h5f:
   ...:     h5f["test"] = 1
   ...:     print(h5f["test"].id.get_offset())
   ...: print(os.path.getsize("test.h5"))
512
520
```