### PR TITLE
Add tests for fixed length strings with fillvalues

### DIFF
--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -547,6 +547,14 @@ cdef class PropDCID(PropOCID):
         if string_info is not None and string_info.length is None:
             tid = py_create(value.dtype, logical=1)
             ret = H5Pget_fill_value(self.id, tid.id, &c_ptr)
+            if c_ptr == NULL:
+                # If the pointer is NULL (either the value did not get changed,
+                # or maybe the 0 length string, it's unclear currently), if
+                # PyBytes_FromString is called on the pointer, we get a
+                # segfault. If we set the value to empty bytes, then we
+                # shouldn't segfault.
+                value[0] = b""
+                return
             fill_value = c_ptr
             value[0] = fill_value
             return

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1141,6 +1141,15 @@ class TestStrings(BaseDataset):
         self.assertEqual(string_info.encoding, 'ascii')
         self.assertEqual(string_info.length, 10)
 
+    def test_fixed_bytes_fillvalue(self):
+        """ Vlen bytes dataset handles fillvalue """
+        dt = h5py.string_dtype(encoding='ascii', length=10)
+        fill_value = b'bar'
+        ds = self.f.create_dataset('x', (100,), dtype=dt, fillvalue=fill_value)
+        self.assertEqual(self.f['x'][0], fill_value)
+        self.assertEqual(self.f['x'].asstr()[0], fill_value.decode())
+        self.assertEqual(self.f['x'].fillvalue, fill_value)
+
     def test_fixed_utf8(self):
         dt = h5py.string_dtype(encoding='utf-8', length=5)
         ds = self.f.create_dataset('x', (100,), dtype=dt)
@@ -1156,6 +1165,15 @@ class TestStrings(BaseDataset):
             ds[8:10] = np.array([s, s], dtype='U')
 
         np.testing.assert_array_equal(ds[:8], np.array([s.encode('utf-8')] * 8, dtype='S'))
+
+    def test_fixed_utf_8_fillvalue(self):
+        """ Vlen unicode dataset handles fillvalue """
+        dt = h5py.string_dtype(encoding='utf-8', length=10)
+        fill_value = 'bár'.encode("utf-8")
+        ds = self.f.create_dataset('x', (100,), dtype=dt, fillvalue=fill_value)
+        self.assertEqual(self.f['x'][0], fill_value)
+        self.assertEqual(self.f['x'].asstr()[0], fill_value.decode("utf-8"))
+        self.assertEqual(self.f['x'].fillvalue, fill_value)
 
     def test_fixed_unicode(self):
         """ Fixed-length unicode datasets are unsupported (raise TypeError) """


### PR DESCRIPTION
I suspect the support for adding vlen strings may have broken fixed length
strings. These tests do the same thing as the vlen strings, but use
fixed length dtypes.

This may be related to #2110 (in that I've seen segfaults), but possibly not (in that I'm seeing issues on linux).