### PR TITLE
Fix sphinx extlinks warning

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,8 +37,8 @@ extensions = [
 intersphinx_mapping = {'low': ('https://api.h5py.org', None)}
 
 extlinks = {
-    'issue': ('https://github.com/h5py/h5py/issues/%s', 'GH'),
-    'pr': ('https://github.com/h5py/h5py/pull/%s', 'PR '),
+    'issue': ('https://github.com/h5py/h5py/issues/%s', 'GH%s'),
+    'pr': ('https://github.com/h5py/h5py/pull/%s', 'PR %s'),
 }
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
https://github.com/sphinx-doc/sphinx/commit/93cf1a57d916a1ff96c8e8a0356d0256e40489ac
requires that the caption contain '%s' once. Previously our captions did
not contain '%s', this adds it in.
