### PR TITLE
Add timeout for uploading coverage data to codecov

### DIFF
--- a/ci/upload_coverage.py
+++ b/ci/upload_coverage.py
@@ -48,7 +48,7 @@ def send_coverage(*, workdir, coverage_files, codecov_token):
     if codecov_token is not None:
         codecov_args.extend(['-t', codecov_token])
     codecov_args.extend(['--file', 'coverage.xml'])
-    run_with_python(['codecov'] + codecov_args)
+    run_with_python(['codecov'] + codecov_args, timeout=60)
 
 
 def main():

--- a/ci/upload_coverage.py
+++ b/ci/upload_coverage.py
@@ -18,11 +18,12 @@ PYVERSION = '{}.{}'.format(sys.version_info[0], sys.version_info[1])
 
 
 def msg(*args):
-    print('ERR:', *args, file=sys.stderr)
+    print('ERR:', *args, file=sys.stderr, flush=True)
 
 
 def pmsg(*args):
     pprint(*args, stream=sys.stderr)
+    sys.stderr.flush()
 
 
 def run_with_python(args, **kwargs):

--- a/ci/upload_coverage.py
+++ b/ci/upload_coverage.py
@@ -33,20 +33,7 @@ def run_with_python(args, **kwargs):
         exe = []
     cmd = exe + args
     msg("Running:", *cmd)
-    try:
-        res = run(cmd, check=True, stdout=PIPE, stderr=PIPE, **kwargs)
-    except CalledProcessError as e:
-        msg("STDOUT:")
-        sys.stdout.buffer.write(e.stdout)
-        msg("STDERR:")
-        sys.stderr.buffer.write(e.stderr)
-        raise
-    else:
-        msg("STDOUT:")
-        sys.stdout.buffer.write(res.stdout)
-        msg("STDERR:")
-        sys.stderr.buffer.write(res.stderr)
-        return res
+    return run(cmd, check=True, input=b'', **kwargs)
 
 
 def send_coverage(*, workdir, coverage_files, codecov_token):


### PR DESCRIPTION
This means the `upload_coverage.py` script fails rather than hanging. The call to `codecov` gets a maximum of 30 seconds to complete, which should be plenty.

See my investigation in #2113 for details of what I think is going on.