### PR TITLE
Validate `maxshape` in `Group.require_dataset`

### DIFF
--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -20,7 +20,7 @@ from .compat import filename_decode, filename_encode
 from .. import h5, h5g, h5i, h5o, h5r, h5t, h5l, h5p, h5s, h5d
 from . import base
 from .base import HLObject, MutableMappingHDF5, phil, with_phil
-from . import dataset
+from . import datasetu
 from . import datatype
 from .vds import vds_support
 
@@ -211,11 +211,14 @@ class Group(HLObject, MutableMappingHDF5):
         the same shape and a conversion-compatible dtype to be returned.  If
         True, the shape and dtype must match exactly.
 
+        If keyword "maxshape" is given, the maxshape and dtype must match
+        instead.
+
         Other dataset keywords (see create_dataset) may be provided, but are
         only used if a new dataset is to be created.
 
         Raises TypeError if an incompatible object already exists, or if the
-        shape or dtype don't match according to the above rules.
+        shape, maxshape or dtype don't match according to the above rules.
         """
         with phil:
             if name not in self:

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -218,7 +218,7 @@ class Group(HLObject, MutableMappingHDF5):
         shape or dtype don't match according to the above rules.
         """
         with phil:
-            if not name in self:
+            if name not in self:
                 return self.create_dataset(name, *(shape, dtype), **kwds)
 
             if isinstance(shape, int):
@@ -235,7 +235,7 @@ class Group(HLObject, MutableMappingHDF5):
                     raise TypeError("Max shapes do not match (existing %s vs new %s)" % (dset.maxshape, kwds["maxshape"]))
 
             if exact:
-                if not dtype == dset.dtype:
+                if dtype != dset.dtype:
                     raise TypeError("Datatypes do not exactly match (existing %s vs new %s)" % (dset.dtype, dtype))
             elif not numpy.can_cast(dtype, dset.dtype):
                 raise TypeError("Datatypes cannot be safely cast (existing %s vs new %s)" % (dset.dtype, dtype))

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -228,8 +228,11 @@ class Group(HLObject, MutableMappingHDF5):
             if not isinstance(dset, dataset.Dataset):
                 raise TypeError("Incompatible object (%s) already exists" % dset.__class__.__name__)
 
-            if not shape == dset.shape:
-                raise TypeError("Shapes do not match (existing %s vs new %s)" % (dset.shape, shape))
+            if shape != dset.shape:
+                if "maxshape" not in kwds:
+                    raise TypeError("Shapes do not match (existing %s vs new %s)" % (dset.shape, shape))
+                elif kwds["maxshape"] != dset.maxshape:
+                    raise TypeError("Max shapes do not match (existing %s vs new %s)" % (dset.maxshape, kwds["maxshape"]))
 
             if exact:
                 if not dtype == dset.dtype:

--- a/h5py/tests/test_group.py
+++ b/h5py/tests/test_group.py
@@ -164,16 +164,16 @@ class TestRequire(BaseGroup):
         assert isinstance(group, Group)
 
     def test_require_shape(self):
-        ds = self.f.require_dataset("foo/resizable", maxshape=(None, 3), dtype=int)
+        ds = self.f.require_dataset("foo/resizable", shape=(0, 3), maxshape=(None, 3), dtype=int)
         ds.resize(20, axis=0)
-        self.f.require_dataset("foo/resizable", maxshape=(None, 3), dtype=int)
+        self.f.require_dataset("foo/resizable", shape=(0, 3), maxshape=(None, 3), dtype=int)
         self.f.require_dataset("foo/resizable", shape=(20, 3), dtype=int)
         with self.assertRaises(TypeError):
-            self.f.require_dataset("foo/resizable", maxshape=(3, None), dtype=int)
+            self.f.require_dataset("foo/resizable", shape=(0, 0), maxshape=(3, None), dtype=int)
         with self.assertRaises(TypeError):
-            self.f.require_dataset("foo/resizable", maxshape=(None, 5), dtype=int)
+            self.f.require_dataset("foo/resizable", shape=(0, 0), maxshape=(None, 5), dtype=int)
         with self.assertRaises(TypeError):
-            self.f.require_dataset("foo/resizable", maxshape=(None, 5, 2), dtype=int)
+            self.f.require_dataset("foo/resizable", shape=(0, 0), maxshape=(None, 5, 2), dtype=int)
         with self.assertRaises(TypeError):
             self.f.require_dataset("foo/resizable", shape=(10, 3), dtype=int)
 

--- a/h5py/tests/test_group.py
+++ b/h5py/tests/test_group.py
@@ -163,6 +163,21 @@ class TestRequire(BaseGroup):
         group = self.f.get('foo/bar/baz')
         assert isinstance(group, Group)
 
+    def test_require_shape(self):
+        ds = self.f.require_dataset("foo/resizable", maxshape=(None, 3), dtype=int)
+        ds.resize(20, axis=0)
+        self.f.require_dataset("foo/resizable", maxshape=(None, 3), dtype=int)
+        self.f.require_dataset("foo/resizable", shape=(20, 3), dtype=int)
+        with self.assertRaises(TypeError):
+            self.f.require_dataset("foo/resizable", maxshape=(3, None), dtype=int)
+        with self.assertRaises(TypeError):
+            self.f.require_dataset("foo/resizable", maxshape=(None, 5), dtype=int)
+        with self.assertRaises(TypeError):
+            self.f.require_dataset("foo/resizable", maxshape=(None, 5, 2), dtype=int)
+        with self.assertRaises(TypeError):
+            self.f.require_dataset("foo/resizable", shape=(10, 3), dtype=int)
+
+
 class TestDelete(BaseGroup):
 
     """


### PR DESCRIPTION
This PR validates the `maxshape` over `shape` in `Group.require_dataset` so that resizable datasets can be required without knowing their exact shape on resizable axes. closes #2018

PS: Sorry for the live testing, can't run `tox` due to an issue with my WSL setup.