### PR TITLE
Support chunk cache configuration per dataset

### DIFF
--- a/docs/high/file.rst
+++ b/docs/high/file.rst
@@ -327,10 +327,10 @@ given dataset's chunks are controlled when creating the dataset, but it is
 possible to adjust the behavior of the chunk *cache* when opening the file.
 
 The parameters controlling this behavior are prefixed by ``rdcc``, for *raw data
-chunk cache*.
+chunk cache*. They apply to all datasets unless specifically changed for each one.
 
 * ``rdcc_nbytes`` sets the total size (measured in bytes) of the raw data chunk
-  cache for each dataset.  The default size is 1 MB.
+  cache for each dataset.  The default size is 1 MiB.
   This should be set to the size of each chunk times the number of
   chunks that are likely to be needed in cache.
 * ``rdcc_w0`` sets the policy for chunks to be

--- a/docs/high/group.rst
+++ b/docs/high/group.rst
@@ -384,10 +384,35 @@ Reference
             it grow as needed. If only a name is given instead of an iterable
             of tuples, it is equivalent to
             ``[(name, 0, h5py.h5f.UNLIMITED)]``.
+
         :keyword allow_unknown_filter: Do not check that the requested filter is
             available for use (T/F). This should only be set if you will
             write any data with ``write_direct_chunk``, compressing the
             data before passing it to h5py.
+
+        :keyword rdcc_nbytes: Total size of the dataset's chunk cache in bytes.
+            The default size is 1024**2 (1 MiB).
+
+        :keyword rdcc_w0: The chunk preemption policy for this dataset. This
+            must be between 0 and 1 inclusive and indicates the weighting
+            according to which chunks which have been fully read or written are
+            penalized when determining which chunks to flush from cache. A value
+            of 0 means fully read or written chunks are treated no differently
+            than other chunks (the preemption is strictly LRU) while a value of
+            1 means fully read or written chunks are always preempted before
+            other chunks. If your application only reads or writes data once,
+            this can be safely set to 1. Otherwise, this should be set lower
+            depending on how often you re-read or re-write the same data. The
+            default value is 0.75.
+
+        :keyword rdcc_nslots: The number of chunk slots in the dataset's chunk
+            cache. Increasing this value reduces the number of cache collisions,
+            but slightly increases the memory used. Due to the hashing strategy,
+            this value should ideally be a prime number. As a rule of thumb,
+            this value should be at least 10 times the number of chunks that can
+            fit in rdcc_nbytes bytes. For maximum performance, this value should
+            be set approximately 100 times that number of chunks. The default
+            value is 521.
 
     .. method:: require_dataset(name, shape, dtype, exact=False, **kwds)
 
@@ -399,6 +424,9 @@ Reference
 
         If keyword "maxshape" is given, the maxshape and dtype must match
         instead.
+
+        If any of the keywords "rdcc_nslots", "rdcc_nbytes", or "rdcc_w0" are
+        given, they will be used to configure the dataset's chunk cache.
 
         Other dataset keywords (see create_dataset) may be provided, but are
         only used if a new dataset is to be created.

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -38,8 +38,8 @@ def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
                   fletcher32=None, maxshape=None, compression_opts=None,
                   fillvalue=None, scaleoffset=None, track_times=False,
                   external=None, track_order=None, dcpl=None, dapl=None,
-                  efile_prefix=None, virtual_prefix=None,
-                  allow_unknown_filter=False):
+                  efile_prefix=None, virtual_prefix=None, allow_unknown_filter=False,
+                  rdcc_nslots=None, rdcc_nbytes=None, rdcc_w0=None):
     """ Return a new low-level dataset identifier """
 
     # Convert data to a C-contiguous ndarray
@@ -138,7 +138,7 @@ def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
     if maxshape is not None:
         maxshape = tuple(m if m is not None else h5s.UNLIMITED for m in maxshape)
 
-    if efile_prefix is not None or virtual_prefix is not None:
+    if any([efile_prefix, virtual_prefix, rdcc_nbytes, rdcc_nslots, rdcc_w0]):
         dapl = dapl or h5p.create(h5p.DATASET_ACCESS)
 
     if efile_prefix is not None:
@@ -147,11 +147,20 @@ def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
     if virtual_prefix is not None:
         dapl.set_virtual_prefix(virtual_prefix)
 
+    if rdcc_nbytes or rdcc_nslots or rdcc_w0:
+        cache_settings = list(dapl.get_chunk_cache())
+        if rdcc_nslots is not None:
+            cache_settings[0] = rdcc_nslots
+        if rdcc_nbytes is not None:
+            cache_settings[1] = rdcc_nbytes
+        if rdcc_w0 is not None:
+            cache_settings[2] = rdcc_w0
+        dapl.set_chunk_cache(*cache_settings)
+
     if isinstance(data, Empty):
         sid = h5s.create(h5s.NULL)
     else:
         sid = h5s.create_simple(shape, maxshape)
-
 
     dset_id = h5d.create(parent.id, name, tid, sid, dcpl=dcpl, dapl=dapl)
 
@@ -160,13 +169,13 @@ def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
 
     return dset_id
 
-def open_dset(parent, name, dapl=None, efile_prefix=None, virtual_prefix=None, **kwds):
+
+def open_dset(parent, name, dapl=None, efile_prefix=None, virtual_prefix=None,
+              rdcc_nslots=None, rdcc_nbytes=None, rdcc_w0=None, **kwds):
     """ Return an existing low-level dataset identifier """
 
-    if efile_prefix is not None or virtual_prefix is not None:
+    if any([efile_prefix, virtual_prefix, rdcc_nbytes, rdcc_nslots, rdcc_w0]):
         dapl = dapl or h5p.create(h5p.DATASET_ACCESS)
-    else:
-        dapl = dapl or None
 
     if efile_prefix is not None:
         dapl.set_efile_prefix(efile_prefix)
@@ -174,9 +183,20 @@ def open_dset(parent, name, dapl=None, efile_prefix=None, virtual_prefix=None, *
     if virtual_prefix is not None:
         dapl.set_virtual_prefix(virtual_prefix)
 
+    if rdcc_nbytes or rdcc_nslots or rdcc_w0:
+        cache_settings = list(dapl.get_chunk_cache())
+        if rdcc_nslots is not None:
+            cache_settings[0] = rdcc_nslots
+        if rdcc_nbytes is not None:
+            cache_settings[1] = rdcc_nbytes
+        if rdcc_w0 is not None:
+            cache_settings[2] = rdcc_w0
+        dapl.set_chunk_cache(*cache_settings)
+
     dset_id = h5d.open(parent.id, name, dapl=dapl)
 
     return dset_id
+
 
 class AstypeWrapper:
     """Wrapper to convert data on reading from a dataset.
@@ -273,7 +293,7 @@ def readtime_dtype(basetype, names):
         raise ValueError("Field names only allowed for compound types")
 
     for name in names:  # Check all names are legal
-        if not name in basetype.names:
+        if name not in basetype.names:
             raise ValueError("Field %s does not appear in this type." % name)
 
     return numpy.dtype([(name, basetype.fields[name][0]) for name in names])
@@ -370,6 +390,7 @@ class ChunkIterator:
                 self._chunk_index[dim] = 0
             dim -= 1
         return tuple(slices)
+
 
 class Dataset(HLObject):
 

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -404,8 +404,8 @@ class File(Group):
         swmr
             Open the file in SWMR read mode. Only used when mode = 'r'.
         rdcc_nbytes
-            Total size of the raw data chunk cache in bytes. The default size
-            is 1024**2 (1 MB) per dataset.
+            Total size of the dataset chunk cache in bytes. The default size
+            is 1024**2 (1 MiB) per dataset. Applies to all datasets unless individually changed.
         rdcc_w0
             The chunk preemption policy for all datasets.  This must be
             between 0 and 1 inclusive and indicates the weighting according to
@@ -417,7 +417,7 @@ class File(Group):
             other chunks.  If your application only reads or writes data once,
             this can be safely set to 1.  Otherwise, this should be set lower
             depending on how often you re-read or re-write the same data.  The
-            default value is 0.75.
+            default value is 0.75. Applies to all datasets unless individually changed.
         rdcc_nslots
             The number of chunk slots in the raw data chunk cache for this
             file. Increasing this value reduces the number of cache collisions,
@@ -426,7 +426,7 @@ class File(Group):
             thumb, this value should be at least 10 times the number of chunks
             that can fit in rdcc_nbytes bytes. For maximum performance, this
             value should be set approximately 100 times that number of
-            chunks. The default value is 521.
+            chunks. The default value is 521. Applies to all datasets unless individually changed.
         track_order
             Track dataset/group/attribute creation order under root group
             if True. If None use global default h5.get_config().track_order.

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -283,8 +283,6 @@ class Group(HLObject, MutableMappingHDF5):
             except KeyError:
                 dset = self[name]
                 raise TypeError("Incompatible object (%s) already exists" % dset.__class__.__name__)
-            except Exception:
-                raise
 
             if shape != dset.shape:
                 if "maxshape" not in kwds:

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1805,6 +1805,28 @@ def test_allow_unknown_filter(writable_file):
     assert str(fake_filter_id) in ds._filters
 
 
+def test_dset_chunk_cache():
+    """Chunk cache configuration for individual datasets."""
+    from io import BytesIO
+    buf = BytesIO()
+    with h5py.File(buf, 'w') as fout:
+        ds = fout.create_dataset(
+            'x', shape=(10, 20), chunks=(5, 4), dtype='i4',
+            rdcc_nbytes=2 * 1024 * 1024, rdcc_w0=0.2, rdcc_nslots=997)
+        ds_chunk_cache = ds.id.get_access_plist().get_chunk_cache()
+        assert fout.id.get_access_plist().get_cache()[1:] != ds_chunk_cache
+        assert ds_chunk_cache == (997, 2 * 1024 * 1024, 0.2)
+
+    buf.seek(0)
+    with h5py.File(buf, 'r') as fin:
+        ds = fin.require_dataset(
+            'x', shape=(10, 20), dtype='i4',
+            rdcc_nbytes=3 * 1024 * 1024, rdcc_w0=0.67, rdcc_nslots=709)
+        ds_chunk_cache = ds.id.get_access_plist().get_chunk_cache()
+        assert fin.id.get_access_plist().get_cache()[1:] != ds_chunk_cache
+        assert ds_chunk_cache == (709, 3 * 1024 * 1024, 0.67)
+
+
 class TestCommutative(BaseDataset):
     """
     Test the symmetry of operators, at least with the numpy types.

--- a/news/dset-chunk-cache.rst
+++ b/news/dset-chunk-cache.rst
@@ -1,0 +1,33 @@
+New features
+------------
+
+* Chunk cache can be configured per individual HDF5 dataset. Use
+  :meth:`Group.create_dataset` for new datasets or :meth:`Group.require_dataset`
+  for already existing datasets. Any combination of the ``rdcc_nbytes``,
+  ``rdcc_w0``, and ``rdcc_nslots`` arguments is allowed. The file defaults apply
+  to those omitted.
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
As explained in #2126, this PR allows chunk cache configuration for each dataset. This is achieved via `Group.create_dataset()` for new datasets or `Group.require_dataset()` for already existing datasets. The relevant documentation was updated and there is a new test for both of these cases.

Working on the documentation, I noticed that currently the chunk cache explanation is in the [File section](https://docs.h5py.org/en/stable/high/file.html#chunk-cache). I think a more obvious place should be in the Dataset section.