### PR TITLE
Test default fill values for some common types

### DIFF
--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -547,6 +547,14 @@ cdef class PropDCID(PropOCID):
         if string_info is not None and string_info.length is None:
             tid = py_create(value.dtype, logical=1)
             ret = H5Pget_fill_value(self.id, tid.id, &c_ptr)
+            if c_ptr == NULL:
+                # If the pointer is NULL (either the value did not get changed,
+                # or maybe the 0 length string, it's unclear currently), if
+                # PyBytes_FromString is called on the pointer, we get a
+                # segfault. If we set the value to empty bytes, then we
+                # shouldn't segfault.
+                value[0] = b""
+                return
             fill_value = c_ptr
             value[0] = fill_value
             return

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -485,9 +485,9 @@ class TestCreateFillvalue(BaseDataset):
     (np.float64, 0.0),
     (h5py.string_dtype(encoding='utf-8', length=5), b''),
     (h5py.string_dtype(encoding='ascii', length=5), b''),
-    (h5py.string_dtype(encoding='utf-8'), ''),
-    (h5py.string_dtype(encoding='ascii'), ''),
-    (h5py.string_dtype(), ''),
+    (h5py.string_dtype(encoding='utf-8'), b''),
+    (h5py.string_dtype(encoding='ascii'), b''),
+    (h5py.string_dtype(), b''),
 
 ])
 def test_get_unset_fill_value(dt, expected, writable_file):

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -476,6 +476,25 @@ class TestCreateFillvalue(BaseDataset):
                     dtype=[('a', 'i'), ('b', 'f')], fillvalue=42)
 
 
+@pytest.mark.parametrize('dt,expected', [
+    (int, 0),
+    (np.int32, 0),
+    (np.int64, 0),
+    (float, 0.0),
+    (np.float32, 0.0),
+    (np.float64, 0.0),
+    (h5py.string_dtype(encoding='utf-8', length=5), b''),
+    (h5py.string_dtype(encoding='ascii', length=5), b''),
+    (h5py.string_dtype(encoding='utf-8'), ''),
+    (h5py.string_dtype(encoding='ascii'), ''),
+    (h5py.string_dtype(), ''),
+
+])
+def test_get_unset_fill_value(dt, expected, writable_file):
+    dset = writable_file.create_dataset('foo', (10,), dtype=dt)
+    assert dset.fillvalue == expected
+
+
 class TestCreateNamedType(BaseDataset):
 
     """


### PR DESCRIPTION
This continues on from #2111, and the first commit actually segfaults like I expect it to.

Adding my string pointer check fixes the segfault (the tests are currently failing as I'm returning bytes from the function, but expecting strings—we need to decide which is the correct default and either change the test or the code to match). The changes in #2111 should also be included, but those tests didn't segfault, hence why I've opened this as a new PR (so its easy to confirm that both the fillvalues segfault, and the additional null pointer check fixes it).