### PR TITLE
Fix issues with vlen fields and compound types

### DIFF
--- a/h5py/_conv.pyx
+++ b/h5py/_conv.pyx
@@ -718,9 +718,12 @@ cdef int conv_vlen2ndarray(void* ipt,
         data = realloc(data, itemsize * size)
 
     if needs_bkg_buffer(intype.id, outtype.id):
-        back_buf = malloc(H5Tget_size(outtype.id)*size)
+        back_buf = emalloc(H5Tget_size(outtype.id)*size)
 
-    H5Tconvert(intype.id, outtype.id, size, data, back_buf, H5P_DEFAULT)
+    try:
+        H5Tconvert(intype.id, outtype.id, size, data, back_buf, H5P_DEFAULT)
+    finally:
+        free(back_buf)
 
     # We need to use different approaches to creating the ndarray with the converted
     # data depending on the destination dtype.
@@ -861,7 +864,7 @@ cdef int conv_ndarray2vlen(void* ipt,
         PyBuffer_Release(&view)
 
         if needs_bkg_buffer(intype.id, outtype.id):
-            back_buf = malloc(H5Tget_size(outtype.id)*len)
+            back_buf = emalloc(H5Tget_size(outtype.id)*len)
 
         H5Tconvert(intype.id, outtype.id, len, data, back_buf, H5P_DEFAULT)
 

--- a/h5py/_conv.pyx
+++ b/h5py/_conv.pyx
@@ -22,11 +22,12 @@ from .h5t cimport H5PY_OBJ, typewrap, py_create, TypeID, H5PY_PYTHON_OPAQUE_TAG
 from libc.stdlib cimport realloc
 from libc.string cimport strcmp
 from .utils cimport emalloc, efree
+from ._proxy cimport needs_bkg_buffer
 cfg = get_config()
 
 # Initialization of numpy
 cimport numpy as cnp
-from numpy cimport npy_intp, NPY_WRITEABLE, NPY_C_CONTIGUOUS, NPY_OWNDATA
+from numpy cimport npy_intp, NPY_WRITEABLE, NPY_C_CONTIGUOUS, NPY_OWNDATA, PyArray_DATA
 cnp._import_array()
 import numpy as np
 
@@ -700,6 +701,7 @@ cdef int conv_vlen2ndarray(void* ipt,
         int flags = NPY_WRITEABLE | NPY_C_CONTIGUOUS | NPY_OWNDATA
         npy_intp dims[1]
         void* data
+        void* back_buf = NULL
         cdef char[:] buf
         cnp.ndarray ndarray
         PyObject* ndarray_obj
@@ -714,17 +716,30 @@ cdef int conv_vlen2ndarray(void* ipt,
     itemsize = H5Tget_size(outtype.id)
     if itemsize > H5Tget_size(intype.id):
         data = realloc(data, itemsize * size)
-    H5Tconvert(intype.id, outtype.id, size, data, NULL, H5P_DEFAULT)
+
+    if needs_bkg_buffer(intype.id, outtype.id):
+        back_buf = malloc(H5Tget_size(outtype.id)*size)
+
+    H5Tconvert(intype.id, outtype.id, size, data, back_buf, H5P_DEFAULT)
+
+    # We need to use different approaches to creating the ndarray with the converted
+    # data depending on the destination dtype.
+    # For simple dtypes, we can use SimpleNewFromData, but types like
+    # string & void need a size specified, so this function can't be used.
+    # Additionally, Cython doesn't expose NumPy C-API functions like NewFromDescr,
+    # so we fall back on the Python frombuffer() function. Finally, that function does
+    # not support object arrays, so in that case we copy directly to the underlying buffer
+    # of a new ndarray.
 
     if elem_dtype.kind in b"biufcmMO":
         # type_num is enough to create an array for these dtypes
         ndarray = cnp.PyArray_SimpleNewFromData(1, dims, elem_dtype.type_num, data)
-    else:
-        # dtypes like string & void need a size specified, so can't be used with
-        # SimpleNewFromData. Cython doesn't expose NumPy C-API functions
-        # like NewFromDescr, so we'll construct this with a Python function.
+    elif elem_dtype.kind != b'V':
         buf = <char[:itemsize * size]> data
         ndarray = np.frombuffer(buf, dtype=elem_dtype)
+    else:
+        ndarray = np.empty(size, dtype=elem_dtype)
+        memcpy(PyArray_DATA(ndarray), data, itemsize * size)
 
     PyArray_ENABLEFLAGS(ndarray, flags)
     ndarray_obj = <PyObject*>ndarray
@@ -827,22 +842,29 @@ cdef int conv_ndarray2vlen(void* ipt,
         size_t len, nbytes
         PyObject* buf_obj0
         Py_buffer view
+        void* back_buf = NULL
+    try:
+        buf_obj0 = buf_obj[0]
+        ndarray = <cnp.ndarray> buf_obj0
+        len = ndarray.shape[0]
+        nbytes = len * max(H5Tget_size(outtype.id), H5Tget_size(intype.id))
 
-    buf_obj0 = buf_obj[0]
-    ndarray = <cnp.ndarray> buf_obj0
-    len = ndarray.shape[0]
-    nbytes = len * max(H5Tget_size(outtype.id), H5Tget_size(intype.id))
+        data = emalloc(nbytes)
 
-    data = emalloc(nbytes)
+        PyObject_GetBuffer(ndarray, &view, PyBUF_INDIRECT)
+        PyBuffer_ToContiguous(data, &view, view.len, b'C')
+        PyBuffer_Release(&view)
 
-    PyObject_GetBuffer(ndarray, &view, PyBUF_INDIRECT)
-    PyBuffer_ToContiguous(data, &view, view.len, b'C')
-    PyBuffer_Release(&view)
+        if needs_bkg_buffer(intype.id, outtype.id):
+            back_buf = malloc(H5Tget_size(outtype.id)*len)
 
-    H5Tconvert(intype.id, outtype.id, len, data, NULL, H5P_DEFAULT)
+        H5Tconvert(intype.id, outtype.id, len, data, back_buf, H5P_DEFAULT)
 
-    in_vlen[0].len = len
-    in_vlen[0].ptr = data
+        in_vlen[0].len = len
+        in_vlen[0].ptr = data
+
+    finally:
+        free(back_buf)
 
     return 0
 

--- a/h5py/_conv.pyx
+++ b/h5py/_conv.pyx
@@ -748,7 +748,7 @@ cdef int conv_vlen2ndarray(void* ipt,
         # so we'll fall back to allocating a new array and copying the data in.
         ndarray = np.empty(size, dtype=elem_dtype)
         memcpy(PyArray_DATA(ndarray), data, itemsize * size)
-        
+
         # In this code path, `data`, allocated by hdf5 to hold the v-len data,
         # will no longer be used since have copied its contents to the ndarray.
         efree(data)

--- a/h5py/_conv.pyx
+++ b/h5py/_conv.pyx
@@ -748,6 +748,10 @@ cdef int conv_vlen2ndarray(void* ipt,
         # so we'll fall back to allocating a new array and copying the data in.
         ndarray = np.empty(size, dtype=elem_dtype)
         memcpy(PyArray_DATA(ndarray), data, itemsize * size)
+        
+        # In this code path, `data`, allocated by hdf5 to hold the v-len data,
+        # will no longer be used since have copied its contents to the ndarray.
+        efree(data)
 
     PyArray_ENABLEFLAGS(ndarray, flags)
     ndarray_obj = <PyObject*>ndarray

--- a/h5py/_proxy.pxd
+++ b/h5py/_proxy.pxd
@@ -14,3 +14,5 @@ cdef herr_t attr_rw(hid_t attr, hid_t mtype, void *progbuf, int read) except -1
 
 cdef herr_t dset_rw(hid_t dset, hid_t mtype, hid_t mspace, hid_t fspace,
                     hid_t dxpl, void* progbuf, int read) except -1
+
+cdef htri_t needs_bkg_buffer(hid_t src, hid_t dst) except -1

--- a/h5py/_proxy.pyx
+++ b/h5py/_proxy.pyx
@@ -53,8 +53,9 @@ cdef herr_t attr_rw(hid_t attr, hid_t mtype, void *progbuf, int read) except -1:
             else:
                 need_bkg = needs_bkg_buffer(mtype, atype)
             if need_bkg:
-                back_buf = malloc(msize*npoints)
-                memcpy(back_buf, progbuf, msize*npoints)
+                back_buf = create_buffer(msize, asize, npoints)
+                if read:
+                    memcpy(back_buf, progbuf, msize*npoints)
 
             if read:
                 H5Aread(attr, atype, conv_buf)
@@ -134,7 +135,8 @@ cdef herr_t dset_rw(hid_t dset, hid_t mtype, hid_t mspace, hid_t fspace,
                 need_bkg = needs_bkg_buffer(mtype, dstype)
             if need_bkg:
                 back_buf = create_buffer(H5Tget_size(dstype), H5Tget_size(mtype), npoints)
-                h5py_copy(mtype, mspace, back_buf, progbuf, H5PY_GATHER)
+                if read:
+                    h5py_copy(mtype, mspace, back_buf, progbuf, H5PY_GATHER)
 
             if read:
                 H5Dread(dset, dstype, cspace, fspace, dxpl, conv_buf)

--- a/h5py/tests/common.py
+++ b/h5py/tests/common.py
@@ -17,6 +17,7 @@ from contextlib import contextmanager
 from functools import wraps
 
 import numpy as np
+from numpy.lib.recfunctions import repack_fields
 import h5py
 
 import unittest as ut
@@ -94,9 +95,9 @@ class TestCase(ut.TestCase):
             if not match:
                 raise AssertionError("Item '%s' appears in b but not a" % x)
 
-    def assertArrayEqual(self, dset, arr, message=None, precision=None):
+    def assertArrayEqual(self, dset, arr, message=None, precision=None, ignore_alignment=False):
         """ Make sure dset and arr have the same shape, dtype and contents, to
-            within the given precision.
+            within the given precision, optionally ignoring differences in dtype alignment.
 
             Note that dset may be a NumPy array or an HDF5 dataset.
         """
@@ -110,22 +111,38 @@ class TestCase(ut.TestCase):
         if np.isscalar(dset) or np.isscalar(arr):
             assert np.isscalar(dset) and np.isscalar(arr), \
                 'Scalar/array mismatch ("%r" vs "%r")%s' % (dset, arr, message)
-            assert dset - arr < precision, \
-                "Scalars differ by more than %.3f%s" % (precision, message)
-            return
+            dset = np.asarray(dset)
+            arr = np.asarray(arr)
 
         assert dset.shape == arr.shape, \
             "Shape mismatch (%s vs %s)%s" % (dset.shape, arr.shape, message)
-        assert dset.dtype == arr.dtype, \
-            "Dtype mismatch (%s vs %s)%s" % (dset.dtype, arr.dtype, message)
+        if dset.dtype != arr.dtype:
+            if ignore_alignment:
+                normalized_dset_dtype = repack_fields(dset.dtype)
+                normalized_arr_dtype = repack_fields(arr.dtype)
+            else:
+                normalized_dset_dtype = dset.dtype
+                normalized_arr_dtype = arr.dtype
+
+            assert normalized_dset_dtype == normalized_arr_dtype, \
+                "Dtype mismatch (%s vs %s)%s" % (normalized_dset_dtype, normalized_dset_dtype, message)
+
+            if ignore_alignment:
+                if normalized_dset_dtype != dset.dtype:
+                    dset = repack_fields(np.asarray(dset))
+                if normalized_arr_dtype != arr.dtype:
+                    arr = repack_fields(np.asarray(arr))
 
         if arr.dtype.names is not None:
             for n in arr.dtype.names:
                 message = '[FIELD %s] %s' % (n, message)
-                self.assertArrayEqual(dset[n], arr[n], message=message, precision=precision)
+                self.assertArrayEqual(dset[n], arr[n], message=message, precision=precision, ignore_alignment=ignore_alignment)
         elif arr.dtype.kind in ('i', 'f'):
             assert np.all(np.abs(dset[...] - arr[...]) < precision), \
                 "Arrays differ by more than %.3f%s" % (precision, message)
+        elif arr.dtype.kind == 'O':
+            for v1, v2 in zip(dset.flat, arr.flat):
+                self.assertArrayEqual(v1, v2, message=message, precision=precision, ignore_alignment=ignore_alignment)
         else:
             assert np.all(dset[...] == arr[...]), \
                 "Arrays are not equal (dtype %s) %s" % (arr.dtype.str, message)

--- a/h5py/tests/test_attrs_data.py
+++ b/h5py/tests/test_attrs_data.py
@@ -66,9 +66,9 @@ class TestScalar(BaseAttrs):
         self.f.attrs['x'] = data
         out = self.f.attrs['x']
 
-        # Specifying ignore_alignment=True because vlen fields have 8 bytes of padding
+        # Specifying check_alignment=False because vlen fields have 8 bytes of padding
         # because the vlen datatype in hdf5 occupies 16 bytes
-        self.assertArrayEqual(out, data, ignore_alignment=True)
+        self.assertArrayEqual(out, data, check_alignment=False)
 
     def test_nesting_compound_with_vlen_fields(self):
         """ Compound scalars with nested compound vlen fields can be written and read """
@@ -90,7 +90,7 @@ class TestScalar(BaseAttrs):
 
         self.f.attrs['x'] = data
         out = self.f.attrs['x']
-        self.assertArrayEqual(out, data, ignore_alignment=True)
+        self.assertArrayEqual(out, data, check_alignment=False)
 
     def test_vlen_compound_with_vlen_string(self):
         """ Compound scalars with vlen compounds containing vlen strings can be written and read """
@@ -102,7 +102,7 @@ class TestScalar(BaseAttrs):
         data = np.array((np.array([(b"apples", b"bananas"), (b"peaches", b"oranges")], dtype=dt_inner),),dtype=dt)[()]
         self.f.attrs['x'] = data
         out = self.f.attrs['x']
-        self.assertArrayEqual(out, data, ignore_alignment=True)
+        self.assertArrayEqual(out, data, check_alignment=False)
 
 
 class TestArray(BaseAttrs):

--- a/h5py/tests/test_attrs_data.py
+++ b/h5py/tests/test_attrs_data.py
@@ -55,6 +55,55 @@ class TestScalar(BaseAttrs):
         self.assertEqual(out, data)
         self.assertEqual(out['b'], data['b'])
 
+    def test_compound_with_vlen_fields(self):
+        """ Compound scalars with vlen fields can be written and read """
+        dt = np.dtype([('a', h5py.vlen_dtype(np.int32)),
+                       ('b', h5py.vlen_dtype(np.int32))])
+
+        data = np.array((np.array(list(range(1, 5)), dtype=np.int32),
+                        np.array(list(range(8, 10)), dtype=np.int32)), dtype=dt)[()]
+
+        self.f.attrs['x'] = data
+        out = self.f.attrs['x']
+
+        # Specifying ignore_alignment=True because vlen fields have 8 bytes of padding
+        # because the vlen datatype in hdf5 occupies 16 bytes
+        self.assertArrayEqual(out, data, ignore_alignment=True)
+
+    def test_nesting_compound_with_vlen_fields(self):
+        """ Compound scalars with nested compound vlen fields can be written and read """
+        dt_inner = np.dtype([('a', h5py.vlen_dtype(np.int32)),
+                             ('b', h5py.vlen_dtype(np.int32))])
+
+        dt = np.dtype([('f1', h5py.vlen_dtype(dt_inner)),
+                       ('f2', np.int64)])
+
+        inner1 = (np.array(range(1, 3), dtype=np.int32),
+                  np.array(range(6, 9), dtype=np.int32))
+
+        inner2 = (np.array(range(10, 14), dtype=np.int32),
+                  np.array(range(16, 20), dtype=np.int32))
+
+        data = np.array((np.array([inner1, inner2], dtype=dt_inner),
+                         2),
+                        dtype=dt)[()]
+
+        self.f.attrs['x'] = data
+        out = self.f.attrs['x']
+        self.assertArrayEqual(out, data, ignore_alignment=True)
+
+    def test_vlen_compound_with_vlen_string(self):
+        """ Compound scalars with vlen compounds containing vlen strings can be written and read """
+        dt_inner = np.dtype([('a', h5py.string_dtype()),
+                             ('b', h5py.string_dtype())])
+
+        dt = np.dtype([('f', h5py.vlen_dtype(dt_inner))])
+
+        data = np.array((np.array([(b"apples", b"bananas"), (b"peaches", b"oranges")], dtype=dt_inner),),dtype=dt)[()]
+        self.f.attrs['x'] = data
+        out = self.f.attrs['x']
+        self.assertArrayEqual(out, data, ignore_alignment=True)
+
 
 class TestArray(BaseAttrs):
 

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1360,9 +1360,9 @@ class TestCompound(BaseDataset):
         self.f["ds"] = data
         out = self.f["ds"]
 
-        # Specifying ignore_alignment=True because vlen fields have 8 bytes of padding
+        # Specifying check_alignment=False because vlen fields have 8 bytes of padding
         # because the vlen datatype in hdf5 occupies 16 bytes
-        self.assertArrayEqual(out, data, ignore_alignment=True)
+        self.assertArrayEqual(out, data, check_alignment=False)
 
 
 class TestSubarray(BaseDataset):

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1340,6 +1340,30 @@ class TestCompound(BaseDataset):
         # Check len() on fields wrapper
         assert len(self.f['test'].fields('x')) == 16
 
+    def test_nested_compound_vlen(self):
+        dt_inner = np.dtype([('a', h5py.vlen_dtype(np.int32)),
+                            ('b', h5py.vlen_dtype(np.int32))])
+
+        dt = np.dtype([('f1', h5py.vlen_dtype(dt_inner)),
+                       ('f2', np.int64)])
+
+        inner1 = (np.array(range(1, 3), dtype=np.int32),
+                  np.array(range(6, 9), dtype=np.int32))
+
+        inner2 = (np.array(range(10, 14), dtype=np.int32),
+                  np.array(range(16, 21), dtype=np.int32))
+
+        data = np.array([(np.array([inner1, inner2], dtype=dt_inner), 2),
+                        (np.array([inner1], dtype=dt_inner), 3)],
+                        dtype=dt)
+
+        self.f["ds"] = data
+        out = self.f["ds"]
+
+        # Specifying ignore_alignment=True because vlen fields have 8 bytes of padding
+        # because the vlen datatype in hdf5 occupies 16 bytes
+        self.assertArrayEqual(out, data, ignore_alignment=True)
+
 
 class TestSubarray(BaseDataset):
     def test_write_list(self):

--- a/h5py/tests/test_dataset_getitem.py
+++ b/h5py/tests/test_dataset_getitem.py
@@ -118,7 +118,7 @@ class TestScalarFloat(TestCase):
 
     def setUp(self):
         TestCase.setUp(self)
-        self.data = np.array(42.5, dtype='f')
+        self.data = np.array(42.5, dtype=np.double)
         self.dset = self.f.create_dataset('x', data=self.data)
 
     def test_ndim(self):


### PR DESCRIPTION
Fixing some issues (#596, #623, #2083, #2085), all related to segmentation faults or buffer overruns when reading and writing compound types with vlen fields of compound types.

They all boil down to two specific problems:
1. The background buffer passed to `H5Tconvert` when writing attributes was of the wrong size. It needs to be the size of the destination data.
2. When converting a vlen to ndarray, when the inner data is compound, we need to provide a background buffer to the conversion function. This means that we can now support vlens of compounds that in turn contain vlens of compounds.

Also updated the `TestCase.assertArrayEqual` method to handle comparisons across "object" types (where memberwise `==` is not supported).

One (perhaps minor) unexpected behavior that remains is extra padding around ndarray fields that are read from an HDF5 file. 
``` python
with h5py.File("x.h5", mode="w") as f:
    dt = np.dtype([('a', h5py.vlen_dtype(np.int32)),
                    ('b', h5py.vlen_dtype(np.int32))])

    data = np.array((np.array(list(range(1, 5)), dtype=np.int32),
                    np.array(list(range(8, 10)), dtype=np.int32)), dtype=dt)

    f.attrs['x'] = data
    out = f.attrs['x']
    print(data.dtype)
    print(out.dtype)
```
```
[('a', 'O'), ('b', 'O')]
{'names': ['a', 'b'], 'formats': ['O', 'O'], 'offsets': [0, 16], 'itemsize': 32}
```
In this example, there is 8 bytes of padding after both `a` and `b` fields when reading the attribute. This is because of the vlen datatype requires 16 bytes in HDF5, and it looks like we use the same offsets for the in-memory data as the persisted types. We can automatically remove this padding (when reading attributes and datasets), but this broke a number of unit tests where we verify that the alignment is round-tripped, so I left the behavior as-is.

-----

Closes #596
Closes #623
Closes #2083
Closes #2085