### PR TITLE
See if bumping travis python versions fixes travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-dist: xenial
+dist: jammy
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ matrix:
     # needed to work around https://github.com/travis-ci/travis-ci/issues/4794
     # TODO: We should see if we can replace this with installing python via pyenv # based on toxenv
     # Test on ppc64le
-    - python: 3.7
+    - python: 3.10
       env:
-      - TOXENV=py37-test-deps
+      - TOXENV=py310-test-deps
       # NumPy 1.21.5 fails to compile: https://github.com/numpy/numpy/issues/20761
       - TOX_OPTS="--force-dep numpy!=1.21.5"
       - HDF5_VERSION=1.10.5
@@ -35,12 +35,12 @@ matrix:
       os: linux-ppc64le
     - os: linux
       services: docker
-      python: 3.7
+      python: 3.10
       virt: vm
       group: edge
       arch: arm64
       env:
-        - TOXENV=py37-test-deps
+        - TOXENV=py310-test-deps
         - TOX_OPTS=""
         - HDF5_VERSION=1.10.5
         - HDF5_DIR=$HDF5_CACHE_DIR/$HDF5_VERSION


### PR DESCRIPTION
Both travis builds seem to be failing with errors that look like they could be caused by running on an old python version. Let's see if bumping to 3.10 fixes that.