### PR TITLE
Fix when to activate authentication for ros3 driver

### DIFF
--- a/docs/high/file.rst
+++ b/docs/high/file.rst
@@ -96,18 +96,20 @@ of supported drivers and their options:
           Raw data filename extension. Default is '-r.h5'.
 
     'ros3'
-        Allows read only access to HDF5 files on S3. Keywords:
+        Allows read only access to HDF5 files in AWS S3. Keywords:
 
         aws_region:
-          Name of the AWS "region" where the S3 bucket with the file is, e.g. ``b"us-east-1"``. Default is ``b''``.
+          AWS region of the S3 bucket with the file, e.g. ``b"us-east-1"``.
+          Default is ``b''``.
 
         secret_id:
-          "Access ID" for the resource. Default is ``b''``.
+          AWS access key ID. Default is ``b''``.
 
         secret_key:
-          "Secret Access Key" associated with the ID and resource. Default is ``b''``.
+          AWS secret access key. Default is ``b''``.
 
-        The argument values must be ``bytes`` objects.
+        The argument values must be ``bytes`` objects. All three arguments are
+        required to activate AWS authentication.
 
 
 .. _file_fileobj:

--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -1090,7 +1090,7 @@ cdef class PropFAID(PropInstanceID):
             """
             cdef H5FD_ros3_fapl_t config
             config.version = H5FD_CURR_ROS3_FAPL_T_VERSION
-            if len(aws_region) or len(secret_id) or len(secret_key):
+            if len(aws_region) and len(secret_id) and len(secret_key):
                 config.authenticate = <hbool_t>1
             else:
                 config.authenticate = <hbool_t>0


### PR DESCRIPTION
AWS authentication will be used only when AWS S3 bucket's region and both AWS access keys are specified. See: #2133.