### PR TITLE
Re-enable all output formats for documentation on Read the Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,3 +11,5 @@ sphinx:
 python:
    install:
    - requirements: docs/requirements-rtd.txt
+
+formats: all


### PR DESCRIPTION
Commit e2d161a (Explicit configuration for Readthedocs, 2021-11-16)
introduced a regression that disabled the creation of downloadable Epub,
PDF, and HTMLZip documentation on Read the Docs. This commit configures
Read the Docs to resume its old behaviour and fully fixes issue #2122.

Tested on Read the Docs:
 - http://aaed8324-a4cc-4e99-a119-1e351760bea4.readthedocs.io/
 - https://readthedocs.org/projects/aaed8324-a4cc-4e99-a119-1e351760bea4/downloads/