### PR TITLE
Support HDF5 file s3:// locations for ros3 driver

### DIFF
--- a/docs/high/file.rst
+++ b/docs/high/file.rst
@@ -96,11 +96,15 @@ of supported drivers and their options:
           Raw data filename extension. Default is '-r.h5'.
 
     'ros3'
-        Allows read only access to HDF5 files in AWS S3. Keywords:
+        Allows read-only access to HDF5 files in AWS S3 or S3 compatible object
+        stores. HDF5 file name must be one of http://, https://, or s3://
+        resource location. An s3:// location will be translated into an AWS
+        <path-style https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#path-style-access>_
+        location. Keywords:
 
         aws_region:
           AWS region of the S3 bucket with the file, e.g. ``b"us-east-1"``.
-          Default is ``b''``.
+          Default is ``b''``. Required for s3:// locations.
 
         secret_id:
           AWS access key ID. Default is ``b''``.

--- a/h5py/tests/conftest.py
+++ b/h5py/tests/conftest.py
@@ -6,3 +6,17 @@ import pytest
 def writable_file(tmp_path):
     with h5py.File(tmp_path / 'test.h5', 'w') as f:
         yield f
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        '--no-network', action='store_true', default=False, help='No network access'
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption('--no-network'):
+        nonet = pytest.mark.skip(reason='No Internet')
+        for item in items:
+            if 'nonetwork' in item.keywords:
+                item.add_marker(nonet)

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -1009,40 +1009,6 @@ f = h5py.File({str(filename)!r}, mode={mode!r}, locking={locking})
             assert open_in_subprocess(fname, mode="w", locking=True)
 
 
-# unittest doesn't work with pytest fixtures (and possibly other features),
-# hence no subclassing TestCase
-@pytest.mark.skipif(h5py.version.hdf5_version_tuple < (1, 10, 6)
-                    or not h5.get_config().ros3,
-                    reason="ros3 driver not available")
-class TestROS3:
-    def test_ros3(self):
-        """ ROS3 driver and options """
-
-        with File("https://dandiarchive.s3.amazonaws.com/ros3test.hdf5", 'r',
-                  driver='ros3') as f:
-            assert f
-            assert 'mydataset' in f.keys()
-            assert f["mydataset"].shape == (100,)
-
-    def test_ros3_s3_fails(self):
-        """ROS3 exceptions for s3:// location"""
-        with pytest.raises(ValueError,
-                           match='AWS region required for s3:// location'):
-            File('s3://fakebucket/fakekey', 'r', driver='ros3')
-
-        with pytest.raises(ValueError,
-                           match=r'^foo://wrong/scheme: S3 location must begin with'):
-            File('foo://wrong/scheme', 'r', driver='ros3')
-
-    def test_ros3_s3uri(self):
-        """Use S3 URI with ROS3 driver"""
-        with File('s3://dandiarchive/ros3test.hdf5', 'r', driver='ros3',
-                  aws_region=b'us-east-2') as f:
-            assert f
-            assert 'mydataset' in f.keys()
-            assert f["mydataset"].shape == (100,)
-
-
 def test_close_gc(writable_file):
     # https://github.com/h5py/h5py/issues/1852
     for i in range(100):

--- a/h5py/tests/test_ros3.py
+++ b/h5py/tests/test_ros3.py
@@ -14,9 +14,12 @@
 import h5py
 import pytest
 
-pytestmark = pytest.mark.skipif(
-    h5py.version.hdf5_version_tuple < (1, 10, 6) or not h5py.h5.get_config().ros3,
-    reason="ros3 driver not available")
+pytestmark = [
+    pytest.mark.skipif(
+        h5py.version.hdf5_version_tuple < (1, 10, 6) or not h5py.h5.get_config().ros3,
+        reason="ros3 driver not available"),
+    pytest.mark.nonetwork
+]
 
 
 def test_ros3():

--- a/h5py/tests/test_ros3.py
+++ b/h5py/tests/test_ros3.py
@@ -1,0 +1,47 @@
+# This file is part of h5py, a Python interface to the HDF5 library.
+#
+# http://www.h5py.org
+#
+# Copyright 2008-2013 Andrew Collette and contributors
+#
+# License:  Standard 3-clause BSD; see "license.txt" for full license terms
+#           and contributor agreement.
+
+"""
+    Read-only S3 virtual file driver (VFD) test module.
+"""
+
+import h5py
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    h5py.version.hdf5_version_tuple < (1, 10, 6) or not h5py.h5.get_config().ros3,
+    reason="ros3 driver not available")
+
+
+def test_ros3():
+    """ ROS3 driver and options """
+
+    with h5py.File("https://dandiarchive.s3.amazonaws.com/ros3test.hdf5", 'r',
+                   driver='ros3') as f:
+        assert f
+        assert 'mydataset' in f.keys()
+        assert f["mydataset"].shape == (100,)
+
+
+def test_ros3_s3_fails():
+    """ROS3 exceptions for s3:// location"""
+    with pytest.raises(ValueError, match='AWS region required for s3:// location'):
+        h5py.File('s3://fakebucket/fakekey', 'r', driver='ros3')
+
+    with pytest.raises(ValueError, match=r'^foo://wrong/scheme: S3 location must begin with'):
+        h5py.File('foo://wrong/scheme', 'r', driver='ros3')
+
+
+def test_ros3_s3uri():
+    """Use S3 URI with ROS3 driver"""
+    with h5py.File('s3://dandiarchive/ros3test.hdf5', 'r', driver='ros3',
+                   aws_region=b'us-east-2') as f:
+        assert f
+        assert 'mydataset' in f.keys()
+        assert f["mydataset"].shape == (100,)

--- a/news/ros3.rst
+++ b/news/ros3.rst
@@ -1,0 +1,33 @@
+New features
+------------
+
+* When using the ros3 driver, AWS authentication will be activated only if all
+  three driver arguments are provided. Previously AWS authentication was active
+  if any one of the arguments was set causing an error from the HDF5 library.
+* HDF5 file names for ros3 driver can now also be s3:// resource locations. H5py
+  will translate them into AWS path-style URLs for use by the driver.
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
+markers =
+    nonetwork: Tests to skip when no network access
 filterwarnings =
     error::h5py.h5py_warnings.H5pyDeprecationWarning
 required_plugins = pytest-mpi


### PR DESCRIPTION
This PR is adding support for s3:// file locations when using the ros3 driver. This is done in the h5py code since the HDF5 library's ROS3 VFD currently does not support this. s3:// style is much more common. This functionality was also mentioned in #2133.