### PR TITLE
Fix incompatible function pointer types

### DIFF
--- a/h5py/_errors.pxd
+++ b/h5py/_errors.pxd
@@ -412,7 +412,7 @@ cdef extern from "hdf5.h":
 
     herr_t    H5Eprint(hid_t estack_id, void *stream)
 
-    ctypedef herr_t (*H5E_walk_t)(int n, H5E_error_t *err_desc, void* client_data)
+    ctypedef herr_t (*H5E_walk_t)(unsigned int n, const H5E_error_t *err_desc, void* client_data)
     herr_t    H5Ewalk(hid_t estack_id, H5E_direction_t direction, H5E_walk_t func, void* client_data)
 
 # --- Functions for managing the HDF5 error callback mechanism ---

--- a/h5py/_errors.pyx
+++ b/h5py/_errors.pyx
@@ -94,7 +94,7 @@ cdef struct err_data_t:
     H5E_error_t err
     int n
 
-cdef herr_t walk_cb(int n, H5E_error_t *desc, void *e) nogil:
+cdef herr_t walk_cb(unsigned int n, const H5E_error_t *desc, void *e) nogil:
 
     cdef err_data_t *ee = <err_data_t*>e
 


### PR DESCRIPTION
This PR fixs some imcompatible function pointer types. Compiling h5py with recent version of LLVM with `-Wincompatible-function-pointer-types` compile option is not happy about this.

`H5E_walk_t` [in HDF5 is defined as](https://github.com/HDFGroup/hdf5/blob/ae414872f50187e64cbd6cc8f076c22cf5df2d53/src/H5Epublic.h#L175):

```c
typedef herr_t (*H5E_walk2_t)(unsigned n, const H5E_error2_t *err_desc, void *client_data);
```