### PR TITLE
Clarify which versions of HDF5 are supported

### DIFF
--- a/docs/build.rst
+++ b/docs/build.rst
@@ -79,6 +79,11 @@ To install h5py from source, you need:
 
 * A supported Python version with development headers
 * HDF5 1.8.4 or newer with development headers
+
+  * HDF5 versions newer than the h5py version you're using might not work.
+  * Odd minor versions of HDF5 (e.g. 1.13) are experimental, and might not work.
+    Use a 'maintenance' version like 1.12.x if possible.
+
 * A C compiler
 
 On Unix platforms, you also need ``pkg-config`` unless you explicitly specify

--- a/setup.py
+++ b/setup.py
@@ -93,8 +93,15 @@ A strong emphasis on automatic conversion between Python (Numpy) datatypes and
 data structures and their HDF5 equivalents vastly simplifies the process of
 reading and writing data from Python.
 
-Supports HDF5 versions 1.8.4 and higher.  On Windows, HDF5 is included with
-the installer.
+Wheels are provided for several popular platforms, with an included copy of
+the HDF5 library (usually the latest version when h5py is released).
+
+You can also `build h5py from source
+<https://docs.h5py.org/en/stable/build.html#source-installation>`_
+with any HDF5 stable release from version 1.8.4 onwards, although naturally new
+HDF5 versions released after this version of h5py may not work.
+Odd-numbered minor versions of HDF5 (e.g. 1.13) are experimental, and may not
+be supported.
 """
 
 package_data = {'h5py': [], "h5py.tests.data_files": ["*.h5"]}

--- a/setup.py
+++ b/setup.py
@@ -119,11 +119,12 @@ setup(
   maintainer = 'Andrew Collette',
   maintainer_email = 'andrew.collette@gmail.com',
   license = 'BSD',
-  url = 'http://www.h5py.org',
+  url = 'https://www.h5py.org',
   project_urls = {
       'Source': 'https://github.com/h5py/h5py',
+      'Documentation': 'https://docs.h5py.org/en/stable/',
+      'Release notes': 'https://docs.h5py.org/en/stable/whatsnew/index.html'
   },
-  download_url = 'https://pypi.python.org/pypi/h5py',
   packages = [
       'h5py',
       'h5py._hl',


### PR DESCRIPTION
Make it clear that future versions of HDF5 (from the point when h5py is released) might not work, and experimental HDF5 releases aren't supported.

I also took the opportunity to clean up one or two other bits of information that are displayed on PyPI.

Closes #2129