### PR TITLE
Add an `__array__()` method to the `FieldsWrapper` class

### DIFF
--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -253,6 +253,12 @@ class FieldsWrapper:
             names = [names]
         self.read_dtype = readtime_dtype(prior_dtype, names)
 
+    def __array__(self, dtype=None):
+        data = self[:]
+        if dtype is not None:
+            data = data.astype(dtype)
+        return data
+
     def __getitem__(self, args):
         data = self._dset.__getitem__(args, new_dtype=self.read_dtype)
         if self.extract_field is not None:

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1336,6 +1336,16 @@ class TestCompound(BaseDataset):
         np.testing.assert_array_equal(
             self.f['test'].fields('x')[:], testdata['x']
         )
+        # Check __array__() method of fields wrapper
+        np.testing.assert_array_equal(
+            np.asarray(self.f['test'].fields(['x', 'y'])), testdata[['x', 'y']]
+        )
+        # Check type conversion of __array__() method
+        dt_int = np.dtype([('x', np.int32)])
+        np.testing.assert_array_equal(
+            np.asarray(self.f['test'].fields(['x']), dtype=dt_int),
+            testdata[['x']].astype(dt_int)
+        )
 
         # Check len() on fields wrapper
         assert len(self.f['test'].fields('x')) == 16

--- a/news/add_fields_array.rst
+++ b/news/add_fields_array.rst
@@ -1,0 +1,29 @@
+New features
+------------
+
+* `FieldsWrapper` now implements the `__array__()` method. This speeds up accessing fields with functions that expect an `__array__()` method, like `np.asarray()`.
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
**Why this PR**
When trying to access fields of compound datasets with numpy functions (like `np.asarray(dset.fields("FieldA"))`), loading might take very long, as the numpy function tries to retrieve the whole array by iterating over every single element via the `__getitem__()` method. To speed up the loading, I added the  `__array__()`[1] method to the `FieldsWrapper` class, which returns the whole array.

This solves issue https://github.com/h5py/h5py/issues/2144

[1] More details about [the `__array__()` method ](https://numpy.org/devdocs/user/basics.interoperability.html#the-array-method) in the numpy docs.