### PR TITLE
fix wrong file driver version

### DIFF
--- a/h5py/api_types_hdf5.pxd
+++ b/h5py/api_types_hdf5.pxd
@@ -237,6 +237,7 @@ cdef extern from "hdf5.h":
 
   # Class information for each file driver
   ctypedef struct H5FD_class_t:
+    unsigned version;
     const char *name
     haddr_t maxaddr
     H5F_close_degree_t fc_degree

--- a/h5py/h5fd.pyx
+++ b/h5py/h5fd.pyx
@@ -191,6 +191,7 @@ cdef herr_t H5FD_fileobj_flush(H5FD_fileobj_t *f, hid_t dxpl, hbool_t closing) e
 cdef H5FD_class_t info
 memset(&info, 0, sizeof(info))
 
+info.version = 0x01
 info.name = 'fileobj'
 info.maxaddr = libc.stdint.SIZE_MAX - 1
 info.fc_degree = H5F_CLOSE_WEAK


### PR DESCRIPTION
Due to commit [1] applied in hdf5 (1.13.2), import hdf5 failed

|>>> import h5py
|Traceback (most recent call last):
|  File "<stdin>", line 1, in <module>
|  File "/usr/lib/python3.10/site-packages/h5py/__init__.py", line 56, in <module>
|    from . import h5a, h5d, h5ds, h5f, h5fd, h5g, h5r, h5s, h5t, h5p, h5z, h5pl
|  File "h5py/h5fd.pyx", line 220, in init h5py.h5fd
|RuntimeError: Wrong file driver version # (wrong file driver version #)

Initial driver version to fix the error

[1] https://github.com/HDFGroup/hdf5/commit/42b767fc67ad1e13735e3cee2077f2e108f9463e

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>

<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->
