### PR TITLE
Fix complex32

### DIFF
--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -1223,7 +1223,8 @@ cdef class TypeCompoundID(TypeCompositeID):
         if len(field_names) == 2                                and \
             tuple(field_names) == (cfg._r_name, cfg._i_name)    and \
             field_types[0] == field_types[1]                    and \
-            field_types[0].kind == 'f':
+            field_types[0].kind == 'f'                          and \
+            field_types[0].itemsize in (4, 8, 16):
 
             bstring = field_types[0].str
             blen = int(bstring[2:])

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1037,6 +1037,13 @@ class TestDtype(BaseDataset):
         dset = self.f.create_dataset('foo', (5,), '|S10')
         self.assertEqual(dset.dtype, np.dtype('|S10'))
 
+    def test_dtype_complex32(self):
+        """ Retrieve dtype from complex float16 dataset (gh-2156) """
+        # No native support in numpy as of v1.23.3, so expect compound type.
+        complex32 = np.dtype([('r', np.float16), ('i', np.float16)])
+        dset = self.f.create_dataset('foo', (5,), complex32)
+        self.assertEqual(dset.dtype, complex32)
+
 
 class TestLen(BaseDataset):
 

--- a/news/complex32.rst
+++ b/news/complex32.rst
@@ -1,0 +1,30 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* Complex float16 data could cause a `TypeError` when trying to coerce to the
+  currently unavailable numpy.dtype('c4').  Now a compound type is used instead.
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
This is my attempt to fix #2156. It's basically a one-line change to restrict complex dtypes to the ones currently supported by numpy (float, double, and long double). Otherwise a compound dtype is returned.