### PR TITLE
Add CI/tox support for Python 3.11

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ jobs:
   pool:
     vmImage: ubuntu-20.04
   variables:
-    CIBW_BUILD: cp3{7,8,9,10}-manylinux_x86_64
+    CIBW_BUILD: cp3{7,8,9,10,11}-manylinux_x86_64
     CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/h5py/manylinux2010_x86_64-hdf5
     # Include less debugging info for smaller wheels (default is -g2)
     CIBW_ENVIRONMENT: "CFLAGS=-g1"
@@ -43,7 +43,7 @@ jobs:
     HDF5_VERSION: 1.12.2
     HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
     HDF5_VSVERSION: "16-64"
-    CIBW_BUILD: cp3{7,8,9,10}-win_amd64
+    CIBW_BUILD: cp3{7,8,9,10,11}-win_amd64
   steps:
     - template: ci/azure-pipelines-wheels.yml
       parameters:
@@ -60,7 +60,7 @@ jobs:
     HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
     CIBW_BUILD_VERBOSITY_MACOS: 3
     CIBW_ARCHS_MACOS: $(arch)
-    CIBW_BUILD: cp3{7,8,9,10}-macosx_*
+    CIBW_BUILD: cp3{7,8,9,10,11}-macosx_*
     CIBW_ENVIRONMENT_MACOS: LD_LIBRARY_PATH="$(HDF5_CACHE_DIR)/$(HDF5_VERSION)/lib:${LD_LIBRARY_PATH}" PKG_CONFIG_PATH="$(HDF5_CACHE_DIR)/$(HDF5_VERSION)/lib/pkgconfig:${PKG_CONFIG_PATH}"
     CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
       DYLD_FALLBACK_LIBRARY_PATH=$(HDF5_CACHE_DIR)/$(HDF5_VERSION)/lib delocate-listdeps {wheel} &&
@@ -171,6 +171,10 @@ jobs:
         python.version: '3.10'
         TOXENV: py310-test-deps,py310-test-mindeps,py310-test-deps-pre
         WHL_FILE: h5py*-cp310-*manylinux2010_x86_64.whl
+      py311:
+        python.version: '3.11'
+        TOXENV: py311-test-deps,py311-test-mindeps,py311-test-deps-pre
+        WHL_FILE: h5py*-cp311-*manylinux2010_x86_64.whl
 
   steps:
     - template: ci/azure-pipelines-test-wheels.yml
@@ -253,6 +257,10 @@ jobs:
         python.version: '3.10'
         TOXENV: py310-test-deps,py310-test-mindeps,py310-test-deps-pre
         WHL_FILE: h5py*-cp310-*.whl
+      py311:
+        python.version: '3.11'
+        TOXENV: py311-test-deps,py311-test-mindeps,py311-test-deps-pre
+        WHL_FILE: h5py*-cp311-*.whl
 
   steps:
     - template: ci/azure-pipelines-test-wheels.yml
@@ -329,6 +337,10 @@ jobs:
         python.version: '3.10'
         TOXENV: py310-test-deps,py310-test-mindeps,py310-test-deps-pre
         WHL_FILE: h5py*-cp310-*.whl
+      py311:
+        python.version: '3.11'
+        TOXENV: py311-test-deps,py311-test-mindeps,py311-test-deps-pre
+        WHL_FILE: h5py*-cp311-*.whl
 
   steps:
     - template: ci/azure-pipelines-test-wheels.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -158,23 +158,23 @@ jobs:
       py37:
         python.version: '3.7'
         TOXENV: py37-test-deps,py37-test-mindeps,py37-test-deps-pre,py37-test-deps-tables
-        WHL_FILE: h5py*-cp37-*manylinux2010_x86_64.whl
+        WHL_FILE: h5py*-cp37-*manylinux2014_x86_64.whl
       py38:
         python.version: '3.8'
         TOXENV: py38-test-deps,py38-test-mindeps,py38-test-deps-pre
-        WHL_FILE: h5py*-cp38-*manylinux2010_x86_64.whl
+        WHL_FILE: h5py*-cp38-*manylinux2014_x86_64.whl
       py39:
         python.version: '3.9'
         TOXENV: py39-test-deps,py39-test-mindeps,py39-test-deps-pre
-        WHL_FILE: h5py*-cp39-*manylinux2010_x86_64.whl
+        WHL_FILE: h5py*-cp39-*manylinux2014_x86_64.whl
       py310:
         python.version: '3.10'
         TOXENV: py310-test-deps,py310-test-mindeps,py310-test-deps-pre
-        WHL_FILE: h5py*-cp310-*manylinux2010_x86_64.whl
+        WHL_FILE: h5py*-cp310-*manylinux2014_x86_64.whl
       py311:
         python.version: '3.11'
         TOXENV: py311-test-deps,py311-test-mindeps,py311-test-deps-pre
-        WHL_FILE: h5py*-cp311-*manylinux2010_x86_64.whl
+        WHL_FILE: h5py*-cp311-*manylinux2014_x86_64.whl
 
   steps:
     - template: ci/azure-pipelines-test-wheels.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
     vmImage: ubuntu-20.04
   variables:
     CIBW_BUILD: cp3{7,8,9,10,11}-manylinux_x86_64
-    CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/h5py/manylinux2010_x86_64-hdf5
+    CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/h5py/manylinux2014_x86_64-hdf5
     # Include less debugging info for smaller wheels (default is -g2)
     CIBW_ENVIRONMENT: "CFLAGS=-g1"
   steps:

--- a/ci/azure-pipelines-wheels.yml
+++ b/ci/azure-pipelines-wheels.yml
@@ -34,7 +34,7 @@ steps:
 - bash: |
     set -o errexit
     python -m pip install --upgrade pip
-    pip install cibuildwheel==2.3.1
+    pip install cibuildwheel==2.11.1
   displayName: 'Install cibuildwheel'
 
 - script: env

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # We want an envlist like
 # envlist = {py36,py37,pypy3}-{test}-{deps,mindeps}-{,mpi4py}-{,pre},nightly,docs,checkreadme,pre-commit
 # but we want to skip mpi and pre by default, so this envlist is below
-envlist = {py37,py38,py39,py310,pypy3}-{test}-{deps,mindeps},nightly,docs,apidocs,checkreadme,pre-commit,rever
+envlist = {py37,py38,py39,py310,py311,pypy3}-{test}-{deps,mindeps},nightly,docs,apidocs,checkreadme,pre-commit,rever
 isolated_build = True
 
 [testenv]
@@ -15,6 +15,7 @@ deps =
     py38-deps: numpy>=1.17.5
     py39-deps: numpy>=1.19.3
     py310-deps: numpy>=1.21.3
+    py311-deps: numpy>=1.23.2
 
     mindeps: oldest-supported-numpy
 


### PR DESCRIPTION
This only does the minimal amount to get wheels running, further cleanup of the CI would be a good idea (e.g. dropping old Python versions, moving static CI tests to newer Python version).
