### PR TITLE
Move static metadata to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,80 @@
 [build-system]
-# Further build requirements - like numpy & cython - come from setup.py via
-# the PEP 517 interface.
 requires = [
-    "setuptools",
-    "wheel",
+    "Cython ~=0.29",
     "oldest-supported-numpy",
     "pkgconfig",
-    "Cython >=0.29; python_version<'3.8'",
-    "Cython >=0.29.14; python_version=='3.8'",
-    "Cython >=0.29.15; python_version>='3.9'",
+    "setuptools >=61",
 ]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "h5py"
+description = "Read and write HDF5 files from Python"
+authors = [
+    {name = "Andrew Collette", email = "andrew.collette@gmail.com"},
+]
+maintainers = [
+    {name = "Thomas Kluyver", email = "thomas@kluyver.me.uk"},
+]
+license = {text = "BSD-3-Clause"}
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Information Technology",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: Unix",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS :: MacOS X",
+    "Operating System :: Microsoft :: Windows",
+    "Programming Language :: Cython",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Database",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+requires-python = ">=3.7"
+dynamic = ["dependencies", "version"]
+
+[project.readme]
+text = """\
+The h5py package provides both a high- and low-level interface to the HDF5
+library from Python. The low-level interface is intended to be a complete
+wrapping of the HDF5 API, while the high-level component supports  access to
+HDF5 files, datasets and groups using established Python and NumPy concepts.
+
+A strong emphasis on automatic conversion between Python (Numpy) datatypes and
+data structures and their HDF5 equivalents vastly simplifies the process of
+reading and writing data from Python.
+
+Wheels are provided for several popular platforms, with an included copy of
+the HDF5 library (usually the latest version when h5py is released).
+
+You can also `build h5py from source
+<https://docs.h5py.org/en/stable/build.html#source-installation>`_
+with any HDF5 stable release from version 1.8.4 onwards, although naturally new
+HDF5 versions released after this version of h5py may not work.
+Odd-numbered minor versions of HDF5 (e.g. 1.13) are experimental, and may not
+be supported.
+"""
+content-type = "text/x-rst"
+
+[project.urls]
+Homepage = "https://www.h5py.org/"
+Source = "https://github.com/h5py/h5py"
+Documentation = "https://docs.h5py.org/en/stable/"
+"Release notes" = "https://docs.h5py.org/en/stable/whatsnew/index.html"
+"Discussion forum" = "https://forum.hdfgroup.org/c/hdf-tools/h5py"
+
+[tool.setuptools]
+# to ignore .pxd and .pyx files in wheels
+include-package-data = false
+packages = [
+    "h5py",
+    "h5py._hl",
+    "h5py.tests",
+    "h5py.tests.data_files",
+    "h5py.tests.test_vds",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ authors = [
 ]
 maintainers = [
     {name = "Thomas Kluyver", email = "thomas@kluyver.me.uk"},
+    {name = "Thomas A Caswell", email = "tcaswell@bnl.gov"},
 ]
 license = {text = "BSD-3-Clause"}
 classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -58,51 +58,7 @@ if os.environ.get('H5PY_SETUP_REQUIRES', '1') == '0':
 CMDCLASS = {'build_ext': setup_build.h5py_build_ext}
 
 
-# --- Distutils setup and metadata --------------------------------------------
-
-cls_txt = \
-"""
-Development Status :: 5 - Production/Stable
-Intended Audience :: Developers
-Intended Audience :: Information Technology
-Intended Audience :: Science/Research
-License :: OSI Approved :: BSD License
-Programming Language :: Cython
-Programming Language :: Python
-Programming Language :: Python :: 3
-Programming Language :: Python :: Implementation :: CPython
-Topic :: Scientific/Engineering
-Topic :: Database
-Topic :: Software Development :: Libraries :: Python Modules
-Operating System :: Unix
-Operating System :: POSIX :: Linux
-Operating System :: MacOS :: MacOS X
-Operating System :: Microsoft :: Windows
-"""
-
-short_desc = "Read and write HDF5 files from Python"
-
-long_desc = \
-"""
-The h5py package provides both a high- and low-level interface to the HDF5
-library from Python. The low-level interface is intended to be a complete
-wrapping of the HDF5 API, while the high-level component supports  access to
-HDF5 files, datasets and groups using established Python and NumPy concepts.
-
-A strong emphasis on automatic conversion between Python (Numpy) datatypes and
-data structures and their HDF5 equivalents vastly simplifies the process of
-reading and writing data from Python.
-
-Wheels are provided for several popular platforms, with an included copy of
-the HDF5 library (usually the latest version when h5py is released).
-
-You can also `build h5py from source
-<https://docs.h5py.org/en/stable/build.html#source-installation>`_
-with any HDF5 stable release from version 1.8.4 onwards, although naturally new
-HDF5 versions released after this version of h5py may not work.
-Odd-numbered minor versions of HDF5 (e.g. 1.13) are experimental, and may not
-be supported.
-"""
+# --- Dynamic metadata for setuptools -----------------------------------------
 
 package_data = {'h5py': [], "h5py.tests.data_files": ["*.h5"]}
 if os.name == 'nt':
@@ -111,31 +67,11 @@ if os.name == 'nt':
 setup(
   name = 'h5py',
   version = VERSION,
-  description = short_desc,
-  long_description = long_desc,
-  classifiers = [x for x in cls_txt.split("\n") if x],
-  author = 'Andrew Collette',
-  author_email = 'andrew.collette@gmail.com',
-  maintainer = 'Andrew Collette',
-  maintainer_email = 'andrew.collette@gmail.com',
-  license = 'BSD',
-  url = 'https://www.h5py.org',
-  project_urls = {
-      'Source': 'https://github.com/h5py/h5py',
-      'Documentation': 'https://docs.h5py.org/en/stable/',
-      'Release notes': 'https://docs.h5py.org/en/stable/whatsnew/index.html'
-  },
-  packages = [
-      'h5py',
-      'h5py._hl',
-      'h5py.tests',
-      'h5py.tests.data_files',
-      'h5py.tests.test_vds',
-  ],
   package_data = package_data,
   ext_modules = [Extension('h5py.x',['x.c'])],  # To trick build into running build_ext
   install_requires = RUN_REQUIRES,
   setup_requires = SETUP_REQUIRES,
-  python_requires='>=3.7',
   cmdclass = CMDCLASS,
 )
+
+# see pyproject.toml for static metadata

--- a/tox.ini
+++ b/tox.ini
@@ -80,10 +80,12 @@ commands=
 skip_install=True
 # Work around https://github.com/tox-dev/tox/issues/2442
 package_env = DUMMY NON-EXISTENT ENV NAME
-deps=twine
+deps=
+    build
+    twine
 commands=
-    python setup.py sdist
-    twine check dist/*
+    python -m build --sdist
+    twine check --strict dist/*
 
 [testenv:pre-commit]
 skip_install=True


### PR DESCRIPTION
This PR moves static project metadata from `setup.py` to `pyproject.toml`, as is described by [PEP 621](https://peps.python.org/pep-0621/) and supported by [setuptools >=61](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html).

Build system changes:

- wheel does not need to be included in `requires` (most recent docs have removed this)
- Specific versions of Cython also don't need to be listed, replaced with `Cython ~=0.29`
- Alphasort `requires` list

Project metadata changes:

- Removed Andrew Collette from maintainers (kept in authors); replaced with @takluyver as this is observed from the [contributors](https://github.com/h5py/h5py/graphs/contributors)
- Change licence from "BSD" to SPDX identifier "BSD-3-Clause"
- Packages don't need to be manually listed, the are found using [custom discovery](https://setuptools.pypa.io/en/latest/userguide/package_discovery.html)
- URLs table has been expanded slightly
- Readme (long_description) content-type is now specified, so that `twine check --strict dist/*` pass (`tox -e checkreadme`)

Other notes:

- The installed wheel now includes *.pxd and *.pyx files. Not sure why this is (perhaps due to custom discovery?), and I'm not sure if its a good or bad thing to include for a binary wheel.
- While there are [dynamic methods](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#dynamic-metadata) to extract version from (e.g.) `h5py.version.version`, this did not work, so this is best left to `setup.py` to evaluate for now.