### PR TITLE
Better access to compression/filter information

### DIFF
--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -641,6 +641,21 @@ Reference
 
         Whether Fletcher32 checksumming is enabled (T/F).  See :ref:`dataset_fletcher32`.
 
+    .. attribute:: filter_ids
+                   filter_names
+
+        The numeric filter IDs and the string names (as stored in the file) of
+        the filters in use. Each attribute is a tuple.
+
+        Filters are mostly used to compress data, but can also do things like
+        checksumming (see :ref:`dataset_compression`). Other attributes listed
+        above provide convenient shortcuts to check on common filters.
+        IDs for filters built into h5py can be found in the :mod:`h5py.h5z`
+        module, while filter IDs from plugins are listed in `HDF Group's registry
+        <https://portal.hdfgroup.org/display/support/Registered+Filter+Plugins>`_.
+
+        .. versionadded:: 3.8
+
     .. attribute:: fillvalue
 
         Value used when reading uninitialized portions of the dataset, or None

--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -623,6 +623,11 @@ Reference
         String with the currently applied compression filter, or None if
         compression is not enabled for this dataset.  See :ref:`dataset_compression`.
 
+        This only recognises the built-in compression options ``'gzip'``,
+        ``'lzf'`` and ``'szip'``. Other compression mechanisms will show as
+        ``'unknown'`` from h5py 3.8. Use :attr:`filter_ids` and
+        :attr:`filter_names` to get more complete information.
+
     .. attribute:: compression_opts
 
         Options for the compression filter.  See :ref:`dataset_compression`.

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -570,6 +570,21 @@ class Dataset(HLObject):
 
     @property
     @with_phil
+    def filter_ids(self):
+        """Numeric IDs of HDF5 filters used for this dataset"""
+        pl = self._dcpl
+        return tuple([pl.get_filter(i)[0] for i in range(pl.get_nfilters())])
+
+    @property
+    @with_phil
+    def filter_names(self):
+        """Names, as stored in the file, of the filters used for this dataset"""
+        pl = self._dcpl
+        return tuple([pl.get_filter(i)[3].decode('utf-8', 'surrogateescape')
+                for i in range(pl.get_nfilters())])
+
+    @property
+    @with_phil
     def shuffle(self):
         """Shuffle filter present (T/F)"""
         return 'shuffle' in self._filters

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -560,6 +560,8 @@ class Dataset(HLObject):
         for x in ('gzip','lzf','szip'):
             if x in self._filters:
                 return x
+        if any(f not in filters._COMP_FILTERS for f in self._filters):
+            return 'unknown'  # Filter from a plugin
         return None
 
     @property

--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -244,10 +244,15 @@ def fill_dcpl(plist, shape, dtype, chunks, compression, compression_opts,
     external = _normalize_external(external)
     # End argument validation
 
-    if (chunks is True) or \
-    (chunks is None and any((shuffle, fletcher32, compression, maxshape,
-                             scaleoffset is not None))):
-        chunks = guess_chunk(shape, maxshape, dtype.itemsize)
+    if chunks is None and any((
+        shuffle, fletcher32, compression, maxshape, scaleoffset is not None
+    )):
+        chunks = True
+
+    pre_chunked = plist.get_layout() == h5d.CHUNKED and plist.get_chunk() != ()
+    if chunks is True:
+        # Guess chunk shape unless a passed-in property list already has chunks
+        chunks = None if pre_chunked else guess_chunk(shape, maxshape, dtype.itemsize)
 
     if maxshape is True:
         maxshape = (None,)*len(shape)

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -298,7 +298,7 @@ class Group(HLObject, MutableMappingHDF5):
 
             return dset
 
-    def create_dataset_like(self, name, other, **kwupdate):
+    def create_dataset_like(self, name, other, **kwargs):
         """ Create a dataset similar to `other`.
 
         name
@@ -313,22 +313,31 @@ class Group(HLObject, MutableMappingHDF5):
         shape and dtype, in which case the provided values take precedence over
         those from `other`.
         """
-        for k in ('shape', 'dtype', 'chunks', 'compression',
-                  'compression_opts', 'scaleoffset', 'shuffle', 'fletcher32',
-                  'fillvalue'):
-            kwupdate.setdefault(k, getattr(other, k))
-        # TODO: more elegant way to pass these (dcpl to create_dataset?)
+        kwargs.setdefault('shape', other.shape)
+        kwargs.setdefault('dtype', other.dtype)
         dcpl = other.id.get_create_plist()
-        kwupdate.setdefault('track_times', dcpl.get_obj_track_times())
-        kwupdate.setdefault('track_order', dcpl.get_attr_creation_order() > 0)
+        # track_times needs to be passed specifically, because otherwise h5py
+        # applies its default (False) to override the HDF5 default.
+        kwargs.setdefault('track_times', dcpl.get_obj_track_times())
 
         # Special case: the maxshape property always exists, but if we pass it
         # to create_dataset, the new dataset will automatically get chunked
         # layout. So we copy it only if it is different from shape.
         if other.maxshape != other.shape:
-            kwupdate.setdefault('maxshape', other.maxshape)
+            kwargs.setdefault('maxshape', other.maxshape)
 
-        return self.create_dataset(name, **kwupdate)
+        # If compression is not specified, copy the filter pipeline as is,
+        # including any filters we don't recognise.
+        # New compression arg should replace existing filters, not chain.
+        if 'compression' in kwargs:
+            for filter_id in other.filter_ids:
+                dcpl.remove_filter(filter_id)
+
+            # Copy the filters which are separate from the compression kwarg
+            for k in ('shuffle', 'fletcher32', 'scaleoffset'):
+                kwargs.setdefault(k, getattr(other, k))
+
+        return self.create_dataset(name, dcpl=dcpl, **kwargs)
 
     def require_group(self, name):
         # TODO: support kwargs like require_dataset

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1857,6 +1857,7 @@ def test_allow_unknown_filter(writable_file):
         allow_unknown_filter=True
     )
     assert str(fake_filter_id) in ds._filters
+    assert ds.compression == 'unknown'
 
 
 def test_dset_chunk_cache():

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1951,3 +1951,14 @@ class TestVirtualPrefix(BaseDataset):
         self.assertEqual(virtual_prefix, virtual_prefix_readback)
         self.assertIsInstance(dset, Dataset)
         self.assertEqual(dset.shape, (10, 3))
+
+
+def test_filter_properties(writable_file):
+    ds = writable_file.create_dataset(
+        'foo', shape=1000, dtype=np.float32,
+        fletcher32=True, shuffle=True, compression='lzf'
+    )
+    assert ds.filter_ids == (
+        h5py.h5z.FILTER_SHUFFLE, h5py.h5z.FILTER_LZF, h5py.h5z.FILTER_FLETCHER32
+    )
+    assert ds.filter_names == ('shuffle', 'lzf', 'fletcher32')

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -949,6 +949,34 @@ class TestCreateLike(BaseDataset):
         self.assertEqual(similar.shape, (10,))
         self.assertEqual(similar.maxshape, (20,))
 
+    def test_chunking_compression(self):
+        foo = self.f.create_dataset(
+            'foo', dtype=np.uint16, shape=(100,), chunks=(21,), compression='gzip'
+        )
+        bar = self.f.create_dataset_like('bar', foo)
+        self.assertEqual(bar.shape, (100,))
+        self.assertEqual(bar.chunks, (21,))
+        self.assertEqual(bar.filter_ids, (h5py.h5z.FILTER_DEFLATE,))
+
+    def test_remove_compression(self):
+        foo = self.f.create_dataset(
+            'foo', dtype=np.uint16, shape=(100,), chunks=(21,), compression='gzip'
+        )
+        baz = self.f.create_dataset_like('baz', foo, compression=None)
+        self.assertEqual(baz.filter_ids, ())
+        self.assertEqual(baz.chunks, (21,))
+
+    def test_replace_compression(self):
+        foo = self.f.create_dataset(
+            'foo', dtype=np.uint16, shape=(100,), chunks=(21,), compression='gzip',
+            shuffle=True, fletcher32=True,
+        )
+        baz = self.f.create_dataset_like('baz', foo, compression='lzf')
+        self.assertEqual(baz.filter_ids, (
+            h5py.h5z.FILTER_SHUFFLE, h5py.h5z.FILTER_LZF, h5py.h5z.FILTER_FLETCHER32
+        ))
+        self.assertEqual(baz.chunks, (21,))
+
 class TestChunkIterator(BaseDataset):
     def test_no_chunks(self):
         dset = self.f.create_dataset("foo", ())


### PR DESCRIPTION
This follows from the discussion in #2161. The changes are:

- `dset.compression` will return 'unknown' rather than `None` if a plugin filter is used and none of the three built-in compression filters (gzip, lzf, szip) are included.
  - Technically the unknown filter doesn't have to be a compression filter, but it probably will be.
  - What should we do if there are plugin filters used *and* one that we recognise (like 'gzip')? In master, and in this PR at present, we still name the filter we recognise.
- New properties `dset.filter_ids` and `dset.filter_names` give you more information on all the filters in use, compression or otherwise.
  - If you need to get the filter options or flags, you still need to go to the low-level API: `dset.id.get_create_plist().get_filter(i)`
- `group.create_dataset_like()` can now copy a filter pipeline even if it doesn't recognise the filters in it.
  - I'm still figuring out parts of how this interacts with keyword arguments.

Closes #2161