### PR TITLE
Add new H5FD_class_value_t typedef and fix wrong file driver version import error

### DIFF
--- a/h5py/api_types_hdf5.pxd
+++ b/h5py/api_types_hdf5.pxd
@@ -235,40 +235,100 @@ cdef extern from "hdf5.h":
     H5FD_MPIO_INDEPENDENT = 0,
     H5FD_MPIO_COLLECTIVE
 
+  # File driver identifier type and values
+  IF HDF5_VERSION >= (1, 14, 0):
+    ctypedef int H5FD_class_value_t
+
+    H5FD_class_value_t H5_VFD_INVALID      # -1
+    H5FD_class_value_t H5_VFD_SEC2         # 0
+    H5FD_class_value_t H5_VFD_CORE         # 1
+    H5FD_class_value_t H5_VFD_LOG          # 2
+    H5FD_class_value_t H5_VFD_FAMILY       # 3
+    H5FD_class_value_t H5_VFD_MULTI        # 4
+    H5FD_class_value_t H5_VFD_STDIO        # 5
+    H5FD_class_value_t H5_VFD_SPLITTER     # 6
+    H5FD_class_value_t H5_VFD_MPIO         # 7
+    H5FD_class_value_t H5_VFD_DIRECT       # 8
+    H5FD_class_value_t H5_VFD_MIRROR       # 9
+    H5FD_class_value_t H5_VFD_HDFS         # 10
+    H5FD_class_value_t H5_VFD_ROS3         # 11
+    H5FD_class_value_t H5_VFD_SUBFILING    # 12
+    H5FD_class_value_t H5_VFD_IOC          # 13
+    H5FD_class_value_t H5_VFD_ONION        # 14
+
   # Class information for each file driver
-  ctypedef struct H5FD_class_t:
-    const char *name
-    haddr_t maxaddr
-    H5F_close_degree_t fc_degree
-    herr_t  (*terminate)()
-    hsize_t (*sb_size)(H5FD_t *file)
-    herr_t  (*sb_encode)(H5FD_t *file, char *name, unsigned char *p)
-    herr_t  (*sb_decode)(H5FD_t *f, const char *name, const unsigned char *p)
-    size_t  fapl_size
-    void *  (*fapl_get)(H5FD_t *file)
-    void *  (*fapl_copy)(const void *fapl)
-    herr_t  (*fapl_free)(void *fapl)
-    size_t  dxpl_size
-    void *  (*dxpl_copy)(const void *dxpl)
-    herr_t  (*dxpl_free)(void *dxpl)
-    H5FD_t *(*open)(const char *name, unsigned flags, hid_t fapl, haddr_t maxaddr)
-    herr_t  (*close)(H5FD_t *file)
-    int     (*cmp)(const H5FD_t *f1, const H5FD_t *f2)
-    herr_t  (*query)(const H5FD_t *f1, unsigned long *flags)
-    herr_t  (*get_type_map)(const H5FD_t *file, H5FD_mem_t *type_map)
-    haddr_t (*alloc)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, hsize_t size)
-    herr_t  (*free)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr, hsize_t size)
-    haddr_t (*get_eoa)(const H5FD_t *file, H5FD_mem_t type)
-    herr_t  (*set_eoa)(H5FD_t *file, H5FD_mem_t type, haddr_t addr)
-    haddr_t (*get_eof)(const H5FD_t *file, H5FD_mem_t type)
-    herr_t  (*get_handle)(H5FD_t *file, hid_t fapl, void**file_handle)
-    herr_t  (*read)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl, haddr_t addr, size_t size, void *buffer)
-    herr_t  (*write)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl, haddr_t addr, size_t size, const void *buffer)
-    herr_t  (*flush)(H5FD_t *file, hid_t dxpl_id, hbool_t closing)
-    herr_t  (*truncate)(H5FD_t *file, hid_t dxpl_id, hbool_t closing)
-    herr_t  (*lock)(H5FD_t *file, hbool_t rw)
-    herr_t  (*unlock)(H5FD_t *file)
-    H5FD_mem_t fl_map[<int>H5FD_MEM_NTYPES]
+  IF HDF5_VERSION < (1, 14, 0):
+    ctypedef struct H5FD_class_t:
+      const char *name
+      haddr_t maxaddr
+      H5F_close_degree_t fc_degree
+      herr_t  (*terminate)()
+      hsize_t (*sb_size)(H5FD_t *file)
+      herr_t  (*sb_encode)(H5FD_t *file, char *name, unsigned char *p)
+      herr_t  (*sb_decode)(H5FD_t *f, const char *name, const unsigned char *p)
+      size_t  fapl_size
+      void *  (*fapl_get)(H5FD_t *file)
+      void *  (*fapl_copy)(const void *fapl)
+      herr_t  (*fapl_free)(void *fapl)
+      size_t  dxpl_size
+      void *  (*dxpl_copy)(const void *dxpl)
+      herr_t  (*dxpl_free)(void *dxpl)
+      H5FD_t *(*open)(const char *name, unsigned flags, hid_t fapl, haddr_t maxaddr)
+      herr_t  (*close)(H5FD_t *file)
+      int     (*cmp)(const H5FD_t *f1, const H5FD_t *f2)
+      herr_t  (*query)(const H5FD_t *f1, unsigned long *flags)
+      herr_t  (*get_type_map)(const H5FD_t *file, H5FD_mem_t *type_map)
+      haddr_t (*alloc)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, hsize_t size)
+      herr_t  (*free)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr, hsize_t size)
+      haddr_t (*get_eoa)(const H5FD_t *file, H5FD_mem_t type)
+      herr_t  (*set_eoa)(H5FD_t *file, H5FD_mem_t type, haddr_t addr)
+      haddr_t (*get_eof)(const H5FD_t *file, H5FD_mem_t type)
+      herr_t  (*get_handle)(H5FD_t *file, hid_t fapl, void**file_handle)
+      herr_t  (*read)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl, haddr_t addr, size_t size, void *buffer)
+      herr_t  (*write)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl, haddr_t addr, size_t size, const void *buffer)
+      herr_t  (*flush)(H5FD_t *file, hid_t dxpl_id, hbool_t closing)
+      herr_t  (*truncate)(H5FD_t *file, hid_t dxpl_id, hbool_t closing)
+      herr_t  (*lock)(H5FD_t *file, hbool_t rw)
+      herr_t  (*unlock)(H5FD_t *file)
+      H5FD_mem_t fl_map[<int>H5FD_MEM_NTYPES]
+  ELSE:
+    unsigned H5FD_CLASS_VERSION  # File driver struct version
+
+    ctypedef struct H5FD_class_t:
+      unsigned version  # File driver class struct version number
+      H5FD_class_value_t value
+      const char *name
+      haddr_t maxaddr
+      H5F_close_degree_t fc_degree
+      herr_t  (*terminate)()
+      hsize_t (*sb_size)(H5FD_t *file)
+      herr_t  (*sb_encode)(H5FD_t *file, char *name, unsigned char *p)
+      herr_t  (*sb_decode)(H5FD_t *f, const char *name, const unsigned char *p)
+      size_t  fapl_size
+      void *  (*fapl_get)(H5FD_t *file)
+      void *  (*fapl_copy)(const void *fapl)
+      herr_t  (*fapl_free)(void *fapl)
+      size_t  dxpl_size
+      void *  (*dxpl_copy)(const void *dxpl)
+      herr_t  (*dxpl_free)(void *dxpl)
+      H5FD_t *(*open)(const char *name, unsigned flags, hid_t fapl, haddr_t maxaddr)
+      herr_t  (*close)(H5FD_t *file)
+      int     (*cmp)(const H5FD_t *f1, const H5FD_t *f2)
+      herr_t  (*query)(const H5FD_t *f1, unsigned long *flags)
+      herr_t  (*get_type_map)(const H5FD_t *file, H5FD_mem_t *type_map)
+      haddr_t (*alloc)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, hsize_t size)
+      herr_t  (*free)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr, hsize_t size)
+      haddr_t (*get_eoa)(const H5FD_t *file, H5FD_mem_t type)
+      herr_t  (*set_eoa)(H5FD_t *file, H5FD_mem_t type, haddr_t addr)
+      haddr_t (*get_eof)(const H5FD_t *file, H5FD_mem_t type)
+      herr_t  (*get_handle)(H5FD_t *file, hid_t fapl, void**file_handle)
+      herr_t  (*read)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl, haddr_t addr, size_t size, void *buffer)
+      herr_t  (*write)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl, haddr_t addr, size_t size, const void *buffer)
+      herr_t  (*flush)(H5FD_t *file, hid_t dxpl_id, hbool_t closing)
+      herr_t  (*truncate)(H5FD_t *file, hid_t dxpl_id, hbool_t closing)
+      herr_t  (*lock)(H5FD_t *file, hbool_t rw)
+      herr_t  (*unlock)(H5FD_t *file)
+      H5FD_mem_t fl_map[<int>H5FD_MEM_NTYPES]
 
   # The main datatype for each driver
   ctypedef struct H5FD_t:

--- a/h5py/h5fd.pyx
+++ b/h5py/h5fd.pyx
@@ -216,5 +216,7 @@ info.fl_map = [H5FD_MEM_SUPER,  # default
                H5FD_MEM_SUPER,  # lheap
                H5FD_MEM_SUPER   # ohdr
 	       ]
+IF HDF5_VERSION >= (1, 14, 0):
+    info.version = H5FD_CLASS_VERSION
 
 fileobj_driver = H5FDregister(&info)


### PR DESCRIPTION
Enable `import h5py` to work for libhdf5-1.14.0. Does what  #2154 did but in the proper way.