### PR TITLE
Some fixes for testing with tox 4.0

### DIFF
--- a/ci/azure-pipelines-test-wheels.yml
+++ b/ci/azure-pipelines-test-wheels.yml
@@ -13,6 +13,9 @@ steps:
   displayName: Install tox
 - bash: |
     ls $PIPELINE_WORKSPACE/${{ parameters.platform }}_wheels/
+    echo "PIPELINE_WORKSPACE=$PIPELINE_WORKSPACE"
+    echo "parameters.platform=${{ parameters.platform }}"
+    echo "Matching files" $PIPELINE_WORKSPACE/${{ parameters.platform }}_wheels/$WHL_FILE
     tox --installpkg $PIPELINE_WORKSPACE/${{ parameters.platform }}_wheels/$WHL_FILE
   displayName: Run tests
 - task: PythonScript@0

--- a/ci/azure-pipelines-test-wheels.yml
+++ b/ci/azure-pipelines-test-wheels.yml
@@ -13,10 +13,11 @@ steps:
   displayName: Install tox
 - bash: |
     ls $PIPELINE_WORKSPACE/${{ parameters.platform }}_wheels/
-    echo "PIPELINE_WORKSPACE=$PIPELINE_WORKSPACE"
-    echo "parameters.platform=${{ parameters.platform }}"
-    echo "Matching files" $PIPELINE_WORKSPACE/${{ parameters.platform }}_wheels/$WHL_FILE
-    tox --installpkg $PIPELINE_WORKSPACE/${{ parameters.platform }}_wheels/$WHL_FILE
+    # Bash's own globbing doesn't like Windows-style paths, so expand it using Python
+    WHL_PATH=$(python3 -c "import glob, sys; print(glob.glob(sys.argv[1])[0])" \
+               "$PIPELINE_WORKSPACE/${{ parameters.platform }}_wheels/$WHL_FILE")
+    echo "Will install wheel from $WHL_PATH"
+    tox --installpkg $WHL_PATH
   displayName: Run tests
 - task: PythonScript@0
   inputs:

--- a/setup_configure.py
+++ b/setup_configure.py
@@ -279,11 +279,6 @@ class HDF5LibWrapper:
 
         print("Loading library to get build settings and version:", path)
 
-        print("CWD", os.getcwd())
-        print("libdirs", libdirs)
-        for k in ['TOXENV', 'HDF5_VERSION', 'HDF5_DIR', 'HDF5_VSVERSION']:
-            print(k, repr(os.environ.get(k)))
-
         self._lib_path = path
 
         if op.isabs(path) and not op.exists(path):

--- a/setup_configure.py
+++ b/setup_configure.py
@@ -279,6 +279,11 @@ class HDF5LibWrapper:
 
         print("Loading library to get build settings and version:", path)
 
+        print("CWD", os.getcwd())
+        print("libdirs", libdirs)
+        for k in ['TOXENV', 'HDF5_VERSION', 'HDF5_DIR', 'HDF5_VSVERSION']:
+            print(k, repr(os.environ.get(k)))
+
         self._lib_path = path
 
         if op.isabs(path) and not op.exists(path):

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,7 @@ basepython = python3.8
 [testenv:docs]
 skip_install=True
 # Work around https://github.com/tox-dev/tox/issues/2442
-package_env = ❌ DUMMY NON-EXISTENT ENV NAME ❌
+package_env = DUMMY NON-EXISTENT ENV NAME
 changedir=docs
 deps=
     sphinx
@@ -79,7 +79,7 @@ commands=
 [testenv:checkreadme]
 skip_install=True
 # Work around https://github.com/tox-dev/tox/issues/2442
-package_env = ❌ DUMMY NON-EXISTENT ENV NAME ❌
+package_env = DUMMY NON-EXISTENT ENV NAME
 deps=twine
 commands=
     python setup.py sdist
@@ -88,7 +88,7 @@ commands=
 [testenv:pre-commit]
 skip_install=True
 # Work around https://github.com/tox-dev/tox/issues/2442
-package_env = ❌ DUMMY NON-EXISTENT ENV NAME ❌
+package_env = DUMMY NON-EXISTENT ENV NAME
 deps=pre-commit
 passenv = HOMEPATH SSH_AUTH_SOCK
 commands=
@@ -97,7 +97,7 @@ commands=
 [testenv:rever]
 skip_install=True
 # Work around https://github.com/tox-dev/tox/issues/2442
-package_env = ❌ DUMMY NON-EXISTENT ENV NAME ❌
+package_env = DUMMY NON-EXISTENT ENV NAME
 deps=
     re-ver
     xonsh

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ passenv =
     OMPI_* # used to configure OpenMPI
     CC
     ZLIB_ROOT
-whitelist_externals =
+allowlist_externals =
     mpirun
 setenv =
     COVERAGE_FILE={toxinidir}/.coverage_dir/coverage-{envname}

--- a/tox.ini
+++ b/tox.ini
@@ -61,6 +61,8 @@ basepython = python3.8
 
 [testenv:docs]
 skip_install=True
+# Work around https://github.com/tox-dev/tox/issues/2442
+package_env = ❌ DUMMY NON-EXISTENT ENV NAME ❌
 changedir=docs
 deps=
     sphinx
@@ -76,6 +78,8 @@ commands=
 
 [testenv:checkreadme]
 skip_install=True
+# Work around https://github.com/tox-dev/tox/issues/2442
+package_env = ❌ DUMMY NON-EXISTENT ENV NAME ❌
 deps=twine
 commands=
     python setup.py sdist
@@ -83,6 +87,8 @@ commands=
 
 [testenv:pre-commit]
 skip_install=True
+# Work around https://github.com/tox-dev/tox/issues/2442
+package_env = ❌ DUMMY NON-EXISTENT ENV NAME ❌
 deps=pre-commit
 passenv = HOMEPATH SSH_AUTH_SOCK
 commands=
@@ -90,6 +96,8 @@ commands=
 
 [testenv:rever]
 skip_install=True
+# Work around https://github.com/tox-dev/tox/issues/2442
+package_env = ❌ DUMMY NON-EXISTENT ENV NAME ❌
 deps=
     re-ver
     xonsh


### PR DESCRIPTION
I was overly optimistic in my assessment that a recent bugfix release of Tox had fixed the issue we were seeing - it had fixed the one issue I had looked at, but not a couple of others.

One config option has simply been renamed, and there's currently an issue with defining a mixture of environments that install an already-built wheel and environments that don't install the package at all. I copied a workaround described at https://github.com/tox-dev/tox/issues/2442#issuecomment-1347555684 .