### PR TITLE
Get rid of testing warnings about NumPy integer overflow

### DIFF
--- a/h5py/tests/test_file_alignment.py
+++ b/h5py/tests/test_file_alignment.py
@@ -65,7 +65,7 @@ class TestFileAlignment(TestCase):
                         dataset_name(i), shape, dtype='uint8')
                     # Assign data so that the dataset is instantiated in
                     # the file
-                    dataset[...] = i
+                    dataset[...] = (i % 256)  # Truncate to uint8
                     assert is_aligned(dataset, offset=alignment_interval)
 
     def test_alignment_set_below_threshold(self):


### PR DESCRIPTION
With recent versions of NumPy, the tests generate a load of warnings like this:

```
.tox/py311-test-deps-pre/lib/python3.11/site-packages/h5py/tests/test_file_alignment.py::TestFileAlignment::test_alignment_set_above_threshold
.tox/py311-test-deps-pre/lib/python3.11/site-packages/h5py/tests/test_file_alignment.py::TestFileAlignment::test_alignment_set_above_threshold
.tox/py311-test-deps-pre/lib/python3.11/site-packages/h5py/tests/test_file_alignment.py::TestFileAlignment::test_alignment_set_above_threshold
  /home/vsts/work/1/s/.tox/py311-test-deps-pre/lib/python3.11/site-packages/h5py/_hl/dataset.py:929: DeprecationWarning: NumPy will stop allowing conversion of out-of-bound Python integers to integer arrays.  The conversion of 256 to uint8 will fail in the future.
  For the old behavior, usually:
      np.array(value).astype(dtype)`
  will give the desired result (the cast overflows).
    val = numpy.asarray(val, order='C', dtype=dt)
```

This PR should get rid of those.