### PR TITLE
Add H5Dchunk_iter()

### DIFF
--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -122,6 +122,7 @@ hdf5:
   1.10.5    herr_t H5Dget_num_chunks(hid_t dset_id, hid_t fspace_id, hsize_t *nchunks)
   1.10.5    herr_t H5Dget_chunk_info(hid_t dset_id, hid_t fspace_id, hsize_t chk_idx, hsize_t *offset, unsigned *filter_mask, haddr_t *addr, hsize_t *size)
   1.10.5    herr_t H5Dget_chunk_info_by_coord(hid_t dset_id, const hsize_t *offset, unsigned *filter_mask, haddr_t *addr, hsize_t *size)
+  1.12.3    herr_t H5Dchunk_iter(hid_t dset_id, hid_t dxpl_id, H5D_chunk_iter_op_t cb, void *op_data)
 
 
   # === H5E - Minimal error-handling interface ================================

--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -122,6 +122,7 @@ hdf5:
   1.10.5    herr_t H5Dget_num_chunks(hid_t dset_id, hid_t fspace_id, hsize_t *nchunks)
   1.10.5    herr_t H5Dget_chunk_info(hid_t dset_id, hid_t fspace_id, hsize_t chk_idx, hsize_t *offset, unsigned *filter_mask, haddr_t *addr, hsize_t *size)
   1.10.5    herr_t H5Dget_chunk_info_by_coord(hid_t dset_id, const hsize_t *offset, unsigned *filter_mask, haddr_t *addr, hsize_t *size)
+  1.10.10-1.10.99 herr_t H5Dchunk_iter(hid_t dset_id, hid_t dxpl_id, H5D_chunk_iter_op_t cb, void *op_data)
   1.12.3    herr_t H5Dchunk_iter(hid_t dset_id, hid_t dxpl_id, H5D_chunk_iter_op_t cb, void *op_data)
 
 

--- a/h5py/api_types_hdf5.pxd
+++ b/h5py/api_types_hdf5.pxd
@@ -95,7 +95,8 @@ cdef extern from "hdf5.h":
   ctypedef  herr_t (*H5D_operator_t)(void *elem, hid_t type_id, unsigned ndim,
                     hsize_t *point, void *operator_data) except -1
 
-  IF HDF5_VERSION >= (1, 12, 3):
+
+  IF HDF5_VERSION >= (1, 12, 3) or (HDF5_VERSION >= (1, 10, 10) and HDF5_VERSION < (1, 10, 99)):
     ctypedef int (*H5D_chunk_iter_op_t)(const hsize_t *offset, unsigned filter_mask,
                                         haddr_t addr, hsize_t size, void *op_data) except -1
 

--- a/h5py/api_types_hdf5.pxd
+++ b/h5py/api_types_hdf5.pxd
@@ -95,6 +95,10 @@ cdef extern from "hdf5.h":
   ctypedef  herr_t (*H5D_operator_t)(void *elem, hid_t type_id, unsigned ndim,
                     hsize_t *point, void *operator_data) except -1
 
+  IF HDF5_VERSION >= (1, 12, 3):
+    ctypedef int (*H5D_chunk_iter_op_t)(const hsize_t *offset, unsigned filter_mask,
+                                        haddr_t addr, hsize_t size, void *op_data) except -1
+
 # === H5F - File API ==========================================================
 
   # File constants
@@ -153,7 +157,7 @@ cdef extern from "hdf5.h":
       H5F_LIBVER_NBOUNDS
     int H5F_LIBVER_LATEST  # Use the latest possible format available for storing objects
 
-  IF HDF5_VERSION >= (1, 11, 4) and HDF5_VERSION < (1, 13, 0):
+  IF HDF5_VERSION >= (1, 11, 4) and HDF5_VERSION < (1, 14, 0):
     ctypedef enum H5F_libver_t:
       H5F_LIBVER_EARLIEST = 0,        # Use the earliest possible format for storing objects
       H5F_LIBVER_V18 = 1,
@@ -162,7 +166,7 @@ cdef extern from "hdf5.h":
       H5F_LIBVER_NBOUNDS
     int H5F_LIBVER_LATEST  # Use the latest possible format available for storing objects
 
-  IF HDF5_VERSION >= (1, 13, 0):
+  IF HDF5_VERSION >= (1, 14, 0):
     ctypedef enum H5F_libver_t:
       H5F_LIBVER_EARLIEST = 0,        # Use the earliest possible format for storing objects
       H5F_LIBVER_V18 = 1,

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1794,8 +1794,9 @@ def test_get_chunk_details():
         assert si.size > 0
 
 
-@ut.skipUnless(h5py.version.hdf5_version_tuple >= (1, 12, 3),
-               "chunk iteration requires  HDF5 >= 1.12.3")
+@ut.skipUnless(h5py.version.hdf5_version_tuple >= (1, 12, 3) or
+               (h5py.version.hdf5_version_tuple >= (1, 10, 10) and h5py.version.hdf5_version_tuple < (1, 10, 99)),
+               "chunk iteration requires  HDF5 1.10.10 and later 1.10, or 1.12.3 and later")
 def test_chunk_iter():
     """H5Dchunk_iter() for chunk information"""
     from io import BytesIO
@@ -1822,7 +1823,7 @@ def test_chunk_iter():
             assert chunk_info.byte_offset == known.byte_offset
             assert chunk_info.size == known.size
 
-        h5py.h5d.chunk_visit(dsid, callback)
+        h5py.h5d.visitchunks(dsid, callback)
 
 
 def test_empty_shape(writable_file):

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1823,7 +1823,7 @@ def test_chunk_iter():
             assert chunk_info.byte_offset == known.byte_offset
             assert chunk_info.size == known.size
 
-        h5py.h5d.visitchunks(dsid, callback)
+        dsid.chunk_iter(callback)
 
 
 def test_empty_shape(writable_file):

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1794,6 +1794,37 @@ def test_get_chunk_details():
         assert si.size > 0
 
 
+@ut.skipUnless(h5py.version.hdf5_version_tuple >= (1, 12, 3),
+               "chunk iteration requires  HDF5 >= 1.12.3")
+def test_chunk_iter():
+    """H5Dchunk_iter() for chunk information"""
+    from io import BytesIO
+    buf = BytesIO()
+    with h5py.File(buf, 'w') as f:
+        f.create_dataset('test', shape=(100, 100), chunks=(10, 10), dtype='i4')
+        f['test'][:] = 1
+
+    buf.seek(0)
+    with h5py.File(buf, 'r') as f:
+        dsid = f['test'].id
+
+        num_chunks = dsid.get_num_chunks()
+        assert num_chunks == 100
+        ci = {}
+        for j in range(num_chunks):
+            si = dsid.get_chunk_info(j)
+            ci[si.chunk_offset] = si
+
+        def callback(chunk_info):
+            known = ci[chunk_info.chunk_offset]
+            assert chunk_info.chunk_offset == known.chunk_offset
+            assert chunk_info.filter_mask == known.filter_mask
+            assert chunk_info.byte_offset == known.byte_offset
+            assert chunk_info.size == known.size
+
+        h5py.h5d.chunk_visit(dsid, callback)
+
+
 def test_empty_shape(writable_file):
     ds = writable_file.create_dataset('empty', dtype='int32')
     assert ds.shape is None


### PR DESCRIPTION
This new function is a faster way to go over all dataset's chunks and invoke a user callback function. It will also appear in the next HDF5-1.12.3 release, hence the mention of that version.

Not yet integrated in the high-level interface.