### PR TITLE
Changes necessary to support HDF5 1.14

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,7 +76,7 @@ jobs:
       parameters:
         platform: macos_$(arch)
 
-- job: 'ubuntu1604'
+- job: 'ubuntu'
   pool:
     vmImage: ubuntu-20.04
   strategy:
@@ -103,12 +103,6 @@ jobs:
         HDF5_VERSION: 1.10.3
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         H5PY_ENFORCE_COVERAGE: yes
-      py37-deps-hdf51106:
-        python.version: '3.7'
-        TOXENV: py37-test-deps
-        HDF5_VERSION: 1.10.6
-        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
-        H5PY_ENFORCE_COVERAGE: yes
       py38-deps-hdf51107:
         python.version: '3.8'
         TOXENV: py38-test-deps
@@ -125,6 +119,12 @@ jobs:
         python.version: '3.9'
         TOXENV: py39-test-deps
         HDF5_VERSION: 1.12.2
+        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
+        H5PY_ENFORCE_COVERAGE: yes
+      py310-deps-hdf51140:
+        python.version: '3.10'
+        TOXENV: py310-test-deps
+        HDF5_VERSION: 1.14.0
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         H5PY_ENFORCE_COVERAGE: yes
     # do mpi tests
@@ -200,13 +200,6 @@ jobs:
         HDF5_VSVERSION: "16-64"
         H5PY_ENFORCE_COVERAGE: yes
     # 64 bit - HDF5 1.10
-      py38-hdf5110:
-        python.version: '3.8'
-        TOXENV: py38-test-deps,py38-test-mindeps,py38-test-deps-pre
-        HDF5_VERSION: 1.10.6
-        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
-        HDF5_VSVERSION: "16-64"
-        H5PY_ENFORCE_COVERAGE: yes
       py39-hdf5110:
         python.version: '3.9'
         TOXENV: py39-test-deps,py39-test-mindeps,py39-test-deps-pre
@@ -220,6 +213,13 @@ jobs:
         python.version: '3.8'
         TOXENV: py38-test-deps
         HDF5_VERSION: 1.12.0
+        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
+        HDF5_VSVERSION: "16-64"
+        H5PY_ENFORCE_COVERAGE: yes
+      py310-hdf5114:
+        python.version: '3.10'
+        TOXENV: py310-test-deps
+        HDF5_VERSION: 1.14.0
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         HDF5_VSVERSION: "16-64"
         H5PY_ENFORCE_COVERAGE: yes

--- a/docs/high/file.rst
+++ b/docs/high/file.rst
@@ -452,10 +452,12 @@ Reference
                     ``h5.get_config().track_order``.
     :param fs_strategy: The file space handling strategy to be used.
             Only allowed when creating a new file. One of "fsm", "page",
-            "aggregate", "none", or None (to use the HDF5 default).
+            "aggregate", "none", or ``None`` (to use the HDF5 default).
     :param fs_persist: A boolean to indicate whether free space should be
             persistent or not. Only allowed when creating a new file. The
             default is False.
+    :param fs_page_size: File space page size in bytes. Only use when
+            fs_strategy="page". If ``None`` use the HDF5 default (4096 bytes).
     :param fs_threshold: The smallest free-space section size that the free
             space manager will track. Only allowed when creating a new file.
             The default is 1.


### PR DESCRIPTION
Now that 1.14 has been released, we should bring these changes into master, and also set up testing with 1.14.