### PR TITLE
Remove unnecessary Cython 'cimport class' syntax

### DIFF
--- a/h5py/h5s.pxd
+++ b/h5py/h5s.pxd
@@ -10,7 +10,7 @@
 
 from .defs cimport *
 
-from ._objects cimport class ObjectID
+from ._objects cimport ObjectID
 
 cdef class SpaceID(ObjectID):
     pass

--- a/h5py/h5t.pxd
+++ b/h5py/h5t.pxd
@@ -10,7 +10,7 @@
 
 from .defs cimport *
 
-from ._objects cimport class ObjectID
+from ._objects cimport ObjectID
 
 cdef class TypeID(ObjectID):
 


### PR DESCRIPTION
This appears to be an old leftover that hasn't been needed for a long time, and is being removed for Cython 3.0 (https://github.com/cython/cython/pull/4904). PyCharm's static analysis also doesn't recognise it, leading to spurious warnings.