### PR TITLE
Allow arbitrary array-ish objects for fancy indexing

### DIFF
--- a/h5py/_selector.pyx
+++ b/h5py/_selector.pyx
@@ -15,6 +15,7 @@ from numpy cimport (
 )
 from cpython cimport PyNumber_Index
 
+import collections.abc
 import numpy as np
 from .defs cimport *
 from .h5d cimport DatasetID
@@ -172,8 +173,8 @@ cdef class Selector:
                 continue
 
             # [[0, 2, 10]] - list/array of indices ('fancy indexing')
-            if isinstance(a, (list, np.ndarray)):
-                if isinstance(a, list) and len(a) == 0:
+            if isinstance(a, (np.ndarray, collections.abc.Sequence)):
+                if not isinstance(a, np.ndarray) and len(a) == 0:
                     a = np.asarray(a, dtype=np.intp)
                 else:
                     a = np.asarray(a)

--- a/h5py/_selector.pyx
+++ b/h5py/_selector.pyx
@@ -173,54 +173,55 @@ cdef class Selector:
                 continue
 
             # [[0, 2, 10]] - list/array of indices ('fancy indexing')
-            if isinstance(a, (np.ndarray, collections.abc.Sequence)):
-                if not isinstance(a, np.ndarray) and len(a) == 0:
-                    a = np.asarray(a, dtype=np.intp)
-                else:
-                    a = np.asarray(a)
+            if isinstance(a, np.ndarray):
                 if a.ndim != 1:
                     raise TypeError("Only 1D arrays allowed for fancy indexing")
-                if a.dtype.kind == 'b':
-                    if self.rank == 1:
-                        # The dataset machinery should fall back to a faster
-                        # alternative (using PointSelection) in this case.
-                        # https://github.com/h5py/h5py/issues/2189
-                        raise TypeError("Use other code for boolean selection on 1D dataset")
-                    if a.size != l:
-                        raise TypeError("boolean index did not match indexed array")
-                    a = a.nonzero()[0]
-                if not np.issubdtype(a.dtype, np.integer):
-                    raise TypeError("Indexing arrays must have integer dtypes")
-                if array_ix != -1:
-                    raise TypeError("Only one indexing vector or array is currently allowed for fancy indexing")
+            else:
+                arr = np.asarray(a)
+                if arr.ndim != 1:
+                    raise TypeError("Selection can't process %r" % a)
+                a = arr
+                if a.size == 0:
+                    # asarray([]) gives float dtype by default
+                    a = a.astype(np.intp)
 
-                # Convert negative indices to positive
-                if np.any(a < 0):
-                    a = a.copy()
-                    a[a < 0] += l
+            if a.dtype.kind == 'b':
+                if self.rank == 1:
+                    # The dataset machinery should fall back to a faster
+                    # alternative (using PointSelection) in this case.
+                    # https://github.com/h5py/h5py/issues/2189
+                    raise TypeError("Use other code for boolean selection on 1D dataset")
+                if a.size != l:
+                    raise TypeError("boolean index did not match indexed array")
+                a = a.nonzero()[0]
+            if not np.issubdtype(a.dtype, np.integer):
+                raise TypeError("Indexing arrays must have integer dtypes")
+            if array_ix != -1:
+                raise TypeError("Only one indexing vector or array is currently allowed for fancy indexing")
 
-                # Bounds check
-                if np.any((a < 0) | (a > l)):
-                    if l == 0:
-                        msg = "Fancy indexing out of range for empty dimension"
-                    else:
-                        msg = f"Fancy indexing out of range for (0-{l-1})"
-                    raise IndexError(msg)
+            # Convert negative indices to positive
+            if np.any(a < 0):
+                a = a.copy()
+                a[a < 0] += l
 
-                if np.any(np.diff(a) <= 0):
-                    raise TypeError("Indexing elements must be in increasing order")
+            # Bounds check
+            if np.any((a < 0) | (a > l)):
+                if l == 0:
+                    msg = "Fancy indexing out of range for empty dimension"
+                else:
+                    msg = f"Fancy indexing out of range for (0-{l-1})"
+                raise IndexError(msg)
 
-                array_ix = dim_ix
-                array_arg = a
-                self.start[dim_ix] = 0
-                self.stride[dim_ix] = 1
-                self.count[dim_ix] = a.shape[0]
-                self.block[dim_ix] = 1
-                self.scalar[dim_ix] = False
+            if np.any(np.diff(a) <= 0):
+                raise TypeError("Indexing elements must be in increasing order")
 
-                continue
-
-            raise TypeError("Simple selection can't process %r" % a)
+            array_ix = dim_ix
+            array_arg = a
+            self.start[dim_ix] = 0
+            self.stride[dim_ix] = 1
+            self.count[dim_ix] = a.shape[0]
+            self.block[dim_ix] = 1
+            self.scalar[dim_ix] = False
 
         if nargs < self.rank:
             # Fill in ellipsis or trailing dimensions

--- a/h5py/tests/test_selections.py
+++ b/h5py/tests/test_selections.py
@@ -117,6 +117,10 @@ class TestSelection(BaseSelection):
         st2 = sel.select((10,), 1, dset)
         self.assertIsInstance(st2, sel.SimpleSelection)
 
+        # args is str, should be rejected
+        with self.assertRaises(TypeError):
+            sel.select((100,), "foo", dset)
+
         # args is RegionReference, return a Selection instance
         st3 = sel.select((100,100), regref, dset)
         self.assertIsInstance(st3, sel.Selection)

--- a/h5py/tests/test_selections.py
+++ b/h5py/tests/test_selections.py
@@ -105,6 +105,10 @@ class TestSelection(BaseSelection):
         st = sel.select((10,), list([1,2,3]), dset)
         self.assertIsInstance(st, sel.FancySelection)
 
+        # args[0] is tuple, return a FancySelection
+        st = sel.select((10,), ((1, 2, 3),), dset)
+        self.assertIsInstance(st, sel.FancySelection)
+
         # args is a Boolean mask, return a PointSelection
         st1 = sel.select((5,), np.array([True,False,False,False,True]), dset)
         self.assertIsInstance(st1, sel.PointSelection)

--- a/news/fancy-index-seq.rst
+++ b/news/fancy-index-seq.rst
@@ -1,0 +1,31 @@
+New features
+------------
+
+* :ref:`dataset_fancy` now accepts tuples, or any other sequence type, rather
+  than only lists and NumPy arrays. This also includes ``range`` objects,
+  but this will normally be less efficient than the equivalent slice.
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
Including tuples and range objects (though slices should generally be preferred over range). This should match numpy's behaviour more - anything that `asarray()` converts to a 1D array of integers should work.

Still under discussion with @tacaswell, but I think we're leaning this way.

Closes #1757
Closes #1758 
Closes #2118 
Closes #2119