### PR TITLE
Add 'sleep 5' command at end of Travis script stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ install:
 script:
     - if [[ $CIBW_ARCHS == aarch64 ]]; then python3 -m cibuildwheel --output-dir wheelhouse; fi
     - tox $TOX_OPTS
+    - sleep 5
 
 after_success:
     - python ci/upload_coverage.py


### PR DESCRIPTION
Travis support tell me that this could help with the output being cut off when jobs get stuck.