### PR TITLE
FIX: modify existing attributes if track_order is True and type is preserved

### DIFF
--- a/news/modify-attributes.rst
+++ b/news/modify-attributes.rst
@@ -1,0 +1,30 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* Modify existing attributes if `track_order` is True and type is preserved to
+  prevent HDF5 error when deleting/overwriting attribute.
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
This aims to fix #2204.

In the case of `track_order=True` existing attributes are modified instead of overwritten if the type is preserved.

This prevents this HDF5 error https://github.com/HDFGroup/hdf5/issues/1388 where attributes in dense storage can't be deleted.
