### PR TITLE
Try to fix ARM wheel upload error

### DIFF
--- a/ci/upload_wheels.sh
+++ b/ci/upload_wheels.sh
@@ -1,5 +1,12 @@
-ANACONDA_ORG="scipy-wheels-nightly";
-pip install git+https://github.com/Anaconda-Server/anaconda-client;
+set -e
+
+ANACONDA_ORG="scipy-wheels-nightly"
+
+# unclear why conda-package-handling is not on PyPI, but anaconda-client needs
+# it, and anaconda-client on PyPI is *really* old and the devs seem to no longer
+# upload it?
+pip install git+https://github.com/conda/conda-package-handling/
+pip install git+https://github.com/Anaconda-Server/anaconda-client
 
 if [[ "$TRAVIS_EVENT_TYPE" != "cron" && -z "$TRAVIS_TAG" ]] ; then
   echo "Not uploading wheels (build not for cron or git tag)"
@@ -25,5 +32,5 @@ fi
 
 # upload wheels
 if [[ -n "${ANACONDA_ORG_UPLOAD_TOKEN}" ]] ; then
-   anaconda -t ${ANACONDA_ORG_UPLOAD_TOKEN} upload -u ${ANACONDA_ORG} "${TRAVIS_BUILD_DIR}"/wheelhouse/h5py-*.whl;
+   anaconda -t ${ANACONDA_ORG_UPLOAD_TOKEN} upload -u ${ANACONDA_ORG} "${TRAVIS_BUILD_DIR}"/wheelhouse/h5py-*.whl
 fi;


### PR DESCRIPTION
It looks like the ARM wheels have been failing for ~7 months now (based on the uploaded wheels). This does the following to address that:
 * Make the script set -e, so that it errors if any command errors.
 * Add the missing conda-package-handling to hopefully let the script pass.

It's possible that this setup no longer works, and we need to use an alternative to anaconda-client to upload wheels (but it looks like other projects have no issues uploading, so we'll need to see what they do).

<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->
