### PR TITLE
Install anaconda-client 1.9 to fix uploads from Travis

### DIFF
--- a/ci/upload_wheels.sh
+++ b/ci/upload_wheels.sh
@@ -1,5 +1,5 @@
 ANACONDA_ORG="scipy-wheels-nightly";
-pip install git+https://github.com/Anaconda-Server/anaconda-client;
+pip install git+https://github.com/Anaconda-Server/anaconda-client@1.9.0;
 
 if [[ "$TRAVIS_EVENT_TYPE" != "cron" && -z "$TRAVIS_TAG" ]] ; then
   echo "Not uploading wheels (build not for cron or git tag)"


### PR DESCRIPTION
Fixes #2215.

We should be able to see that this installs correctly on the PR, but we'll need to wait for the nightly build to actually upload the wheels.