### PR TITLE
Add collective metadata functions to the low level API

### DIFF
--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -328,7 +328,10 @@ hdf5:
   1.12.1 herr_t H5Pget_file_locking(hid_t fapl_id, hbool_t *use_file_locking, hbool_t *ignore_when_disabled)
   1.10.7-1.10.99 herr_t H5Pset_file_locking(hid_t fapl_id, hbool_t use_file_locking, hbool_t ignore_when_disabled)
   1.12.1 herr_t H5Pset_file_locking(hid_t fapl_id, hbool_t use_file_locking, hbool_t ignore_when_disabled)
-
+  MPI 1.10.0 herr_t H5Pset_all_coll_metadata_ops(hid_t accpl_id, hbool_t is_collective)
+  MPI 1.10.0 herr_t H5Pget_all_coll_metadata_ops(hid_t accpl_id, hbool_t *is_collective)
+  MPI 1.10.0 herr_t H5Pset_coll_metadata_write(hid_t fapl_id, hbool_t is_collective)
+  MPI 1.10.0 herr_t H5Pget_coll_metadata_write(hid_t fapl_id, hbool_t *is_collective)
 
   # Dataset creation
   herr_t        H5Pset_layout(hid_t plist, int layout)

--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -1383,6 +1383,47 @@ cdef class PropFAID(PropInstanceID):
             """
             raise RuntimeError("MPI-POSIX driver is broken; removed in h5py 2.3.1")
 
+        if HDF5_VERSION >= (1, 10, 0):
+
+            @with_phil
+            def set_all_coll_metadata_ops(self, is_collective):
+                """ (BOOL is_collective)
+
+                Sets metadata I/O mode for read operations to collective if
+                is_collective is True or independent if is_collective is False.
+                """
+                H5Pset_all_coll_metadata_ops(self.id, is_collective)
+
+            @with_phil
+            def set_coll_metadata_write(self, is_collective):
+                """ (BOOL is_collective)
+
+                Sets metadata I/O mode for write operations to collective if
+                is_collective is True or independent if is_collective is False.
+                """
+                H5Pset_coll_metadata_write(self.id, is_collective)
+
+            @with_phil
+            def get_all_coll_metadata_ops(self):
+                """ () => BOOL is_collective
+
+                Return True if collective metadata I/O mode for read
+                operations is enabled, or False otherwise.
+                """
+                cdef hbool_t is_collective = 0
+                H5Pget_all_coll_metadata_ops(self.id, &is_collective)
+                return <bint> is_collective
+
+            @with_phil
+            def get_coll_metadata_write(self):
+                """ () => BOOL is_collective
+
+                Return True if collective metadata I/O mode for write
+                operations is enabled, or False otherwise.
+                """
+                cdef hbool_t is_collective = 0
+                H5Pget_coll_metadata_write(self.id, &is_collective)
+                return <bint> is_collective
 
     @with_phil
     def get_mdc_config(self):

--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -1685,6 +1685,28 @@ cdef class PropLAID(PropInstanceID):
             H5Idec_ref(fid)
         return propwrap(fid)
 
+    if MPI and HDF5_VERSION >= (1, 10, 0):
+
+        @with_phil
+        def set_all_coll_metadata_ops(self, is_collective):
+            """ (BOOL is_collective)
+
+            Sets metadata I/O mode for read operations to collective if
+            is_collective is True or independent if is_collective is False.
+            """
+            H5Pset_all_coll_metadata_ops(self.id, is_collective)
+
+        @with_phil
+        def get_all_coll_metadata_ops(self):
+            """ () => BOOL is_collective
+
+            Return True if collective metadata I/O mode for read
+            operations is enabled, or False otherwise.
+            """
+            cdef hbool_t is_collective = 0
+            H5Pget_all_coll_metadata_ops(self.id, &is_collective)
+            return <bint> is_collective
+
 # Datatype creation
 cdef class PropTCID(PropOCID):
     """ Datatype creation property list
@@ -1874,6 +1896,29 @@ cdef class PropDAID(PropInstanceID):
             strcpy(self._efile_prefix_buf, prefix)
 
             H5Pset_efile_prefix(self.id, self._efile_prefix_buf)
+
+    if MPI and HDF5_VERSION >= (1, 10, 0):
+
+        @with_phil
+        def set_all_coll_metadata_ops(self, is_collective):
+            """ (BOOL is_collective)
+
+            Sets metadata I/O mode for read operations to collective if
+            is_collective is True or independent if is_collective is False.
+            """
+            H5Pset_all_coll_metadata_ops(self.id, is_collective)
+
+        @with_phil
+        def get_all_coll_metadata_ops(self):
+            """ () => BOOL is_collective
+
+            Return True if collective metadata I/O mode for read
+            operations is enabled, or False otherwise.
+            """
+            cdef hbool_t is_collective = 0
+            H5Pget_all_coll_metadata_ops(self.id, &is_collective)
+            return <bint> is_collective
+
 
     # === Virtual dataset functions ===========================================
     IF HDF5_VERSION >= VDS_MIN_HDF5_VERSION:

--- a/h5py/tests/test_h5p.py
+++ b/h5py/tests/test_h5p.py
@@ -9,7 +9,7 @@
 
 import unittest as ut
 
-from h5py import h5p, h5f, version
+from h5py import h5p, h5f, version, get_config
 
 from .common import TestCase
 
@@ -133,6 +133,32 @@ class TestFA(TestCase):
         falist.set_file_locking(use_file_locking, ignore_when_disabled)
         self.assertEqual((use_file_locking, ignore_when_disabled),
                          falist.get_file_locking())
+
+    @ut.skipUnless(
+        version.hdf5_version_tuple >= (1, 10, 0) and get_config().mpi,
+        'Requires HDF5 1.10.0 or later and MPI')
+    def test_set_all_coll_metadata_ops(self):
+        """
+        Test get/set collective metadata read mode
+        """
+        falist = h5p.create(h5p.FILE_ACCESS)
+        falist.set_all_coll_metadata_ops(True)
+        self.assertEqual(falist.get_all_coll_metadata_ops(), True)
+        falist.set_all_coll_metadata_ops(False)
+        self.assertEqual(falist.get_all_coll_metadata_ops(), False)
+
+    @ut.skipUnless(
+        version.hdf5_version_tuple >= (1, 10, 0) and get_config().mpi,
+        'Requires HDF5 1.10.0 or later and MPI')
+    def test_set_coll_metadata_write(self):
+        """
+        Test get/set collective metadata write mode
+        """
+        falist = h5p.create(h5p.FILE_ACCESS)
+        falist.set_coll_metadata_write(True)
+        self.assertEqual(falist.get_coll_metadata_write(), True)
+        falist.set_coll_metadata_write(False)
+        self.assertEqual(falist.get_coll_metadata_write(), False)
 
 
 class TestPL(TestCase):

--- a/h5py/tests/test_h5p.py
+++ b/h5py/tests/test_h5p.py
@@ -134,32 +134,6 @@ class TestFA(TestCase):
         self.assertEqual((use_file_locking, ignore_when_disabled),
                          falist.get_file_locking())
 
-    @ut.skipUnless(
-        version.hdf5_version_tuple >= (1, 10, 0) and get_config().mpi,
-        'Requires HDF5 1.10.0 or later and MPI')
-    def test_set_all_coll_metadata_ops(self):
-        """
-        Test get/set collective metadata read mode
-        """
-        falist = h5p.create(h5p.FILE_ACCESS)
-        falist.set_all_coll_metadata_ops(True)
-        self.assertEqual(falist.get_all_coll_metadata_ops(), True)
-        falist.set_all_coll_metadata_ops(False)
-        self.assertEqual(falist.get_all_coll_metadata_ops(), False)
-
-    @ut.skipUnless(
-        version.hdf5_version_tuple >= (1, 10, 0) and get_config().mpi,
-        'Requires HDF5 1.10.0 or later and MPI')
-    def test_set_coll_metadata_write(self):
-        """
-        Test get/set collective metadata write mode
-        """
-        falist = h5p.create(h5p.FILE_ACCESS)
-        falist.set_coll_metadata_write(True)
-        self.assertEqual(falist.get_coll_metadata_write(), True)
-        falist.set_coll_metadata_write(False)
-        self.assertEqual(falist.get_coll_metadata_write(), False)
-
 
 class TestPL(TestCase):
     def test_obj_track_times(self):
@@ -225,3 +199,70 @@ class TestPL(TestCase):
         # for a single attribute in compact attribute storage.
         cid.set_attr_phase_change(0, 0)
         self.assertEqual((0,0), cid.get_attr_phase_change())
+
+class TestDACollectiveMetadata(TestCase):
+    '''
+    Feature: setting/getting collective metadata on a dataset access property list
+    '''
+
+    @ut.skipUnless(
+        version.hdf5_version_tuple >= (1, 10, 0) and get_config().mpi,
+        'Requires HDF5 1.10.0 or later and MPI')
+    def test_set_all_coll_metadata_ops(self):
+        """
+        Test get/set collective metadata read mode
+        """
+        dalist = h5p.create(h5p.DATASET_ACCESS)
+        dalist.set_all_coll_metadata_ops(True)
+        self.assertEqual(dalist.get_all_coll_metadata_ops(), True)
+        dalist.set_all_coll_metadata_ops(False)
+        self.assertEqual(dalist.get_all_coll_metadata_ops(), False)
+
+class TestLACollectiveMetadata(TestCase):
+    '''
+    Feature: setting/getting collective metadata on a link access property list
+    '''
+
+    @ut.skipUnless(
+        version.hdf5_version_tuple >= (1, 10, 0) and get_config().mpi,
+        'Requires HDF5 1.10.0 or later and MPI')
+    def test_set_all_coll_metadata_ops(self):
+        """
+        Test get/set collective metadata read mode
+        """
+        lalist = h5p.create(h5p.LINK_ACCESS)
+        lalist.set_all_coll_metadata_ops(True)
+        self.assertEqual(lalist.get_all_coll_metadata_ops(), True)
+        lalist.set_all_coll_metadata_ops(False)
+        self.assertEqual(lalist.get_all_coll_metadata_ops(), False)
+
+class TestFACollectiveMetadata(TestCase):
+    '''
+    Feature: setting/getting collective metadata on a file access property list
+    '''
+
+    @ut.skipUnless(
+        version.hdf5_version_tuple >= (1, 10, 0) and get_config().mpi,
+        'Requires HDF5 1.10.0 or later and MPI')
+    def test_set_all_coll_metadata_ops(self):
+        """
+        Test get/set collective metadata read mode
+        """
+        falist = h5p.create(h5p.FILE_ACCESS)
+        falist.set_all_coll_metadata_ops(True)
+        self.assertEqual(falist.get_all_coll_metadata_ops(), True)
+        falist.set_all_coll_metadata_ops(False)
+        self.assertEqual(falist.get_all_coll_metadata_ops(), False)
+
+    @ut.skipUnless(
+        version.hdf5_version_tuple >= (1, 10, 0) and get_config().mpi,
+        'Requires HDF5 1.10.0 or later and MPI')
+    def test_set_coll_metadata_write(self):
+        """
+        Test get/set collective metadata write mode
+        """
+        falist = h5p.create(h5p.FILE_ACCESS)
+        falist.set_coll_metadata_write(True)
+        self.assertEqual(falist.get_coll_metadata_write(), True)
+        falist.set_coll_metadata_write(False)
+        self.assertEqual(falist.get_coll_metadata_write(), False)

--- a/news/collective_metadata.rst
+++ b/news/collective_metadata.rst
@@ -1,0 +1,32 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* [`H5Pset_all_coll_metadata_ops`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_ALL_COLL_METADATA_OPS)
+* [`H5Pget_all_coll_metadata_ops`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_ALL_COLL_METADATA_OPS)
+* [`H5Pset_coll_metadata_write`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_COLL_METADATA_WRITE)
+* [`H5Pget_coll_metadata_write`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_COLL_METADATA_WRITE)
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
I'd like to add the following functions to the low level API:

  * H5Pset_all_coll_metadata_ops()
  * H5Pget_all_coll_metadata_ops
  * H5Pset_coll_metadata_write()
  * H5Pset_coll_metadata_write()

For context: I'm using h5py on a  HPC cluster to process simulation outputs stored as HDF5. The code is distributed over multiple compute nodes which have 128 cores each.  In order to make use of all of the cpu cores I run python using mpi4py with one process per core. I'm using collective I/O to read the input simulation data and write out the results.

This puts quite a load on the Lustre parallel file system, and I think it's probably because every process accesses the files independently for metadata operations. I'm hoping that can be alleviated by having HDF5 do all file access in collective mode so that only a few processes per node need to access the file system.

For my use case I just need to put the whole file in collective metadata mode. To do that I've added get/set_all_coll_metadata_ops() and get/set_coll_metadata_write() methods to h5p.PropFAID. The HDF5 documentation says that H5Pset_all_coll_metadata_ops() can also be called on group, dataset, datatype, link, or attribute access property lists. Of those I think h5py only exposes link and dataset access property lists so I also added get/set_all_coll_metadata_ops() to h5p.PropLAID and h5p.PropDAID.