### PR TITLE
Bump minimum mpi4py version to 3.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,10 +43,10 @@ RUN_REQUIRES = [
 SETUP_REQUIRES = []
 
 if setup_configure.mpi_enabled():
-    RUN_REQUIRES.append('mpi4py >=3.0.2')
-    SETUP_REQUIRES.append("mpi4py ==3.0.2; python_version<'3.8'")
-    SETUP_REQUIRES.append("mpi4py ==3.0.3; python_version=='3.8.*'")
-    SETUP_REQUIRES.append("mpi4py ==3.1.0; python_version=='3.9.*' or python_version=='3.10.*'")
+    # mpi4py 3.1.1 fixed a typo in python_requires, which made older versions
+    # incompatible with newer setuptools.
+    RUN_REQUIRES.append('mpi4py >=3.1.1')
+    SETUP_REQUIRES.append("mpi4py ==3.1.1; python_version<'3.11'")
     SETUP_REQUIRES.append("mpi4py ==3.1.4; python_version>='3.11'")
 
 # Set the environment variable H5PY_SETUP_REQUIRES=0 if we need to skip

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
 
     mindeps: oldest-supported-numpy
 
-    mpi4py: mpi4py>=3.0.2
+    mpi4py: mpi4py>=3.1.1
 
     tables-deps: tables>=3.4.4
     tables-mindeps: tables==3.4.4


### PR DESCRIPTION
Closes #2222.

mpi4py 3.1.1 was released in August 2021. Anyone who needs to use h5py with an older version of mpi4py would need to fiddle about with the `--no-build-isolation` flag to pip to build with an older version, and then override the runtime dependency or suppress it with `--no-deps`.

Do we need to do a 3.8.1 release to fix #2222 for people using h5py + mpi4py?