### PR TITLE
Adding `h5z.register_filter` wrapper of `H5zregister`

### DIFF
--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -586,6 +586,7 @@ hdf5:
 
   htri_t    H5Zfilter_avail(H5Z_filter_t id_)
   herr_t    H5Zget_filter_info(H5Z_filter_t filter_, unsigned int *filter_config_flags)
+  herr_t    H5Zregister(const void *cls)
   herr_t    H5Zunregister(H5Z_filter_t id_)
 
 hdf5_hl:

--- a/h5py/api_types_hdf5.pxd
+++ b/h5py/api_types_hdf5.pxd
@@ -776,6 +776,7 @@ cdef extern from "hdf5.h":
 
   ctypedef int H5Z_filter_t
 
+  int H5Z_CLASS_T_VERS
   int H5Z_FILTER_ERROR
   int H5Z_FILTER_NONE
   int H5Z_FILTER_ALL

--- a/h5py/h5z.pyx
+++ b/h5py/h5z.pyx
@@ -102,8 +102,19 @@ def get_filter_info(int filter_code):
 def register_filter(Py_ssize_t cls_pointer_address):
     '''(INT cls_pointer_address) => BOOL
 
-    Register a new filter from a memory address pointing a buffer containing a
-    `H5Z_class1_t` or `H5Z_class2_t` data structure describing the filter.
+    Register a new filter from the memory address of a buffer containing a
+    ``H5Z_class1_t`` or ``H5Z_class2_t`` data structure describing the filter.
+
+    `cls_pointer_address` can be retrieved from a HDF5 filter plugin dynamic
+    library::
+
+        import ctypes
+
+        filter_clib = ctypes.CDLL("/path/to/my_hdf5_filter_plugin.so")
+        filter_clib.H5PLget_plugin_info.restype = ctypes.c_void_p
+
+        h5py.h5z.register_filter(filter_clib.H5PLget_plugin_info())
+
     '''
     return <int>H5Zregister(<const void *>cls_pointer_address) >= 0
 

--- a/h5py/h5z.pyx
+++ b/h5py/h5z.pyx
@@ -16,6 +16,8 @@ from ._objects import phil, with_phil
 
 # === Public constants and data structures ====================================
 
+CLASS_T_VERS = H5Z_CLASS_T_VERS
+
 FILTER_LZF = H5PY_FILTER_LZF
 
 FILTER_ERROR    = H5Z_FILTER_ERROR

--- a/h5py/h5z.pyx
+++ b/h5py/h5z.pyx
@@ -97,6 +97,16 @@ def get_filter_info(int filter_code):
 
 
 @with_phil
+def register_filter(Py_ssize_t cls_pointer_address):
+    '''(INT cls_pointer_address) => BOOL
+
+    Register a new filter from a memory address pointing a buffer containing a
+    `H5Z_class1_t` or `H5Z_class2_t` data structure describing the filter.
+    '''
+    return <int>H5Zregister(<const void *>cls_pointer_address) >= 0
+
+
+@with_phil
 def unregister_filter(int filter_code):
     '''(INT filter_code) => BOOL
 

--- a/h5py/tests/test_filters.py
+++ b/h5py/tests/test_filters.py
@@ -14,9 +14,8 @@
 import os
 import numpy as np
 import h5py
-import pytest
 
-from .common import ut, TestCase, insubprocess
+from .common import ut, TestCase
 
 
 class TestFilters(TestCase):
@@ -85,14 +84,6 @@ def test_filter_ref_obj_eq():
 
     assert gzip8 == h5py.filters.Gzip(level=8)
     assert gzip8 != h5py.filters.Gzip(level=7)
-
-
-@pytest.mark.mpi_skip
-@insubprocess
-def test_unregister_filter(request):
-    if h5py.h5z.filter_avail(h5py.h5z.FILTER_LZF):
-        res = h5py.h5z.unregister_filter(h5py.h5z.FILTER_LZF)
-        assert res
 
 
 @ut.skipIf(not os.getenv('H5PY_TEST_CHECK_FILTERS'),  "H5PY_TEST_CHECK_FILTERS not set")

--- a/h5py/tests/test_h5z.py
+++ b/h5py/tests/test_h5z.py
@@ -9,11 +9,14 @@ from ctypes import (
     POINTER,
     Structure,
 )
-
+import pytest
+import h5py
 from h5py import h5z
 
+from .common import insubprocess
 
-# Type of dilter callback function of H5Z_class2_t
+
+# Type of filter callback function of H5Z_class2_t
 H5ZFuncT = CFUNCTYPE(
     c_long,  # restype
     # argtypes
@@ -72,3 +75,11 @@ def test_register_filter():
         h5z.unregister_filter(filter_id)
 
     assert not h5z.filter_avail(filter_id)
+
+
+@pytest.mark.mpi_skip
+@insubprocess
+def test_unregister_filter(request):
+    if h5py.h5z.filter_avail(h5py.h5z.FILTER_LZF):
+        res = h5py.h5z.unregister_filter(h5py.h5z.FILTER_LZF)
+        assert res

--- a/h5py/tests/test_h5z.py
+++ b/h5py/tests/test_h5z.py
@@ -1,0 +1,73 @@
+from ctypes import (
+    addressof,
+    c_char_p,
+    c_int,
+    c_long,
+    c_uint,
+    c_void_p,
+    CFUNCTYPE,
+    POINTER,
+    Structure,
+)
+
+from h5py import h5z
+
+
+# Type of dilter callback function of H5Z_class2_t
+H5ZFuncT = CFUNCTYPE(
+    c_long,  # restype
+    # argtypes
+    c_uint,  # flags
+    c_long,  # cd_nelemts
+    POINTER(c_uint),  # cd_values
+    c_long,  # nbytes
+    POINTER(c_long),  # buf_size
+    POINTER(c_void_p),  # buf
+)
+
+
+class H5ZClass2T(Structure):
+    """H5Z_class2_t structure defining a filter"""
+
+    _fields_ = [
+        ("version", c_int),
+        ("id_", c_int),
+        ("encoder_present", c_uint),
+        ("decoder_present", c_uint),
+        ("name", c_char_p),
+        ("can_apply", c_void_p),
+        ("set_local", c_void_p),
+        ("filter_", H5ZFuncT),
+    ]
+
+
+def test_register_filter():
+    filter_id = 256  # Test ID
+
+    @H5ZFuncT
+    def failing_filter_callback(flags, cd_nelemts, cd_values, nbytes, buf_size, buf):
+        return 0
+
+    dummy_filter_class = H5ZClass2T(
+        version=h5z.CLASS_T_VERS,
+        id_=filter_id,
+        encoder_present=1,
+        decoder_present=1,
+        name=b"dummy filter",
+        can_apply=None,
+        set_local=None,
+        filter_=failing_filter_callback,
+    )
+
+    h5z.register_filter(addressof(dummy_filter_class))
+
+    assert h5z.filter_avail(filter_id)
+    filter_flags = h5z.get_filter_info(filter_id)
+    assert (
+        filter_flags
+        == h5z.FILTER_CONFIG_ENCODE_ENABLED | h5z.FILTER_CONFIG_DECODE_ENABLED
+    )
+
+    h5z.unregister_filter(filter_id)
+
+    assert not h5z.filter_avail(filter_id)

--- a/h5py/tests/test_h5z.py
+++ b/h5py/tests/test_h5z.py
@@ -61,13 +61,14 @@ def test_register_filter():
 
     h5z.register_filter(addressof(dummy_filter_class))
 
-    assert h5z.filter_avail(filter_id)
-    filter_flags = h5z.get_filter_info(filter_id)
-    assert (
-        filter_flags
-        == h5z.FILTER_CONFIG_ENCODE_ENABLED | h5z.FILTER_CONFIG_DECODE_ENABLED
-    )
-
-    h5z.unregister_filter(filter_id)
+    try:
+        assert h5z.filter_avail(filter_id)
+        filter_flags = h5z.get_filter_info(filter_id)
+        assert (
+            filter_flags
+            == h5z.FILTER_CONFIG_ENCODE_ENABLED | h5z.FILTER_CONFIG_DECODE_ENABLED
+        )
+    finally:
+        h5z.unregister_filter(filter_id)
 
     assert not h5z.filter_avail(filter_id)

--- a/news/h5z_register_filter.rst
+++ b/news/h5z_register_filter.rst
@@ -1,0 +1,29 @@
+New features
+------------
+
+* Low-level ``h5z.register_filter`` function that allows to register a HDF5 filter.
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* ``H5Zregister``
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
This PR proposes to provide access to `H5Zregister` through `h5z.register_filter` function which takes as single parameter the memory address of the structure defining the filter.

It also adds a basic test of registering/unregistering a dummy filter defined from Python.

closes #2228
