### PR TITLE
Dataset direct chunk read to user provided buffer

### DIFF
--- a/h5py/tests/test_h5d_direct_chunk.py
+++ b/h5py/tests/test_h5d_direct_chunk.py
@@ -170,3 +170,31 @@ class TestReadDirectChunkToBuffer:
         assert filter_mask == chunk_info.filter_mask
         assert nbytes == chunk_info.size
         assert out == dataset.id.read_direct_chunk(chunk_info.chunk_offset)[1]
+
+    def test_fail_buffer_too_small(self, writable_file):
+        ref_data = numpy.arange(16).reshape(4, 4)
+        dataset = writable_file.create_dataset(
+            "uncompressed", data=ref_data, chunks=ref_data.shape)
+
+        out = bytearray(ref_data.nbytes // 2)
+        with pytest.raises(ValueError):
+            dataset.id.read_direct_chunk_tobuffer((0, 0), out)
+
+    def test_fail_buffer_readonly(self, writable_file):
+        ref_data = numpy.arange(16).reshape(4, 4)
+        dataset = writable_file.create_dataset(
+            "uncompressed", data=ref_data, chunks=ref_data.shape)
+
+        out = bytes(ref_data.nbytes // 2)
+        with pytest.raises(BufferError):
+            dataset.id.read_direct_chunk_tobuffer((0, 0), out)
+
+    def test_fail_buffer_not_contiguous(self, writable_file):
+        ref_data = numpy.arange(16).reshape(4, 4)
+        dataset = writable_file.create_dataset(
+            "uncompressed", data=ref_data, chunks=ref_data.shape)
+
+        array = numpy.empty(ref_data.shape + (2,), dtype=ref_data.dtype)
+        out = array[:, :, ::2]  # Array is not contiguous
+        with pytest.raises(ValueError):
+            dataset.id.read_direct_chunk_tobuffer((0, 0), out)

--- a/h5py/tests/test_h5d_direct_chunk.py
+++ b/h5py/tests/test_h5d_direct_chunk.py
@@ -1,6 +1,7 @@
 import h5py
 import numpy
 import numpy.testing
+import pytest
 
 from .common import ut, TestCase
 
@@ -113,3 +114,59 @@ class TestReadDirectChunk(TestCase):
         with h5py.File(filename, "r") as filehandle:
             dataset = filehandle["created"][...]
             numpy.testing.assert_array_equal(dataset, frame)
+
+
+@pytest.mark.skipif(
+    h5py.version.hdf5_version_tuple < (1, 10, 2),
+    reason="Direct chunk read requires HDF5 >= 1.10.2"
+)
+class TestReadDirectChunkToBuffer:
+
+    def test_uncompressed_data(self, writable_file):
+        ref_data = numpy.arange(16).reshape(4, 4)
+        dataset = writable_file.create_dataset(
+            "uncompressed", data=ref_data, chunks=ref_data.shape)
+
+        # Read to numpy array
+        out_ndarray = numpy.zeros_like(ref_data)
+        filter_mask, nbytes = dataset.id.read_direct_chunk_tobuffer((0, 0), out_ndarray)
+
+        assert numpy.array_equal(out_ndarray, ref_data)
+        assert filter_mask == 0
+        assert nbytes == ref_data.nbytes
+
+        # Read to bytearray
+        out_bytearray = bytearray(ref_data.nbytes)
+        filter_mask, nbytes = dataset.id.read_direct_chunk_tobuffer((0, 0), out_bytearray)
+
+        assert numpy.array_equal(
+            numpy.frombuffer(out_bytearray, dtype=ref_data.dtype).reshape(ref_data.shape),
+            ref_data,
+        )
+        assert filter_mask == 0
+        assert nbytes == ref_data.nbytes
+
+    @pytest.mark.skipif(
+        h5py.version.hdf5_version_tuple < (1, 10, 5),
+        reason="chunk info requires HDF5 >= 1.10.5",
+    )
+    def test_compressed_data(self, writable_file):
+        ref_data = numpy.arange(16).reshape(4, 4)
+        dataset = writable_file.create_dataset(
+            "gzip",
+            data=ref_data,
+            chunks=ref_data.shape,
+            compression="gzip",
+            compression_opts=9,
+        )
+        chunk_info = dataset.id.get_chunk_info(0)
+
+        # read to bytearray
+        out = bytearray(chunk_info.size)
+        filter_mask, nbytes = dataset.id.read_direct_chunk_tobuffer(
+            chunk_info.chunk_offset,
+            out,
+        )
+        assert filter_mask == chunk_info.filter_mask
+        assert nbytes == chunk_info.size
+        assert out == dataset.id.read_direct_chunk(chunk_info.chunk_offset)[1]

--- a/h5py/tests/test_h5d_direct_chunk.py
+++ b/h5py/tests/test_h5d_direct_chunk.py
@@ -141,6 +141,10 @@ class TestReadDirectChunkToOut:
         h5py.version.hdf5_version_tuple < (1, 10, 5),
         reason="chunk info requires HDF5 >= 1.10.5",
     )
+    @pytest.mark.skipif(
+        'gzip' not in h5py.filters.encode,
+        reason="DEFLATE is not installed",
+    )
     def test_compressed_data(self, writable_file):
         ref_data = numpy.arange(16).reshape(4, 4)
         dataset = writable_file.create_dataset(

--- a/news/datasetid_read_chunk_out_argument.rst
+++ b/news/datasetid_read_chunk_out_argument.rst
@@ -1,7 +1,7 @@
 New features
 ------------
 
-* <news item>
+* New ``out`` argument to :func:`h5d.read_direct_chunk` to allow passing the output buffer.
 
 Deprecations
 ------------
@@ -11,8 +11,7 @@ Deprecations
 Exposing HDF5 functions
 -----------------------
 
-* ``H5Dread_chunk`` exposed with a new wrapper :func:`h5d.read_direct_chunk_tobuffer`
-  to allow passing the output buffer.
+* <news item>
 
 Bug fixes
 ---------

--- a/news/datasetid_read_chunk_to_buffer.rst
+++ b/news/datasetid_read_chunk_to_buffer.rst
@@ -1,0 +1,30 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* ``H5Dread_chunk`` exposed with a new wrapper :func:`h5d.read_direct_chunk_tobuffer`
+  to allow passing the output buffer.
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
This PR proposes to add a new method `DatasetID.read_direct_chunk_tobuffer` which allows to read a chunk  directly in a user provided object supporting Python [buffer protocol](https://docs.python.org/3/c-api/buffer.html). As opposed to `DatasetID.read_direct_chunk_tobuffer`, it spares a memory copy and enables the caller to provide its own buffer.

An alternative could be to extend `DatasetID.read_direct_chunk` with an extra `out=None` argument which can take a buffer as input.
We tried a few things:

- Returning the number of bytes read if `out` is not None: [here](https://github.com/jonwright/h5py/blob/3d067e8d911517db1d3cc5e141a457a119a729c1/h5py/h5d.pyx#L520-L594).
  The down side is that the returned type changes depending on the inputs.
- Returning a ndarray "view" on the out buffer: [here](https://github.com/jonwright/h5py/blob/db004d834f415cc4f7b5622c6904cbda7701ab46/h5py/h5d.pyx#L527-L602).
  The down side is that it is slower because it allocates more Python objects and anyway does not returns the same types.


Here is a quick&dirty performance comparison reading chunks from the [kevlar.h5](http://www.silx.org/pub/pyFAI/pyFAI_UM_2020/data_ID13/kevlar.h5) file with the script below:

```
read_direct_chunk_tobuffer: 0.17198193189688027s
read_direct_chunk: 0.25807333388365805s
```

<details>
<summary>Test script</summary>

```python
import h5py
import timeit

with h5py.File("kevlar.h5", "r") as h5f:
    dataset = h5f["entry/data/data"]
    out = bytearray(dataset.nbytes // len(dataset))
    t0 = timeit.default_timer()
    for index in range(len(dataset)):
        dataset.id.read_direct_chunk_tobuffer((index, 0, 0), out)
    dt = timeit.default_timer() - t0
    print(f"read_direct_chunk_tobuffer: {dt}s")

with h5py.File("kevlar.h5", "r") as h5f:
    dataset = h5f["entry/data/data"]
    t0 = timeit.default_timer()
    for index in range(len(dataset)):
        dataset.id.read_direct_chunk((index, 0, 0))
    dt = timeit.default_timer() - t0
    print(f"read_direct_chunk: {dt}s")
```

</details>

This was initiated by @jonwright and we worked together on this proposition.

closes #2231
