### PR TITLE
Remove support for using dset.astype() as a context manager

### DIFF
--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -503,12 +503,8 @@ Reference
             >>> out.dtype
             dtype('int16')
 
-        .. versionchanged:: 3.0
-           Allowed reading through the wrapper object. In earlier versions,
-           :meth:`astype` had to be used as a context manager:
-
-               >>> with dset.astype('int16'):
-               ...     out = dset[:]
+        .. versionchanged:: 3.9
+           :meth:`astype` can no longer be used as a context manager.
 
     .. method:: asstr(encoding=None, errors='strict')
 

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1569,21 +1569,6 @@ class TestRegionRefs(BaseDataset):
 class TestAstype(BaseDataset):
     """.astype() wrapper & context manager
     """
-    def test_astype_ctx(self):
-        dset = self.f.create_dataset('x', (100,), dtype='i2')
-        dset[...] = np.arange(100)
-
-        with warnings.catch_warnings(record=True) as warn_rec:
-            warnings.simplefilter("always")
-
-            with dset.astype('f8'):
-                self.assertArrayEqual(dset[...], np.arange(100, dtype='f8'))
-
-            with dset.astype('f4') as f4ds:
-                self.assertArrayEqual(f4ds[...], np.arange(100, dtype='f4'))
-
-        assert [w.category for w in warn_rec] == [H5pyDeprecationWarning] * 2
-
     def test_astype_wrapper(self):
         dset = self.f.create_dataset('x', (100,), dtype='i2')
         dset[...] = np.arange(100)

--- a/news/rm-astype-ctx.rst
+++ b/news/rm-astype-ctx.rst
@@ -1,0 +1,31 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* Using :meth:Dataset.astype` as a context manager has been removed, after being
+  deprecated in h5py 3.6. Read data by slicing the returned object instead:
+  ``dset.astype('f4')[:]``.
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
Finally removing a wart that I've been planning to get rid of for years, the use of a thread-local variable in the dataset class.

We added and recommended the new way of using this (`dset.astype('f4')[:]`) in 3.0, released October 2020. We added a deprecation warning for the context manager (`with dset.astype('f4'):`) in 3.6, released November 2021 (PR #1842).