### PR TITLE
Try to fix codecov for pull requests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,7 +56,7 @@ test_script:
   # Note that you must use the environment variable %PYTHON% to refer to
   # the interpreter you're using - Appveyor does not do anything special
   # to put the Python evrsion you want to use on PATH.
-  - "py -3.8 -m tox -v"
+  - "py -3.8 -m tox run --discover %PYTHON%\\python.exe"
 
 # This is commented out as there's no easy way to deal with numpy dropping
 # older python versions without a recent pip/setuptools.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,10 +44,10 @@ environment:
 install:
   # We need wheel installed to build wheels
   - "%PYTHON%\\python.exe -m pip install --upgrade wheel pip setuptools"
-  - "py -3.6 -m pip install --upgrade wheel pip setuptools virtualenv"
-  - "py -3.6 -m pip install requests"
-  - "py -3.6 ci\\get_hdf5_win.py"
-  - "py -3.6 -m pip install tox codecov tox-appveyor"
+  - "py -3.8 -m pip install --upgrade wheel pip setuptools virtualenv"
+  - "py -3.8 -m pip install requests"
+  - "py -3.8 ci\\get_hdf5_win.py"
+  - "py -3.8 -m pip install tox codecov tox-appveyor"
 
 build: off
 
@@ -56,7 +56,7 @@ test_script:
   # Note that you must use the environment variable %PYTHON% to refer to
   # the interpreter you're using - Appveyor does not do anything special
   # to put the Python evrsion you want to use on PATH.
-  - "py -3.6 -m tox -v"
+  - "py -3.8 -m tox -v"
 
 # This is commented out as there's no easy way to deal with numpy dropping
 # older python versions without a recent pip/setuptools.
@@ -75,4 +75,4 @@ cache:
 on_success:
   # Specify the commit explicitly, otherwise codecov 'fixes' the merge commit on
   # PR builds to the head commit, unlike the uploads on other services.
-  - "py -3.6 ci\\upload_coverage.py --commit %APPVEYOR_REPO_COMMIT%"
+  - "py -3.8 ci\\upload_coverage.py --commit %APPVEYOR_REPO_COMMIT%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,6 +73,4 @@ cache:
   - "C:\\hdf5"
 
 on_success:
-  # Specify the commit explicitly, otherwise codecov 'fixes' the merge commit on
-  # PR builds to the head commit, unlike the uploads on other services.
-  - "py -3.8 ci\\upload_coverage.py --commit %APPVEYOR_REPO_COMMIT%"
+  - "py -3.8 ci\\upload_coverage.py"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,7 +47,7 @@ install:
   - "py -3.8 -m pip install --upgrade wheel pip setuptools virtualenv"
   - "py -3.8 -m pip install requests"
   - "py -3.8 ci\\get_hdf5_win.py"
-  - "py -3.8 -m pip install tox codecov tox-appveyor"
+  - "py -3.8 -m pip install tox codecov"
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,4 +73,6 @@ cache:
   - "C:\\hdf5"
 
 on_success:
-  - "py -3.6 ci\\upload_coverage.py"
+  # Specify the commit explicitly, otherwise codecov 'fixes' the merge commit on
+  # PR builds to the head commit, unlike the uploads on other services.
+  - "py -3.6 ci\\upload_coverage.py --commit %APPVEYOR_REPO_COMMIT%"

--- a/ci/upload_coverage.py
+++ b/ci/upload_coverage.py
@@ -65,7 +65,7 @@ def run_with_python(args, timeout=30, **kwargs):
         raise CalledProcessError(retcode, cmd)
 
 
-def send_coverage(*, workdir, coverage_files, codecov_token):
+def send_coverage(*, workdir, coverage_files, codecov_token, commit=None):
     chdir(workdir)
     run_with_python(['coverage', 'combine'] + coverage_files)
     msg(f"Combined coverage")
@@ -77,13 +77,17 @@ def send_coverage(*, workdir, coverage_files, codecov_token):
     if codecov_token is not None:
         codecov_args.extend(['-t', codecov_token])
     codecov_args.extend(['--file', 'coverage.xml'])
+    if commit is not None:
+        codecov_args.extend(['--commit', commit])
     run_with_python(['codecov'] + codecov_args)
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--codecov-token", default=None)
+    parser.add_argument("--commit")
     args = parser.parse_args()
+
     msg(f"Working in {GIT_MAIN_DIR}, looking for coverage files...")
     coverage_files = [str(f) for f in COVERAGE_DIR.glob('coverage-*')]
     pmsg(sorted(coverage_files))
@@ -92,6 +96,7 @@ def main():
             workdir=GIT_MAIN_DIR,
             coverage_files=coverage_files,
             codecov_token=args.codecov_token,
+            commit=args.commit,
         )
     else:
         msg("No coverage files found")

--- a/ci/upload_coverage.py
+++ b/ci/upload_coverage.py
@@ -4,6 +4,7 @@ Written in python to be cross-platform
 """
 
 import argparse
+import os
 from os import chdir, environ
 from pathlib import Path
 import platform
@@ -65,6 +66,16 @@ def run_with_python(args, timeout=30, **kwargs):
         raise CalledProcessError(retcode, cmd)
 
 
+def get_pr_azure_ci():
+    # Get pull request number on Azure Pipelines
+    # Return None if not on Azure or not a PR build.
+    return (
+        os.environ.get('SYSTEM_PULLREQUEST_PULLREQUESTNUMBER')
+        or os.environ.get('SYSTEM_PULLREQUEST_PULLREQUESTID')
+        or None
+    )
+
+
 def send_coverage(*, workdir, coverage_files, codecov_token):
     chdir(workdir)
     run_with_python(['coverage', 'combine'] + coverage_files)
@@ -77,6 +88,9 @@ def send_coverage(*, workdir, coverage_files, codecov_token):
     if codecov_token is not None:
         codecov_args.extend(['-t', codecov_token])
     codecov_args.extend(['--file', 'coverage.xml'])
+    pr_num = get_pr_azure_ci()
+    if pr_num is not None:
+        codecov_args.extend(['--pr', pr_num])
     run_with_python(['codecov'] + codecov_args)
 
 

--- a/ci/upload_coverage.py
+++ b/ci/upload_coverage.py
@@ -65,7 +65,7 @@ def run_with_python(args, timeout=30, **kwargs):
         raise CalledProcessError(retcode, cmd)
 
 
-def send_coverage(*, workdir, coverage_files, codecov_token, commit=None):
+def send_coverage(*, workdir, coverage_files, codecov_token):
     chdir(workdir)
     run_with_python(['coverage', 'combine'] + coverage_files)
     msg(f"Combined coverage")
@@ -77,15 +77,12 @@ def send_coverage(*, workdir, coverage_files, codecov_token, commit=None):
     if codecov_token is not None:
         codecov_args.extend(['-t', codecov_token])
     codecov_args.extend(['--file', 'coverage.xml'])
-    if commit is not None:
-        codecov_args.extend(['--commit', commit])
     run_with_python(['codecov'] + codecov_args)
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--codecov-token", default=None)
-    parser.add_argument("--commit")
     args = parser.parse_args()
 
     msg(f"Working in {GIT_MAIN_DIR}, looking for coverage files...")
@@ -96,7 +93,6 @@ def main():
             workdir=GIT_MAIN_DIR,
             coverage_files=coverage_files,
             codecov_token=args.codecov_token,
-            commit=args.commit,
         )
     else:
         msg("No coverage files found")

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,8 +3,6 @@ coverage:
     project:
       default:
         threshold: 0.5%
-  notify:
-    after_n_builds: 10
 # do not notify until at least 5 builds have been uploaded from the CI pipeline
 # you can also set after_n_builds on comments independently
 comment:


### PR DESCRIPTION
I realised while poking around codecov that it was seeing a mixture of reports uploaded for the PR, some of which were associated with the *merge* commit and some with the *head* commit. In particular, the Azure builds send reports for the merge commit, and the Appveyor builds (which test on 32-bit Windows) send them for the merge commit, even though they're testing the merge commit.

I think I've found a workaround to send Appveyor coverage reports for the merge commit. Hopefully this will make the coverage change report on PRs more accurate.

While I was looking at this, I also discovered that the codecov config file was invalid, and I updated the Appveyor config to use Python 3.8 as the 'outer' Python that installs and runs tox.