### PR TITLE
Update zlib to 1.2.13 for Mac wheels

### DIFF
--- a/ci/configure_hdf5_mac.sh
+++ b/ci/configure_hdf5_mac.sh
@@ -9,9 +9,7 @@ function set_compiler_vars() {
 
 
 function build_zlib() {
-    ZLIB_VERSION="1.2.12"
-    # export needed to fix 1.2.12. Next release won't need the export (madler/zlib#615)
-    export cc=$CC
+    ZLIB_VERSION="1.2.13"
 
     pushd /tmp
     curl -sLO https://zlib.net/fossils/zlib-$ZLIB_VERSION.tar.gz


### PR DESCRIPTION
This is not needed for the security fix (see discussion in #2254), but we may as well do it anyway.