### PR TITLE
Bump minimum required Python to 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,25 +26,23 @@ jobs:
     # TODO: We should see if we can replace this with installing python via pyenv # based on toxenv
     # Test on ppc64le
     - arch: ppc64le
-      python: 3.7
+      python: 3.9
       env:
-      - TOXENV=py37-test-deps
-      # NumPy 1.21.5 fails to compile: https://github.com/numpy/numpy/issues/20761
-      - TOX_OPTS="--force-dep numpy!=1.21.5"
+      - TOXENV=py39-test-deps
       - HDF5_VERSION=1.10.5
       - HDF5_DIR=$HDF5_CACHE_DIR/$HDF5_VERSION
       - H5PY_ENFORCE_COVERAGE=yes
     - arch: arm64
       services: docker
-      python: 3.7
+      python: 3.9
       virt: vm
       env:
-        - TOXENV=py37-test-deps
+        - TOXENV=py39-test-deps
         - TOX_OPTS=""
         - HDF5_VERSION=1.10.5
         - HDF5_DIR=$HDF5_CACHE_DIR/$HDF5_VERSION
         - H5PY_ENFORCE_COVERAGE=yes
-        - CIBW_BUILD: cp3*-manylinux*
+        - CIBW_BUILD: cp3{8,9,10,11}-manylinux*
         - CIBW_MANYLINUX_AARCH64_IMAGE: ghcr.io/h5py/manylinux2014_aarch64-hdf5
         - CIBW_ARCHS: aarch64
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,18 +8,12 @@ environment:
 
     ### USING HDF5 1.8 ###
 
-    - PYTHON: "C:\\Python37"
-      TOXENV: "py37-test-deps"
+    - PYTHON: "C:\\Python38"
+      TOXENV: "py38-test-deps"
       HDF5_VSVERSION: "14"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
 
     ### USING HDF5 1.10 ###
-
-    - PYTHON: "C:\\Python37"
-      TOXENV: "py37-test-deps"
-      HDF5_VSVERSION: "14"
-      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
-      HDF5_VERSION: "1.10.6"
 
     - PYTHON: "C:\\Python38"
       TOXENV: "py38-test-deps"
@@ -29,17 +23,17 @@ environment:
 
     ### USING HDF5 1.12 ###
 
-    - PYTHON: "C:\\Python37"
-      TOXENV: "py37-test-deps"
+    - PYTHON: "C:\\Python39"
+      TOXENV: "py39-test-deps"
       HDF5_VSVERSION: "14"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
       HDF5_VERSION: "1.12.0"
 
-    - PYTHON: "C:\\Python38"
-      TOXENV: "py38-test-deps"
+    - PYTHON: "C:\\Python311"
+      TOXENV: "py311-test-deps"
       HDF5_VSVERSION: "14"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
-      HDF5_VERSION: "1.12.0"
+      HDF5_VERSION: "1.12.2"
 
 install:
   # We need wheel installed to build wheels

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ jobs:
   pool:
     vmImage: ubuntu-20.04
   variables:
-    CIBW_BUILD: cp3{7,8,9,10,11}-manylinux_x86_64
+    CIBW_BUILD: cp3{8,9,10,11}-manylinux_x86_64
     CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/h5py/manylinux2014_x86_64-hdf5
     # Include less debugging info for smaller wheels (default is -g2)
     CIBW_ENVIRONMENT: "CFLAGS=-g1"
@@ -43,7 +43,7 @@ jobs:
     HDF5_VERSION: 1.12.2
     HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
     HDF5_VSVERSION: "16-64"
-    CIBW_BUILD: cp3{7,8,9,10,11}-win_amd64
+    CIBW_BUILD: cp3{8,9,10,11}-win_amd64
   steps:
     - template: ci/azure-pipelines-wheels.yml
       parameters:
@@ -60,7 +60,7 @@ jobs:
     HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
     CIBW_BUILD_VERBOSITY_MACOS: 3
     CIBW_ARCHS_MACOS: $(arch)
-    CIBW_BUILD: cp3{7,8,9,10,11}-macosx_*
+    CIBW_BUILD: cp3{8,9,10,11}-macosx_*
     CIBW_ENVIRONMENT_MACOS: LD_LIBRARY_PATH="$(HDF5_CACHE_DIR)/$(HDF5_VERSION)/lib:${LD_LIBRARY_PATH}" PKG_CONFIG_PATH="$(HDF5_CACHE_DIR)/$(HDF5_VERSION)/lib/pkgconfig:${PKG_CONFIG_PATH}"
     CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
       DYLD_FALLBACK_LIBRARY_PATH=$(HDF5_CACHE_DIR)/$(HDF5_VERSION)/lib delocate-listdeps {wheel} &&
@@ -85,24 +85,16 @@ jobs:
       # -mindeps : test with oldest supported version of (python) dependencies
       # -deps-pre : test pre-release versions of (python) dependencies)
       # -tables : also check compatibility with pytables
-      py37:  # HDF5 1.8 installed from apt on Ubuntu
-        python.version: '3.7'
-        TOXENV: py37-test-deps,py37-test-mindeps,py37-test-deps-tables
+    # HDF5 installed from apt on Ubuntu
     # test when we're not in a unicode locale
       py37-Clocale:
-        python.version: '3.7'
-        TOXENV: py37-test-deps
+        python.version: '3.8'
+        TOXENV: py38-test-deps
         TOX_TESTENV_PASSENV: LANG LC_ALL
         LANG: C
         LC_ALL: C
         H5PY_ENFORCE_COVERAGE: yes
     # Build HDF5 1.10 or 1.12 in the test environment
-      py37-deps-hdf51103:
-        python.version: '3.7'
-        TOXENV: py37-test-deps
-        HDF5_VERSION: 1.10.3
-        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
-        H5PY_ENFORCE_COVERAGE: yes
       py38-deps-hdf51107:
         python.version: '3.8'
         TOXENV: py38-test-deps
@@ -128,10 +120,10 @@ jobs:
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         H5PY_ENFORCE_COVERAGE: yes
     # do mpi tests
-      py37-deps-hdf51105-mpi:
-        python.version: '3.7'
-        TOXENV: py37-test-mindeps-mpi4py
-        HDF5_VERSION: 1.10.5
+      py39-deps-hdf51105-mpi:
+        python.version: '3.9'
+        TOXENV: py39-test-mindeps-mpi4py
+        HDF5_VERSION: 1.12.2
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         HDF5_MPI: ON
         CC: mpicc
@@ -155,10 +147,6 @@ jobs:
 
   strategy:
     matrix:
-      py37:
-        python.version: '3.7'
-        TOXENV: py37-test-deps,py37-test-mindeps,py37-test-deps-pre,py37-test-deps-tables
-        WHL_FILE: h5py*-cp37-*manylinux2014_x86_64.whl
       py38:
         python.version: '3.8'
         TOXENV: py38-test-deps,py38-test-mindeps,py38-test-deps-pre
@@ -192,9 +180,9 @@ jobs:
     # -deps-pre : test pre-release versions of (python) dependencies)
     #
     # 64 bit - HDF5 1.8
-      py37-hdf518:
-        python.version: '3.7'
-        TOXENV: py37-test-deps,py37-test-deps-pre
+      py38-hdf518:
+        python.version: '3.8'
+        TOXENV: py38-test-deps
         HDF5_VERSION: 1.8.17
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         HDF5_VSVERSION: "16-64"
@@ -241,10 +229,6 @@ jobs:
 
   strategy:
     matrix:
-      py37:
-        python.version: '3.7'
-        TOXENV: py37-test-deps,py37-test-mindeps,py37-test-deps-tables
-        WHL_FILE: h5py*-cp37-*.whl
       py38:
         python.version: '3.8'
         TOXENV: py38-test-deps,py38-test-mindeps,py38-test-deps-pre
@@ -275,34 +259,14 @@ jobs:
       # -deps : test with default (latest) versions of dependencies
       # -mindeps : test with oldest supported version of (python) dependencies
       # -deps-pre : test pre-release versions of (python) dependencies)
-      py37:
-        python.version: '3.7'
-        TOXENV: py37-test-deps,py37-test-mindeps
-        H5PY_ENFORCE_COVERAGE: yes
       py38:
         python.version: '3.8'
         TOXENV: py38-test-deps,py38-test-mindeps,py38-test-deps-pre
         H5PY_ENFORCE_COVERAGE: yes
       py39:
-        python.version: '3.9'
-        TOXENV: py39-test-deps,py39-test-mindeps,py39-test-deps-pre
+        python.version: '3.11'
+        TOXENV: py311-test-deps,py311-test-mindeps,py311-test-deps-pre
         H5PY_ENFORCE_COVERAGE: yes
-    # test against newer HDF5
-#      py37-deps-hdf51103:
-#        python.version: '3.7'
-#        TOXENV: py37-test-deps
-#        HDF5_VERSION: 1.10.3
-#        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
-#      py37-deps-hdf51104:
-#        python.version: '3.7'
-#        TOXENV: py37-test-deps
-#        HDF5_VERSION: 1.10.4
-#        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
-#      py37-deps-hdf51105:
-#        python.version: '3.7'
-#        TOXENV: py37-test-deps
-#        HDF5_VERSION: 1.10.5
-#        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
     maxParallel: 4
 
   steps:
@@ -321,10 +285,6 @@ jobs:
 
   strategy:
     matrix:
-      py37:
-        python.version: '3.7'
-        TOXENV: py37-test-deps,py37-test-mindeps,py37-test-deps-tables
-        WHL_FILE: h5py*-cp37-*.whl
       py38:
         python.version: '3.8'
         TOXENV: py38-test-deps,py38-test-mindeps,py38-test-deps-pre

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
     "Topic :: Database",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dynamic = ["dependencies", "version"]
 
 [project.readme]

--- a/setup.py
+++ b/setup.py
@@ -26,12 +26,12 @@ VERSION = '3.8.0'
 # these are required to use h5py
 RUN_REQUIRES = [
     # We only really aim to support NumPy & Python combinations for which
-    # there are wheels on PyPI (e.g. NumPy >=1.17.5 for Python 3.8).
+    # there are wheels on PyPI (e.g. NumPy >=1.23.2 for Python 3.11).
     # But we don't want to duplicate the information in oldest-supported-numpy
     # here, and if you can build an older NumPy on a newer Python, h5py probably
     # works (assuming you build it from source too).
-    # NumPy 1.14.5 is the first with wheels for Python 3.7, our minimum Python.
-    "numpy >=1.14.5",
+    # NumPy 1.17.3 is the first with wheels for Python 3.8, our minimum Python.
+    "numpy >=1.17.3",
 ]
 
 # Packages needed to build h5py (in addition to static list in pyproject.toml)

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # We want an envlist like
 # envlist = {py36,py37,pypy3}-{test}-{deps,mindeps}-{,mpi4py}-{,pre},nightly,docs,checkreadme,pre-commit
 # but we want to skip mpi and pre by default, so this envlist is below
-envlist = {py37,py38,py39,py310,py311,pypy3}-{test}-{deps,mindeps},nightly,docs,apidocs,checkreadme,pre-commit,rever
+envlist = {py38,py39,py310,py311,pypy3}-{test}-{deps,mindeps},nightly,docs,apidocs,checkreadme,pre-commit,rever
 isolated_build = True
 
 [testenv]
@@ -11,7 +11,6 @@ deps =
     test: pytest-cov
     test: pytest-mpi>=0.2
 
-    py37-deps: numpy>=1.14.5
     py38-deps: numpy>=1.17.5
     py39-deps: numpy>=1.19.3
     py310-deps: numpy>=1.21.3


### PR DESCRIPTION
We're generally quite conservative with dependencies, because h5py is often used in big institutional environments that may not upgrade quickly. But Python 3.8 is 3.5 years old by now, so I think it's reasonable to drop 3.7.

I've removed some test jobs, and moved some others onto newer versions of Python, trying to keep a decent coverage of different combinations.