### PR TITLE
Clarify valid key types

### DIFF
--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -195,13 +195,15 @@ class CommonStateObject:
 
         if isinstance(name, bytes):
             coding = h5t.CSET_ASCII
-        else:
+        elif isinstance(name, str):
             try:
                 name = name.encode('ascii')
                 coding = h5t.CSET_ASCII
             except UnicodeEncodeError:
                 name = name.encode('utf8')
                 coding = h5t.CSET_UTF8
+        else:
+            raise TypeError(f"A name should be string or bytes, not {type(name)}")
 
         if lcpl:
             return name, get_lcpl(coding)

--- a/h5py/tests/test_attribute_create.py
+++ b/h5py/tests/test_attribute_create.py
@@ -89,3 +89,7 @@ class TestArray(TestCase):
         dt = np.dtype('()i')
         with self.assertRaises(ValueError):
             self.f.attrs.create('x', data=array, shape=(5,), dtype=dt)
+
+    def test_key_type(self):
+        with self.assertRaises(TypeError):
+            self.f.attrs.create(1, data=('a', 'b'))

--- a/h5py/tests/test_group.py
+++ b/h5py/tests/test_group.py
@@ -94,6 +94,11 @@ class TestCreate(BaseGroup):
         self.assertEqual(group.name, name)
         self.assertEqual(group.id.links.get_info(name.encode('utf8')).cset, h5t.CSET_ASCII)
 
+    def test_type(self):
+        """ Names should be strings or bytes """
+        with self.assertRaises(TypeError):
+            self.f.create_group(1.)
+
     def test_appropriate_low_level_id(self):
         " Binding a group to a non-group identifier fails with ValueError "
         dset = self.f.create_dataset('foo', [1])

--- a/news/fix-2233.rst
+++ b/news/fix-2233.rst
@@ -1,0 +1,29 @@
+New features
+------------
+
+* Validate key types when creating groups and attributes
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
Hi,  
This PR aims to close #2233 , where it's suggested to clarify that only strings and bytes are valid key types.  

Thanks!  
Cyril