### PR TITLE
Add __array__ method to Astype and AsStr wrappers

### DIFF
--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -211,6 +211,12 @@ class AstypeWrapper:
         """
         return len(self._dset)
 
+    def __array__(self, dtype=None):
+        data = self[:]
+        if dtype is not None:
+            data = data.astype(dtype)
+        return data
+
 
 class AsStrWrapper:
     """Wrapper to decode strings on reading the dataset"""
@@ -242,6 +248,11 @@ class AsStrWrapper:
         >>> length = len(dataset.asstr())
         """
         return len(self._dset)
+
+    def __array__(self):
+        return numpy.array([
+            b.decode(self.encoding, self.errors) for b in self._dset
+        ], dtype=object).reshape(self._dset.shape)
 
 
 class FieldsWrapper:

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1257,10 +1257,13 @@ class TestStrings(BaseDataset):
         # len of ds
         self.assertEqual(10, len(ds.asstr()))
 
-
         # Array output
         np.testing.assert_array_equal(
             ds.asstr()[:1], np.array([data], dtype=object)
+        )
+
+        np.testing.assert_array_equal(
+            np.asarray(ds.asstr())[:1], np.array([data], dtype=object)
         )
 
     def test_asstr_fixed(self):
@@ -1580,6 +1583,12 @@ class TestAstype(BaseDataset):
         dset = self.f.create_dataset('x', (100,), dtype='i2')
         dset[...] = np.arange(100)
         self.assertEqual(100, len(dset.astype('f4')))
+
+    def test_astype_wrapper_asarray(self):
+        dset = self.f.create_dataset('x', (100,), dtype='i2')
+        dset[...] = np.arange(100)
+        arr = np.asarray(dset.astype('f4'), dtype='i2')
+        self.assertArrayEqual(arr, np.arange(100, dtype='i2'))
 
 
 class TestScalarCompound(BaseDataset):

--- a/news/dunder_array_to_wrappers.rst
+++ b/news/dunder_array_to_wrappers.rst
@@ -1,0 +1,30 @@
+New features
+------------
+
+* `AsStrWrapper` and `AstypeWrapper` now implement the `__array__()` method.
+  This speeds up access for functions that support it, such as `np.asarray()`.
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
This PR adds `__array__` to `AstypeWrapper` and `AsStrWrapper`, as suggested in #2152 .  

Cheers,  
Cyril
