### PR TITLE
Replace some more uses of np.product() with Python function

### DIFF
--- a/h5py/_hl/attrs.py
+++ b/h5py/_hl/attrs.py
@@ -166,7 +166,7 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
             # is compatible, and reshape if needed.
             else:
 
-                if shape is not None and numpy.product(shape, dtype=numpy.ulonglong) != numpy.product(data.shape, dtype=numpy.ulonglong):
+                if shape is not None and product(shape) != product(data.shape):
                     raise ValueError("Shape of new attribute conflicts with shape of data")
 
                 if shape != data.shape:


### PR DESCRIPTION
We've found in the past that calling `np.product()` for small amounts of data like shape tuples is actually much slower than doing the same calculation in Python - the overhead of numpy's flexible machinery outweighs the core calculation. This converts some more cases which we had missed previously; based on searching the code, I think these are the last ones.

In particular, my colleague @philsmt was doing something which involved creating thousands of small attributes, and found that calls to `np.product()` took something like 1/4 of the time in attribute creation.