### PR TITLE
Error on repeated slicing/indexing of a VirtualSource object

### DIFF
--- a/h5py/_hl/vds.py
+++ b/h5py/_hl/vds.py
@@ -132,15 +132,19 @@ class VirtualSource:
             self.maxshape = tuple([h5s.UNLIMITED if ix is None else ix
                                    for ix in maxshape])
         self.sel = SimpleSelection(shape)
+        self._all_selected = True
 
     @property
     def shape(self):
         return self.sel.array_shape
 
     def __getitem__(self, key):
+        if not self._all_selected:
+            raise RuntimeError("VirtualSource objects can only be sliced once.")
         tmp = copy(self)
         tmp.sel = select(self.shape, key, dataset=None)
         _convert_space_for_key(tmp.sel.id, key)
+        tmp._all_selected = False
         return tmp
 
 class VirtualLayout:

--- a/h5py/tests/test_vds/test_virtual_source.py
+++ b/h5py/tests/test_vds/test_virtual_source.py
@@ -157,6 +157,11 @@ class TestVirtualSource(ut.TestCase):
             with self.assertRaises(TypeError):
                 h5.VirtualSource(a, dtype=int)
 
+    def test_repeated_slice(self):
+        dataset = h5.VirtualSource('test', 'test', (20, 30, 30))
+        sliced = dataset[5:10, :, :]
+        with self.assertRaises(RuntimeError):
+            sliced[:, :4]
 
 
 if __name__ == "__main__":

--- a/news/vsource-repeated-select.rst
+++ b/news/vsource-repeated-select.rst
@@ -1,0 +1,31 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* Sequential slicing/indexing operations on a :class:`.VirtualSource` object
+  (e.g. ``source[:10][::2]``)  now raise an error, rather than giving incorrect
+  results.
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
E.g. `vsource[10:20][::2]` currently appears to work, but does the wrong thing. It's somewhat complex to make it do the right thing, and the need doesn't come up very often, so this just makes the failure explicit.

Closes #2276. 