### PR TITLE
Build wheels & test with HDF5 1.14.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ before_install:
 install:
     - pip install -U pip tox codecov virtualenv
     - ci/get_hdf5_if_needed.sh
-    - if [[ $CIBW_ARCHS == aarch64 ]]; then python -m pip install cibuildwheel; fi
+    - if [[ $CIBW_ARCHS == aarch64 ]]; then python -m pip install 'cibuildwheel<2.15'; fi
 
 script:
     - if [[ $CIBW_ARCHS == aarch64 ]]; then python3 -m cibuildwheel --output-dir wheelhouse; fi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ jobs:
     vmImage: macOS-11
   variables:
     MACOSX_DEPLOYMENT_TARGET: 10.9
-    HDF5_VERSION: 1.14.2
+    HDF5_VERSION: 1.12.2
     H5PY_ROS3: '0'
     H5PY_DIRECT_VFD: '0'
     HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ jobs:
   pool:
     vmImage: windows-2019
   variables:
-    HDF5_VERSION: 1.12.2
+    HDF5_VERSION: 1.14.2
     HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
     HDF5_VSVERSION: "16-64"
     CIBW_BUILD: cp3{8,9,10,11}-win_amd64
@@ -54,7 +54,7 @@ jobs:
     vmImage: macOS-11
   variables:
     MACOSX_DEPLOYMENT_TARGET: 10.9
-    HDF5_VERSION: 1.12.2
+    HDF5_VERSION: 1.14.2
     H5PY_ROS3: '0'
     H5PY_DIRECT_VFD: '0'
     HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
@@ -113,10 +113,10 @@ jobs:
         HDF5_VERSION: 1.12.2
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         H5PY_ENFORCE_COVERAGE: yes
-      py310-deps-hdf51140:
+      py310-deps-hdf51142:
         python.version: '3.10'
         TOXENV: py310-test-deps
-        HDF5_VERSION: 1.14.0
+        HDF5_VERSION: 1.14.2
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         H5PY_ENFORCE_COVERAGE: yes
     # do mpi tests
@@ -207,7 +207,7 @@ jobs:
       py310-hdf5114:
         python.version: '3.10'
         TOXENV: py310-test-deps
-        HDF5_VERSION: 1.14.0
+        HDF5_VERSION: 1.14.2
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         HDF5_VSVERSION: "16-64"
         H5PY_ENFORCE_COVERAGE: yes


### PR DESCRIPTION
Which was just released.

The version for the Linux wheels will need to be updated separately in the repo that creates the docker image, but I'll let the tests run before changing that.