### PR TITLE
Fix `register_filter` on some architectures

### DIFF
--- a/h5py/h5z.pyx
+++ b/h5py/h5z.pyx
@@ -11,6 +11,7 @@
     Filter API and constants.
 """
 
+from libc.stdint cimport uintptr_t
 from ._objects import phil, with_phil
 
 
@@ -99,7 +100,7 @@ def get_filter_info(int filter_code):
 
 
 @with_phil
-def register_filter(Py_ssize_t cls_pointer_address):
+def register_filter(uintptr_t cls_pointer_address):
     '''(INT cls_pointer_address) => BOOL
 
     Register a new filter from the memory address of a buffer containing a


### PR DESCRIPTION
<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->
This PR aims at fixing an issue found during Debian packaging on some specific architectures that's related to the type of `register_filter` argument.
This PR makes use of Cython's `uintptr_t` type.

closes  #2315