### PR TITLE
Update to use HDF5 1.10 compatibility mode rather than 1.8

### DIFF
--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -441,7 +441,7 @@ hdf5:
 # === H5R - Reference API ===================================================
 
   herr_t    H5Rcreate(void *ref, hid_t loc_id, char *name, H5R_type_t ref_type,  hid_t space_id)
-  hid_t     H5Rdereference(hid_t obj_id, H5R_type_t ref_type, void *ref)
+  hid_t     H5Rdereference(hid_t obj_id, hid_t oapl_id, H5R_type_t ref_type, void *ref)
   hid_t     H5Rget_region(hid_t dataset, H5R_type_t ref_type, void *ref)
   herr_t    H5Rget_obj_type(hid_t id, H5R_type_t ref_type, void *ref, H5O_type_t *obj_type)
   ssize_t   H5Rget_name(hid_t loc_id, H5R_type_t ref_type, void *ref, char *name, size_t size)

--- a/h5py/h5r.pyx
+++ b/h5py/h5r.pyx
@@ -13,7 +13,8 @@
 """
 
 # Cython C-level imports
-from ._objects cimport ObjectID
+from ._objects cimport ObjectID, pdefault
+from .h5p cimport PropID
 
 #Python level imports
 from ._objects import phil, with_phil
@@ -66,7 +67,7 @@ def create(ObjectID loc not None, char* name, int ref_type, ObjectID space=None)
 
 
 @with_phil
-def dereference(Reference ref not None, ObjectID id not None):
+def dereference(Reference ref not None, ObjectID id not None, PropID oapl=None):
     """(Reference ref, ObjectID id) => ObjectID or None
 
     Open the object pointed to by the reference and return its
@@ -79,7 +80,9 @@ def dereference(Reference ref not None, ObjectID id not None):
     from . import h5i
     if not ref:
         return None
-    return h5i.wrap_identifier(H5Rdereference(id.id, <H5R_type_t>ref.typecode, &ref.ref))
+    return h5i.wrap_identifier(H5Rdereference(
+        id.id, pdefault(oapl), <H5R_type_t>ref.typecode, &ref.ref
+    ))
 
 
 @with_phil

--- a/setup_build.py
+++ b/setup_build.py
@@ -37,6 +37,9 @@ COMPILER_SETTINGS = {
    'include_dirs'   : [localpath('lzf')],
    'library_dirs'   : [],
    'define_macros'  : [('H5_USE_110_API', None),
+                       # The definition should imply the one below, but CI on
+                       # Ubuntu 20.04 still gets H5Rdereference1 for some reason
+                       ('H5Rdereference_vers', 2),
                        ('NPY_NO_DEPRECATED_API', 0),
                       ]
 }

--- a/setup_build.py
+++ b/setup_build.py
@@ -36,7 +36,7 @@ COMPILER_SETTINGS = {
    'libraries'      : ['hdf5', 'hdf5_hl'],
    'include_dirs'   : [localpath('lzf')],
    'library_dirs'   : [],
-   'define_macros'  : [('H5_USE_18_API', None),
+   'define_macros'  : [('H5_USE_110_API', None),
                        ('NPY_NO_DEPRECATED_API', 0),
                       ]
 }


### PR DESCRIPTION
This follows on from #2313 (requiring HDF5 1.10.4), and mirrors #1542 (moving to the 1.8 API some years ago).

I'm expecting the first commit will fail CI as we get newer versions of some HDF5 C functions; we'll need to adapt to those.