### PR TITLE
Use arr.view(arr.dtype.newbyteorder()) instead of deprecated arr.newbyteorder()

### DIFF
--- a/h5py/_selector.pyx
+++ b/h5py/_selector.pyx
@@ -341,7 +341,7 @@ cdef class Reader:
 
             arr = PyArray_ZEROS(arr_rank, arr_shape, self.np_typenum, 0)
             if not self.native_byteorder:
-                arr = arr.newbyteorder()
+                arr = arr.view(arr.dtype.newbyteorder())
         finally:
             efree(arr_shape)
 


### PR DESCRIPTION
closes #2328 

<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->
