### PR TITLE
`IOError` → `OSError`

### DIFF
--- a/h5py/tests/test_attrs_data.py
+++ b/h5py/tests/test_attrs_data.py
@@ -262,7 +262,7 @@ class TestEmpty(BaseAttrs):
         self.assertTrue(is_empty_dataspace(h5a.open(self.f.id, b'y')))
 
     def test_modify(self):
-        with self.assertRaises(IOError):
+        with self.assertRaises(OSError):
             self.f.attrs.modify('x', 1)
 
     def test_values(self):

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -639,9 +639,9 @@ class TestUnicode(TestCase):
         Modes 'r' and 'r+' do not create files even when given unicode names
         """
         fname = self.mktemp(prefix=chr(0x201a))
-        with self.assertRaises(IOError):
+        with self.assertRaises(OSError):
             File(fname, 'r')
-        with self.assertRaises(IOError):
+        with self.assertRaises(OSError):
             File(fname, 'r+')
 
 

--- a/h5py/tests/test_group.py
+++ b/h5py/tests/test_group.py
@@ -771,7 +771,7 @@ class TestExternalLinks(TestCase):
         with self.assertRaises(KeyError):
             self.f['ext']
 
-    # I would prefer IOError but there's no way to fix this as the exception
+    # I would prefer OSError but there's no way to fix this as the exception
     # class is determined by HDF5.
     def test_exc_missingfile(self):
         """ KeyError raised when attempting to open missing file """
@@ -844,7 +844,7 @@ class TestExtLinkBugs(TestCase):
                 try:
                     if x:
                         x.close()
-                except IOError:
+                except OSError:
                     pass
             return w
         orig_name = self.mktemp()

--- a/setup_configure.py
+++ b/setup_configure.py
@@ -165,7 +165,7 @@ class BuildConfig:
         try:
             if pkgconfig.exists(pc_name):
                 pc = pkgconfig.parse(pc_name)
-        except EnvironmentError:
+        except OSError:
             if os.name != 'nt':
                 print(
                     "Building h5py requires pkg-config unless the HDF5 path "


### PR DESCRIPTION
The following exceptions are kept for compatibility with previous versions; starting from Python 3.3, they are aliases of [`OSError`](https://docs.python.org/3/library/exceptions.html#OSError).
* _exception_ **`EnvironmentError`**
* _exception_ **`IOError`**
* _exception_ **`WindowsError`**

See:
https://docs.python.org/3/library/exceptions.html#IOError

<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->
