### PR TITLE
Fix Cython 3 compatibility

### DIFF
--- a/h5py/api_types_hdf5.pxd
+++ b/h5py/api_types_hdf5.pxd
@@ -259,25 +259,25 @@ cdef extern from "hdf5.h":
       size_t  fapl_size
       void *  (*fapl_get)(H5FD_t *file) except *
       void *  (*fapl_copy)(const void *fapl) except *
-      herr_t  (*fapl_free)(void *fapl) except *
+      herr_t  (*fapl_free)(void *fapl) except -1
       size_t  dxpl_size
       void *  (*dxpl_copy)(const void *dxpl)
       herr_t  (*dxpl_free)(void *dxpl)
       H5FD_t *(*open)(const char *name, unsigned flags, hid_t fapl, haddr_t maxaddr) except *
-      herr_t  (*close)(H5FD_t *file) except *
+      herr_t  (*close)(H5FD_t *file) except -1
       int     (*cmp)(const H5FD_t *f1, const H5FD_t *f2)
       herr_t  (*query)(const H5FD_t *f1, unsigned long *flags)
       herr_t  (*get_type_map)(const H5FD_t *file, H5FD_mem_t *type_map)
       haddr_t (*alloc)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, hsize_t size)
       herr_t  (*free)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr, hsize_t size)
-      haddr_t (*get_eoa)(const H5FD_t *file, H5FD_mem_t type) except *
-      herr_t  (*set_eoa)(H5FD_t *file, H5FD_mem_t type, haddr_t addr) except *
-      haddr_t (*get_eof)(const H5FD_t *file, H5FD_mem_t type) except *
+      haddr_t (*get_eoa)(const H5FD_t *file, H5FD_mem_t type) noexcept
+      herr_t  (*set_eoa)(H5FD_t *file, H5FD_mem_t type, haddr_t addr) noexcept
+      haddr_t (*get_eof)(const H5FD_t *file, H5FD_mem_t type) noexcept
       herr_t  (*get_handle)(H5FD_t *file, hid_t fapl, void**file_handle)
       herr_t  (*read)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl, haddr_t addr, size_t size, void *buffer) except *
       herr_t  (*write)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl, haddr_t addr, size_t size, const void *buffer) except *
-      herr_t  (*flush)(H5FD_t *file, hid_t dxpl_id, hbool_t closing) except *
-      herr_t  (*truncate)(H5FD_t *file, hid_t dxpl_id, hbool_t closing) except *
+      herr_t  (*flush)(H5FD_t *file, hid_t dxpl_id, hbool_t closing) except -1
+      herr_t  (*truncate)(H5FD_t *file, hid_t dxpl_id, hbool_t closing) except -1
       herr_t  (*lock)(H5FD_t *file, hbool_t rw)
       herr_t  (*unlock)(H5FD_t *file)
       H5FD_mem_t fl_map[<int>H5FD_MEM_NTYPES]
@@ -295,27 +295,27 @@ cdef extern from "hdf5.h":
       herr_t  (*sb_encode)(H5FD_t *file, char *name, unsigned char *p)
       herr_t  (*sb_decode)(H5FD_t *f, const char *name, const unsigned char *p)
       size_t  fapl_size
-      void *  (*fapl_get)(H5FD_t *file)
-      void *  (*fapl_copy)(const void *fapl)
-      herr_t  (*fapl_free)(void *fapl)
+      void *  (*fapl_get)(H5FD_t *file) except *
+      void *  (*fapl_copy)(const void *fapl) except *
+      herr_t  (*fapl_free)(void *fapl) except -1
       size_t  dxpl_size
       void *  (*dxpl_copy)(const void *dxpl)
       herr_t  (*dxpl_free)(void *dxpl)
-      H5FD_t *(*open)(const char *name, unsigned flags, hid_t fapl, haddr_t maxaddr)
-      herr_t  (*close)(H5FD_t *file)
+      H5FD_t *(*open)(const char *name, unsigned flags, hid_t fapl, haddr_t maxaddr) except *
+      herr_t  (*close)(H5FD_t *file) except -1
       int     (*cmp)(const H5FD_t *f1, const H5FD_t *f2)
       herr_t  (*query)(const H5FD_t *f1, unsigned long *flags)
       herr_t  (*get_type_map)(const H5FD_t *file, H5FD_mem_t *type_map)
       haddr_t (*alloc)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, hsize_t size)
       herr_t  (*free)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr, hsize_t size)
-      haddr_t (*get_eoa)(const H5FD_t *file, H5FD_mem_t type)
-      herr_t  (*set_eoa)(H5FD_t *file, H5FD_mem_t type, haddr_t addr)
-      haddr_t (*get_eof)(const H5FD_t *file, H5FD_mem_t type)
+      haddr_t (*get_eoa)(const H5FD_t *file, H5FD_mem_t type) noexcept
+      herr_t  (*set_eoa)(H5FD_t *file, H5FD_mem_t type, haddr_t addr) noexcept
+      haddr_t (*get_eof)(const H5FD_t *file, H5FD_mem_t type) noexcept
       herr_t  (*get_handle)(H5FD_t *file, hid_t fapl, void**file_handle)
-      herr_t  (*read)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl, haddr_t addr, size_t size, void *buffer)
-      herr_t  (*write)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl, haddr_t addr, size_t size, const void *buffer)
-      herr_t  (*flush)(H5FD_t *file, hid_t dxpl_id, hbool_t closing)
-      herr_t  (*truncate)(H5FD_t *file, hid_t dxpl_id, hbool_t closing)
+      herr_t  (*read)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl, haddr_t addr, size_t size, void *buffer) except *
+      herr_t  (*write)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl, haddr_t addr, size_t size, const void *buffer) except *
+      herr_t  (*flush)(H5FD_t *file, hid_t dxpl_id, hbool_t closing) except -1
+      herr_t  (*truncate)(H5FD_t *file, hid_t dxpl_id, hbool_t closing) except -1
       herr_t  (*lock)(H5FD_t *file, hbool_t rw)
       herr_t  (*unlock)(H5FD_t *file)
       H5FD_mem_t fl_map[<int>H5FD_MEM_NTYPES]

--- a/h5py/api_types_hdf5.pxd
+++ b/h5py/api_types_hdf5.pxd
@@ -257,27 +257,27 @@ cdef extern from "hdf5.h":
       herr_t  (*sb_encode)(H5FD_t *file, char *name, unsigned char *p)
       herr_t  (*sb_decode)(H5FD_t *f, const char *name, const unsigned char *p)
       size_t  fapl_size
-      void *  (*fapl_get)(H5FD_t *file)
-      void *  (*fapl_copy)(const void *fapl)
-      herr_t  (*fapl_free)(void *fapl)
+      void *  (*fapl_get)(H5FD_t *file) except *
+      void *  (*fapl_copy)(const void *fapl) except *
+      herr_t  (*fapl_free)(void *fapl) except *
       size_t  dxpl_size
       void *  (*dxpl_copy)(const void *dxpl)
       herr_t  (*dxpl_free)(void *dxpl)
-      H5FD_t *(*open)(const char *name, unsigned flags, hid_t fapl, haddr_t maxaddr)
-      herr_t  (*close)(H5FD_t *file)
+      H5FD_t *(*open)(const char *name, unsigned flags, hid_t fapl, haddr_t maxaddr) except *
+      herr_t  (*close)(H5FD_t *file) except *
       int     (*cmp)(const H5FD_t *f1, const H5FD_t *f2)
       herr_t  (*query)(const H5FD_t *f1, unsigned long *flags)
       herr_t  (*get_type_map)(const H5FD_t *file, H5FD_mem_t *type_map)
       haddr_t (*alloc)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, hsize_t size)
       herr_t  (*free)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr, hsize_t size)
-      haddr_t (*get_eoa)(const H5FD_t *file, H5FD_mem_t type)
-      herr_t  (*set_eoa)(H5FD_t *file, H5FD_mem_t type, haddr_t addr)
-      haddr_t (*get_eof)(const H5FD_t *file, H5FD_mem_t type)
+      haddr_t (*get_eoa)(const H5FD_t *file, H5FD_mem_t type) except *
+      herr_t  (*set_eoa)(H5FD_t *file, H5FD_mem_t type, haddr_t addr) except *
+      haddr_t (*get_eof)(const H5FD_t *file, H5FD_mem_t type) except *
       herr_t  (*get_handle)(H5FD_t *file, hid_t fapl, void**file_handle)
-      herr_t  (*read)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl, haddr_t addr, size_t size, void *buffer)
-      herr_t  (*write)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl, haddr_t addr, size_t size, const void *buffer)
-      herr_t  (*flush)(H5FD_t *file, hid_t dxpl_id, hbool_t closing)
-      herr_t  (*truncate)(H5FD_t *file, hid_t dxpl_id, hbool_t closing)
+      herr_t  (*read)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl, haddr_t addr, size_t size, void *buffer) except *
+      herr_t  (*write)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl, haddr_t addr, size_t size, const void *buffer) except *
+      herr_t  (*flush)(H5FD_t *file, hid_t dxpl_id, hbool_t closing) except *
+      herr_t  (*truncate)(H5FD_t *file, hid_t dxpl_id, hbool_t closing) except *
       herr_t  (*lock)(H5FD_t *file, hbool_t rw)
       herr_t  (*unlock)(H5FD_t *file)
       H5FD_mem_t fl_map[<int>H5FD_MEM_NTYPES]

--- a/h5py/h5fd.pyx
+++ b/h5py/h5fd.pyx
@@ -144,10 +144,10 @@ cdef herr_t H5FD_fileobj_close(H5FD_fileobj_t *f) except -1 with gil:
     stdlib_free(f)
     return 0
 
-cdef haddr_t H5FD_fileobj_get_eoa(const H5FD_fileobj_t *f, H5FD_mem_t type):
+cdef haddr_t H5FD_fileobj_get_eoa(const H5FD_fileobj_t *f, H5FD_mem_t type) noexcept nogil:
     return f.eoa
 
-cdef herr_t H5FD_fileobj_set_eoa(H5FD_fileobj_t *f, H5FD_mem_t type, haddr_t addr):
+cdef herr_t H5FD_fileobj_set_eoa(H5FD_fileobj_t *f, H5FD_mem_t type, haddr_t addr) noexcept nogil:
     f.eoa = addr
     return 0
 

--- a/h5py/h5fd.pyx
+++ b/h5py/h5fd.pyx
@@ -151,7 +151,7 @@ cdef herr_t H5FD_fileobj_set_eoa(H5FD_fileobj_t *f, H5FD_mem_t type, haddr_t add
     f.eoa = addr
     return 0
 
-cdef haddr_t H5FD_fileobj_get_eof(const H5FD_fileobj_t *f, H5FD_mem_t type) except -1 with gil:  # HADDR_UNDEF
+cdef haddr_t H5FD_fileobj_get_eof(const H5FD_fileobj_t *f, H5FD_mem_t type) noexcept with gil:  # HADDR_UNDEF
     (<object>f.fileobj).seek(0, libc.stdio.SEEK_END)
     return (<object>f.fileobj).tell()
 
@@ -191,22 +191,38 @@ cdef herr_t H5FD_fileobj_flush(H5FD_fileobj_t *f, hid_t dxpl, hbool_t closing) e
 cdef H5FD_class_t info
 memset(&info, 0, sizeof(info))
 
+# Cython doesn't support "except X" in casting definition currently
+ctypedef herr_t (*file_free_func_ptr)(void *) except -1
+
+ctypedef herr_t (*file_close_func_ptr)(H5FD_t *) except -1
+ctypedef haddr_t (*file_get_eoa_func_ptr)(const H5FD_t *, H5FD_mem_t) noexcept
+ctypedef herr_t (*file_set_eof_func_ptr)(H5FD_t *, H5FD_mem_t, haddr_t) noexcept
+ctypedef haddr_t (*file_get_eof_func_ptr)(const H5FD_t *, H5FD_mem_t) noexcept
+ctypedef herr_t (*file_read_func_ptr)(H5FD_t *, H5FD_mem_t, hid_t, haddr_t, size_t, void*) except -1
+ctypedef herr_t (*file_write_func_ptr)(H5FD_t *, H5FD_mem_t, hid_t, haddr_t, size_t, const void*) except -1
+ctypedef herr_t (*file_truncate_func_ptr)(H5FD_t *, hid_t, hbool_t) except -1
+ctypedef herr_t (*file_flush_func_ptr)(H5FD_t *, hid_t, hbool_t) except -1
+
+
 info.name = 'fileobj'
 info.maxaddr = libc.stdint.SIZE_MAX - 1
 info.fc_degree = H5F_CLOSE_WEAK
 info.fapl_size = sizeof(PyObject *)
 info.fapl_get = <void *(*)(H5FD_t *)>H5FD_fileobj_fapl_get
 info.fapl_copy = <void *(*)(const void *)>H5FD_fileobj_fapl_copy
-info.fapl_free = <herr_t (*)(void *)>H5FD_fileobj_fapl_free
+
+info.fapl_free = <file_free_func_ptr>H5FD_fileobj_fapl_free
+
 info.open = <H5FD_t *(*)(const char *name, unsigned flags, hid_t fapl, haddr_t maxaddr)>H5FD_fileobj_open
-info.close = <herr_t (*)(H5FD_t *)>H5FD_fileobj_close
-info.get_eoa = <haddr_t (*)(const H5FD_t *, H5FD_mem_t)>H5FD_fileobj_get_eoa
-info.set_eoa = <herr_t (*)(H5FD_t *, H5FD_mem_t, haddr_t)>H5FD_fileobj_set_eoa
-info.get_eof = <haddr_t (*)(const H5FD_t *, H5FD_mem_t)>H5FD_fileobj_get_eof
-info.read = <herr_t (*)(H5FD_t *, H5FD_mem_t, hid_t, haddr_t, size_t, void *)>H5FD_fileobj_read
-info.write = <herr_t (*)(H5FD_t *, H5FD_mem_t, hid_t, haddr_t, size_t, const void *)>H5FD_fileobj_write
-info.truncate = <herr_t (*)(H5FD_t *, hid_t, hbool_t)>H5FD_fileobj_truncate
-info.flush = <herr_t (*)(H5FD_t *, hid_t, hbool_t)>H5FD_fileobj_flush
+
+info.close = <file_close_func_ptr>H5FD_fileobj_close
+info.get_eoa = <file_get_eoa_func_ptr>H5FD_fileobj_get_eoa
+info.set_eoa = <file_set_eof_func_ptr>H5FD_fileobj_set_eoa
+info.get_eof = <file_get_eof_func_ptr>H5FD_fileobj_get_eof
+info.read = <file_read_func_ptr>H5FD_fileobj_read
+info.write = <file_write_func_ptr>H5FD_fileobj_write
+info.truncate = <file_truncate_func_ptr>H5FD_fileobj_truncate
+info.flush = <file_flush_func_ptr>H5FD_fileobj_flush
 # H5FD_FLMAP_DICHOTOMY
 info.fl_map = [H5FD_MEM_SUPER,  # default
                H5FD_MEM_SUPER,  # super

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "Cython >=0.29.31,<1",
+    "Cython >=3",
     "oldest-supported-numpy",
     "pkgconfig",
     "setuptools >=61",


### PR DESCRIPTION
Closes #2268.

This is a first step in Cython 3 compatibility. This is based on a branch started by @takluyver. The basic idea so far is that functions needed to be defined with `except X` or `noexcept` to define how errors are handled. The complication was in h5py/h5fd.pyx which casts the h5py version of the file functions (which use a wrapper struct) to match the HDF5 version of the function. Due to what I think is a bug in Cython 3, you can't include an `except X` statement in your casting so as suggested on the Cython mailing list I created ctypedefs for every function pointer that needed one.

TODO:

- [ ] Review all performance warnings during compilation. Cython points out that many functions are not handled yet and it is now assuming that exceptions will be raised and the GIL is acquired to check for an exception.
- [ ] Not needed for initial compatibility, but removal of all IF statements since it is being removed from the Cython language. There are some suggestions on how to not use them, but I'm not sure they will work for all cases used in h5py.

Note the alternative suggested by da-woods (not tagging here to not be annoying) in the above mentioned issue of just specifying the Cython option to force the old behavior.

https://github.com/h5py/h5py/issues/2268#issuecomment-1829300815

#### Example of performance warning

```
performance hint: h5py/_locks.pxi:114:5: Exception check on 'unlock_lock' will always require the GIL to be acquired.
Possible solutions:
        1. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
        2. Use an 'int' return type on the function to allow an error code to be returned.
```