### PR TITLE
Require NumPy < 2 (for now)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ RUN_REQUIRES = [
     # here, and if you can build an older NumPy on a newer Python, h5py probably
     # works (assuming you build it from source too).
     # NumPy 1.17.3 is the first with wheels for Python 3.8, our minimum Python.
-    "numpy >=1.17.3",
+    "numpy >=1.17.3, <2.0",
 ]
 
 # Packages needed to build h5py (in addition to static list in pyproject.toml)


### PR DESCRIPTION
From discussion in #2345: NumPy 2.0 is coming, and will break ABI compatibility.

For the future, it looks like we'll be able to [build with newer Numpy specifying the desired compatibility](https://numpy.org/doc/stable/release/1.25.0-notes.html#compiling-against-the-numpy-c-api-is-now-backwards-compatible-by-default) rather than building with the oldest supported Numpy. We should investigate that once Numpy 2.0 is close to ready (we should get at least 6 weeks with an RC). But for now, let's just make it clear that the package expects Numpy 1.x.