### PR TITLE
MAINT: Add nightly wheel upload

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -41,24 +41,28 @@ jobs:
           definitionId: 1
           reasonFilter: individualCI
           artifact: linux_wheels
+          cache: false
       - uses: git-for-windows/get-azure-pipelines-artifact@v0.3.1
         with:
           repository: h5pyappveyor/h5py
           definitionId: 1
           reasonFilter: individualCI
           artifact: macos_arm64_wheels
+          cache: false
       - uses: git-for-windows/get-azure-pipelines-artifact@v0.3.1
         with:
           repository: h5pyappveyor/h5py
           definitionId: 1
           reasonFilter: individualCI
           artifact: macos_x86_64_wheels
+          cache: false
       - uses: git-for-windows/get-azure-pipelines-artifact@v0.3.1
         with:
           repository: h5pyappveyor/h5py
           definitionId: 1
           reasonFilter: individualCI
           artifact: windows_wheels
+          cache: false
       - name: Repackage wheel artifacts
         run: |
           ls -alt

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -9,10 +9,6 @@ on:
     - cron: '23 1 * * *'
   # Run on demand with workflow dispatch
   workflow_dispatch:
-  # TODO: this is just for testing, remove before merge
-  pull_request:
-    branches:
-      - '*'
 
 
 permissions:
@@ -25,8 +21,7 @@ jobs:
     defaults:
       run:
         shell: bash -el {0}
-    # TODO: Uncomment when working
-    #if: github.repository_owner == 'h5py'
+    if: github.repository_owner == 'h5py'
 
     steps:
       # https://github.com/git-for-windows/get-azure-pipelines-artifact
@@ -68,10 +63,10 @@ jobs:
           ls -alt
           ls -alt *_wheels
           mkdir dist
-          mv *wheels/*.whl dist/
+          mv *_wheels/*.whl dist/
           echo
           echo "Contents of dist/"
-          ls -l dist/
+          ls -alt dist/
 
       - name: Upload wheels to Anaconda Cloud as nightlies
         uses: scientific-python/upload-nightly-action@8f0394fd2aa0c85d7364a9958652e8994e06b23c # 0.1.0

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -1,0 +1,79 @@
+---
+name: Upload nightly wheels to Anaconda Cloud
+
+# Adapted from https://github.com/matplotlib/matplotlib/blob/main/.github/workflows/nightlies.yml
+
+on:
+  # Run daily at 1:23 UTC to upload nightly wheels to Anaconda Cloud
+  schedule:
+    - cron: '23 1 * * *'
+  # Run on demand with workflow dispatch
+  workflow_dispatch:
+  # TODO: this is just for testing, remove before merge
+  pull_request:
+    branches:
+      - '*'
+
+
+permissions:
+  actions: read
+
+jobs:
+  upload_nightly_wheels:
+    name: Upload nightly wheels to Anaconda Cloud
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -el {0}
+    # TODO: Uncomment when working
+    #if: github.repository_owner == 'h5py'
+
+    steps:
+      # https://github.com/git-for-windows/get-azure-pipelines-artifact
+      # looking at
+      #   curl "https://dev.azure.com/h5pyappveyor/h5py/_apis/build/builds?definitionId=1&repositoryFilter=1&branchFilter=4&statusFilter=succeeded"
+      # the "reason" for master runs is "individualCI" and the run ID, then
+      #   curl "https://dev.azure.com/h5pyappveyor/h5py/_apis/build/builds/1821/artifacts"
+      # for example has the artifact name and downloadUrl in case we ever want to do this ourselves
+      - uses: git-for-windows/get-azure-pipelines-artifact@v0.3.1
+        with:
+          repository: h5pyappveyor/h5py
+          definitionId: 1
+          reasonFilter: individualCI
+          artifact: linux_wheels
+      - uses: git-for-windows/get-azure-pipelines-artifact@v0.3.1
+        with:
+          repository: h5pyappveyor/h5py
+          definitionId: 1
+          reasonFilter: individualCI
+          artifact: macos_arm64_wheels
+      - uses: git-for-windows/get-azure-pipelines-artifact@v0.3.1
+        with:
+          repository: h5pyappveyor/h5py
+          definitionId: 1
+          reasonFilter: individualCI
+          artifact: macos_x86_64_wheels
+      - uses: git-for-windows/get-azure-pipelines-artifact@v0.3.1
+        with:
+          repository: h5pyappveyor/h5py
+          definitionId: 1
+          reasonFilter: individualCI
+          artifact: windows_wheels
+      - name: Repackage wheel artifacts
+        run: |
+          ls -alt
+          unzip linux_wheels
+          unzip macos_arm64_wheels
+          unzip macos_x86_64_wheels
+          unzip windows_wheels
+          mkdir dist
+          mv *wheels/*.whl dist/
+          echo
+          echo "Contents of dist/"
+          ls -l dist/
+
+      - name: Upload wheels to Anaconda Cloud as nightlies
+        uses: scientific-python/upload-nightly-action@8f0394fd2aa0c85d7364a9958652e8994e06b23c # 0.1.0
+        with:
+          artifacts_path: dist
+          anaconda_nightly_upload_token: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -66,10 +66,7 @@ jobs:
       - name: Repackage wheel artifacts
         run: |
           ls -alt
-          unzip linux_wheels
-          unzip macos_arm64_wheels
-          unzip macos_x86_64_wheels
-          unzip windows_wheels
+          ls -alt *_wheels
           mkdir dist
           mv *wheels/*.whl dist/
           echo


### PR DESCRIPTION
Closes #2353

Trying to use https://github.com/git-for-windows/get-azure-pipelines-artifact for now but in case it doesn't work the direct JSON queries don't seem too bad actually.

Needs:

- [x] Get artifact working properly
- [x] Repackage properly
- [x] Remove TODO / uncomment lines
- [ ] @tacaswell add `secrets.ANACONDA_ORG_UPLOAD_TOKEN`

Then should be good to merge.