### PR TITLE
Creates access to remaining H5O_info_t struct fields, Closes #2347

### DIFF
--- a/h5py/h5o.pyx
+++ b/h5py/h5o.pyx
@@ -84,13 +84,55 @@ cdef class _OHdr(_ObjInfoBase):
     property nmesgs:
         def __get__(self):
             return self.istr[0].hdr.nmesgs
+    property nchunks:
+        def __get__(self):
+            return self.istr[0].hdr.nchunks
+    property flags:
+        def __get__(self):
+            return self.istr[0].hdr.flags
 
     def __init__(self):
         self.space = _OHdrSpace()
         self.mesg = _OHdrMesg()
 
     def _hash(self):
-        return hash((self.version, self.nmesgs, self.space, self.mesg))
+        return hash((self.version, self.nmesgs, self.nchunks, self.flags, self.space, self.mesg))
+
+cdef class _MetaSizeObj(_ObjInfoBase):
+
+    property index_size:
+        def __get__(self):
+            return self.istr[0].meta_size.obj.index_size
+    property heap_size:
+        def __get__(self):
+            return self.istr[0].meta_size.obj.heap_size
+
+    def _hash(self):
+        return hash((self.index_size, self.heap_size))
+
+cdef class _MetaSizeAttr(_ObjInfoBase):
+
+    property index_size:
+        def __get__(self):
+            return self.istr[0].meta_size.attr.index_size
+    property heap_size:
+        def __get__(self):
+            return self.istr[0].meta_size.attr.heap_size
+
+    def _hash(self):
+        return hash((self.index_size, self.heap_size))
+
+cdef class _OMetaSize(_ObjInfoBase):
+
+    cdef public _MetaSizeObj obj
+    cdef public _MetaSizeAttr attr
+
+    def __init__(self):
+        self.obj = _MetaSizeObj()
+        self.attr = _MetaSizeAttr()
+
+    def _hash(self):
+        return hash((self.obj, self.attr))
 
 cdef class _ObjInfo(_ObjInfoBase):
 
@@ -106,9 +148,24 @@ cdef class _ObjInfo(_ObjInfoBase):
     property rc:
         def __get__(self):
             return self.istr[0].rc
+    property atime:
+        def __get__(self):
+            return self.istr[0].atime
+    property mtime:
+        def __get__(self):
+            return self.istr[0].mtime
+    property ctime:
+        def __get__(self):
+            return self.istr[0].ctime
+    property btime:
+        def __get__(self):
+            return self.istr[0].btime
+    property num_attrs:
+        def __get__(self):
+            return self.istr[0].num_attrs
 
     def _hash(self):
-        return hash((self.fileno, self.addr, self.type, self.rc))
+        return hash((self.fileno, self.addr, self.type, self.rc, self.atime, self.mtime, self.ctime, self.btime, self.num_attrs))
 
 cdef class ObjInfo(_ObjInfo):
 
@@ -118,14 +175,19 @@ cdef class ObjInfo(_ObjInfo):
 
     cdef H5O_info_t infostruct
     cdef public _OHdr hdr
+    cdef public _OMetaSize meta_size
 
     def __init__(self):
         self.hdr = _OHdr()
+        self.meta_size = _OMetaSize()
 
         self.istr = &self.infostruct
         self.hdr.istr = &self.infostruct
         self.hdr.space.istr = &self.infostruct
         self.hdr.mesg.istr = &self.infostruct
+        self.meta_size.istr = &self.infostruct
+        self.meta_size.obj.istr = &self.infostruct
+        self.meta_size.attr.istr = &self.infostruct
 
     def __copy__(self):
         cdef ObjInfo newcopy

--- a/h5py/h5o.pyx
+++ b/h5py/h5o.pyx
@@ -98,38 +98,28 @@ cdef class _OHdr(_ObjInfoBase):
     def _hash(self):
         return hash((self.version, self.nmesgs, self.nchunks, self.flags, self.space, self.mesg))
 
-cdef class _MetaSizeObj(_ObjInfoBase):
+cdef class _ObjMetaInfo:
+
+    cdef H5_ih_info_t *istr
 
     property index_size:
         def __get__(self):
-            return self.istr[0].meta_size.obj.index_size
+            return self.istr[0].index_size
     property heap_size:
         def __get__(self):
-            return self.istr[0].meta_size.obj.heap_size
-
-    def _hash(self):
-        return hash((self.index_size, self.heap_size))
-
-cdef class _MetaSizeAttr(_ObjInfoBase):
-
-    property index_size:
-        def __get__(self):
-            return self.istr[0].meta_size.attr.index_size
-    property heap_size:
-        def __get__(self):
-            return self.istr[0].meta_size.attr.heap_size
+            return self.istr[0].heap_size
 
     def _hash(self):
         return hash((self.index_size, self.heap_size))
 
 cdef class _OMetaSize(_ObjInfoBase):
 
-    cdef public _MetaSizeObj obj
-    cdef public _MetaSizeAttr attr
+    cdef public _ObjMetaInfo obj
+    cdef public _ObjMetaInfo attr
 
     def __init__(self):
-        self.obj = _MetaSizeObj()
-        self.attr = _MetaSizeAttr()
+        self.obj = _ObjMetaInfo()
+        self.attr = _ObjMetaInfo()
 
     def _hash(self):
         return hash((self.obj, self.attr))
@@ -186,8 +176,8 @@ cdef class ObjInfo(_ObjInfo):
         self.hdr.space.istr = &self.infostruct
         self.hdr.mesg.istr = &self.infostruct
         self.meta_size.istr = &self.infostruct
-        self.meta_size.obj.istr = &self.infostruct
-        self.meta_size.attr.istr = &self.infostruct
+        self.meta_size.obj.istr = &(self.istr[0].meta_size.obj)
+        self.meta_size.attr.istr = &(self.istr[0].meta_size.attr)
 
     def __copy__(self):
         cdef ObjInfo newcopy

--- a/news/metasize_info_struct.rst
+++ b/news/metasize_info_struct.rst
@@ -1,0 +1,11 @@
+Exposing HDF5 functions
+-----------------------
+
+* Exposes remaining information from `H5O_info_t` struct such as access, modification, change, and
+birth time. Also exposes field providing number of attributes attached to an object. Expands object
+header metadata struct `H5O_hdr_info_t`, `hdr` field of `H5O_info_t`, to provide number of chunks and
+flags set for object header. Lastly, adds `meta_size` field from `H5O_info_t` struct that provides
+two fields, `attr` which is the storage overhead of any attached attributes, and `obj` which is 
+storage overhead required for chunk storage. The last two fields added can be useful for determining
+the storage overhead incurred from various data layout/chunked strategies, and for obtaining information
+such as that provided by `h5stat`.

--- a/news/metasize_info_struct.rst
+++ b/news/metasize_info_struct.rst
@@ -5,7 +5,7 @@ Exposing HDF5 functions
 birth time. Also exposes field providing number of attributes attached to an object. Expands object
 header metadata struct `H5O_hdr_info_t`, `hdr` field of `H5O_info_t`, to provide number of chunks and
 flags set for object header. Lastly, adds `meta_size` field from `H5O_info_t` struct that provides
-two fields, `attr` which is the storage overhead of any attached attributes, and `obj` which is 
+two fields, `attr` which is the storage overhead of any attached attributes, and `obj` which is
 storage overhead required for chunk storage. The last two fields added can be useful for determining
 the storage overhead incurred from various data layout/chunked strategies, and for obtaining information
 such as that provided by `h5stat`.


### PR DESCRIPTION
These are just exposing additional fields of `H5O_info_t` struct and has no direct interface on high level classes so I don't think tests are necessary. Let me know if otherwise.
