### PR TITLE
Temporarily pin pytest<8 for running tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ isolated_build = True
 
 [testenv]
 deps =
-    test: pytest
+    test: pytest<8
     test: pytest-cov
     test: pytest-mpi>=0.2
 


### PR DESCRIPTION
Tests are currently failing on Windows because the 'pre' tests are picking up pytest 8.0rc1, which has [a bug](https://github.com/pytest-dev/pytest/issues/9765) causing an internal assertion (something to do with finding `conftest.py` - I didn't read the details closely).

It looks like it will be fixed soon, but for now this should let our tests work again.