### PR TITLE
DO NOT MERGE: test Pytest main branch

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ isolated_build = True
 
 [testenv]
 deps =
-    test: pytest<8
+    test: git+https://github.com/pytest-dev/pytest.git@main
     test: pytest-cov
     test: pytest-mpi>=0.2
 


### PR DESCRIPTION
This is in the context of https://github.com/h5py/h5py/pull/2364 that pinned `pytest<8` because there were issues in Pytest 8.0.0rc1.

The `assert mod not in mods` issue https://github.com/pytest-dev/pytest/issues/9765 has been fixed in Pytest main (and back-ported to 8.0.x branch) but it looks like this is not the end of the story. There is now another issue under investigation https://github.com/pytest-dev/pytest/issues/11816.

The goal of this PR is to test the issue does happen in a typical Python project. Sorry to kind of hijack your CI, but it would be very useful to have a public way of showing the issue and testing that it is fixed.