### PR TITLE
Unpin pytest now that 8.0.0rc2 has been released

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ isolated_build = True
 
 [testenv]
 deps =
-    test: pytest<8
+    test: pytest
     test: pytest-cov
     test: pytest-mpi>=0.2
 


### PR DESCRIPTION
pytest 8.0.0rc2 has been released and should have fixed all the issues that were seen on Windows (see https://github.com/h5py/h5py/pull/2364 for more context).

Close #2365.