### PR TITLE
CI: Update scientific-python/upload-nightly-action to 0.5.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -69,7 +69,7 @@ jobs:
           ls -alt dist/
 
       - name: Upload wheels to Anaconda Cloud as nightlies
-        uses: scientific-python/upload-nightly-action@8f0394fd2aa0c85d7364a9958652e8994e06b23c # 0.1.0
+        uses: scientific-python/upload-nightly-action@b67d7fcc0396e1128a474d1ab2b48aa94680f9fc # 0.5.0
         with:
           artifacts_path: dist
           anaconda_nightly_upload_token: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}


### PR DESCRIPTION
Amends PR https://github.com/h5py/h5py/pull/2355

* Update the scientific-python/upload-nightly-action to v0.5.0 for dependency stability and to take advantage of Anaconda Cloud upload bug fixes.
   - c.f. https://github.com/scientific-python/upload-nightly-action/releases/tag/0.5.0

* Use Dependabot to weekly check for updates to GitHub Actions used and then update them in a group in a single PR.
   - c.f. sp-repo-review GH200: Maintained by Dependabot
     https://learn.scientific-python.org/development/guides/gha-basic/#GH200

---

Before opening a pull request, please:

- [N/A] Run simple static checks with `tox -e pre-commit`
- [N/A] Run the tests with e.g. `tox -e py37-test-deps`
- [N/A] If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

