### PR TITLE
Document how to create attributes > 64 KiB

### DIFF
--- a/docs/high/attr.rst
+++ b/docs/high/attr.rst
@@ -29,6 +29,17 @@ dictionaries.
 The default ``track_order`` for all new groups and datasets can be
 specified globally with ``h5.get_config().track_order``.
 
+Large attributes
+----------------
+
+HDF5 allows attributes to be larger than 64 KiB, but these need to be stored in
+a different way. As of March 2024, the way HDF5 documentation suggests you
+configure this does not work. Instead, enable order tracking when creating the
+object you want to attach attributes to::
+
+    grp = f.create_group('g', track_order=True)
+    grp.attrs['large'] = np.arange(1_000_000, dtype=np.uint32)
+
 
 Reference
 ---------


### PR DESCRIPTION
`set_attr_phase_change` doesn't work, but passing `track_order` when creating an object does. :shrug: 

Closes #2311