### PR TITLE
Allow creation of expandable external datasets

### DIFF
--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -246,8 +246,13 @@ def fill_dcpl(plist, shape, dtype, chunks, compression, compression_opts,
     # End argument validation
 
     if (chunks is True) or \
-    (chunks is None and any((shuffle, fletcher32, compression, maxshape and not len(external),
-                             scaleoffset is not None))):
+    if (chunks is True) or (chunks is None and any((
+            shuffle,
+            fletcher32,
+            compression,
+            (maxshape and not len(external)),
+            scaleoffset is not None,
+    ))):
         chunks = guess_chunk(shape, maxshape, dtype.itemsize)
 
     if maxshape is True:

--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -246,7 +246,7 @@ def fill_dcpl(plist, shape, dtype, chunks, compression, compression_opts,
     # End argument validation
 
     if (chunks is True) or \
-    (chunks is None and any((shuffle, fletcher32, compression, maxshape,
+    (chunks is None and any((shuffle, fletcher32, compression, maxshape and not len(external),
                              scaleoffset is not None))):
         chunks = guess_chunk(shape, maxshape, dtype.itemsize)
 

--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -245,7 +245,6 @@ def fill_dcpl(plist, shape, dtype, chunks, compression, compression_opts,
     external = _normalize_external(external)
     # End argument validation
 
-    if (chunks is True) or \
     if (chunks is True) or (chunks is None and any((
             shuffle,
             fletcher32,

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -873,6 +873,18 @@ class TestExternal(BaseDataset):
             with self.assertRaises(exc_type):
                 self.f.create_dataset('foo', shape, external=external)
 
+    def test_create_expandable(self):
+        """ Create expandable external dataset """
+
+        ext_file = self.mktemp()
+        shape = (128, 64)
+        maxshape = (None, 64)
+        exp_dset = self.f.create_dataset('foo', shape=shape, maxshape=maxshape,
+                                         external=ext_file)
+        assert exp_dset.chunks is None
+        assert exp_dset.shape == shape
+        assert exp_dset.maxshape == maxshape
+
 
 class TestAutoCreate(BaseDataset):
 


### PR DESCRIPTION
External HDF5 datasets can be expanded along their first dimension but cannot have chunked layout. This PR avoids setting chunked layout when creating a dataset if both `maxshape` and `external` keyword arguments are present.

Fixes #2396.