### PR TITLE
Skip TestNewLibver for dev libhdf5

### DIFF
--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -435,7 +435,10 @@ class TestDrivers(TestCase):
     # TODO: family driver tests
 
 
-
+@pytest.mark.skipif(
+    h5py.version.hdf5_version_tuple[1] % 2 != 0 ,
+    reason='Not HDF5 release version'
+)
 class TestNewLibver(TestCase):
 
     """


### PR DESCRIPTION
HDF Group has a CI workflow to test h5py with the development branch of libhdf5. The workflow currently fails due to the TestNewLibver tests because the dev libhdf5 version always has a bigger `H5F_LIBVER_LATEST` value. The PR marks these tests for skipping whenever the minor version number is odd.

My apologies for not creating an issue about this first for discussion.