### PR TITLE
Fix iteration order for reopened files with creation order tracked

### DIFF
--- a/h5py/h5f.pyx
+++ b/h5py/h5f.pyx
@@ -616,10 +616,12 @@ cdef class FileID(GroupID):
 
     # Redefine these methods to use the root group explicitly, because otherwise
     # the setting for link order tracking can be missed.
+    @with_phil
     def __iter__(self):
         """ Return an iterator over the names of group members. """
         return iter(h5o.open(self, b'/'))
 
+    @with_phil
     def __reversed__(self):
         """ Return an iterator over group member names in reverse order. """
         return reversed(h5o.open(self, b'/'))

--- a/h5py/h5f.pyx
+++ b/h5py/h5f.pyx
@@ -26,7 +26,7 @@ from .utils cimport emalloc, efree
 # Python level imports
 from collections import namedtuple
 import gc
-from . import _objects
+from . import _objects, h5o
 from ._objects import phil, with_phil
 
 from cpython.bytes cimport PyBytes_FromStringAndSize, PyBytes_AsString
@@ -611,3 +611,15 @@ cdef class FileID(GroupID):
                         int(evictions[1]), int(bypasses[1]))
 
         return PageBufStats(meta, raw)
+
+    # === Special methods =====================================================
+
+    # Redefine these methods to use the root group explicitly, because otherwise
+    # the setting for link order tracking can be missed.
+    def __iter__(self):
+        """ Return an iterator over the names of group members. """
+        return iter(h5o.open(self, b'/'))
+
+    def __reversed__(self):
+        """ Return an iterator over group member names in reverse order. """
+        return reversed(h5o.open(self, b'/'))

--- a/h5py/tests/test_file2.py
+++ b/h5py/tests/test_file2.py
@@ -266,8 +266,12 @@ class TestTrackOrder(TestCase):
         fname = self.mktemp()
         f = h5py.File(fname, 'w', track_order=True)  # creation order
         self.populate(f)
-        self.assertEqual(list(f),
-                         [str(i) for i in range(100)])
+        self.assertEqual(list(f), [str(i) for i in range(100)])
+        f.close()
+
+        # Check order tracking after reopening the file
+        f2 = h5py.File(fname)
+        self.assertEqual(list(f2), [str(i) for i in range(100)])
 
     def test_no_track_order(self):
         fname = self.mktemp()


### PR DESCRIPTION
It's documented that `H5Pget_link_creation_order` can be called on a group or file creation property list. But the flag seems to be saved only in the GCPL for the root group, so getting the value from the FCPL from a reopened file always tells you creation order is not tracked.

This uses the root group explicitly for iterating over a file object, so if it was created with order tracking on, you get names in creation order.

Closes #1577.