### PR TITLE
Python 3.12 requires mpi4py>=3.1.5 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ if setup_configure.mpi_enabled():
     # incompatible with newer setuptools.
     RUN_REQUIRES.append('mpi4py >=3.1.1')
     SETUP_REQUIRES.append("mpi4py ==3.1.1; python_version<'3.11'")
-    SETUP_REQUIRES.append("mpi4py ==3.1.4; python_version=='3.11'")
+    SETUP_REQUIRES.append("mpi4py ==3.1.4; python_version=='3.11.*'")
     SETUP_REQUIRES.append("mpi4py ==3.1.6; python_version>='3.12'")
 
 # Set the environment variable H5PY_SETUP_REQUIRES=0 if we need to skip

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ if setup_configure.mpi_enabled():
     # incompatible with newer setuptools.
     RUN_REQUIRES.append('mpi4py >=3.1.1')
     SETUP_REQUIRES.append("mpi4py ==3.1.1; python_version<'3.11'")
-    SETUP_REQUIRES.append("mpi4py ==3.1.4; python_version>='3.11'")
+    SETUP_REQUIRES.append("mpi4py ==3.1.4; python_version=='3.11'")
+    SETUP_REQUIRES.append("mpi4py ==3.1.6; python_version>='3.12'")
 
 # Set the environment variable H5PY_SETUP_REQUIRES=0 if we need to skip
 # setup_requires for any reason.


### PR DESCRIPTION
See issue #2417.
As for Python 3.11, I added the last version of mpi4py as a requirement.

By the way, I had to bump the `check-manifest` rev in pre-commit (`.pre-commit-config.yaml`) to be able to run `tox -e pre-commit` with Python 3.12. (0.39 -> 0.49)