### PR TITLE
Update Travis CI builds to Ubuntu 20.04 (Focal)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 os: linux
-dist: bionic
+dist: focal
 
 notifications:
   email: false


### PR DESCRIPTION
Hopefully this fixes installing Numpy, by providing a newer version of GCC. Previously builds were on 18.04 (bionic).