### PR TITLE
TST: make sure file descriptors are closed before tests return

### DIFF
--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -457,6 +457,7 @@ class TestDrivers(TestCase):
         # Driver must be 'fileobj' for file-like object if specified
         with self.assertRaises(ValueError):
             File(tf, 'w', driver='core')
+        tf.close()
 
     # TODO: family driver tests
 

--- a/h5py/tests/test_file2.py
+++ b/h5py/tests/test_file2.py
@@ -238,10 +238,12 @@ class TestFileObj(TestCase):
         # HDF5 expects read & write access to a file it's writing;
         # check that we get the correct exception on a write-only file object.
         fileobj = open(os.path.join(self.tempdir, 'a.h5'), 'wb')
+        f = h5py.File(fileobj, 'w')
+        group = f.create_group("group")
         with self.assertRaises(io.UnsupportedOperation):
-            f = h5py.File(fileobj, 'w')
-            group = f.create_group("group")
             group.create_dataset("data", data='foo', dtype=h5py.string_dtype())
+        f.close()
+        fileobj.close()
 
 
     def test_method_vanish(self):


### PR DESCRIPTION
Continuing to scratch my own itch for running the test suite with warnings promoted to errors (`pytest -Werror`), these are the only two tests I see failing locally (but there could be more, some tests are simply skipped on my system), and they were simple enough to fix.

I opened a couple similar PRs in the past, fixing mostly deprecation warnings from numpy that I discovered in CI of packages that depend on h5py and promote warnings as errors. Would you consider doing the same thing directly in h5py's CI so you don't need reports from downstream in the future ?