### PR TITLE
Update documentation to use `tox -e py38-test-deps` for tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@ Thanks for contributing to h5py!
 Before opening a pull request, please:
 
 - Run simple static checks with `tox -e pre-commit`
-- Run the tests with e.g. `tox -e py38-test-deps`
+- Run the tests with e.g. `tox -e py312-test-deps`
 - If your change is visible to someone using or building h5py, add a release
   note in the news/ folder.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@ Thanks for contributing to h5py!
 Before opening a pull request, please:
 
 - Run simple static checks with `tox -e pre-commit`
-- Run the tests with e.g. `tox -e py37-test-deps`
+- Run the tests with e.g. `tox -e py38-test-deps`
 - If your change is visible to someone using or building h5py, add a release
   note in the news/ folder.
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -142,7 +142,7 @@ The easiest way to run the tests is with
 
     pip install tox  # Get tox
 
-    tox -e py38-test-deps  # Run tests in one environment
+    tox -e py312-test-deps  # Run tests in one environment
     tox                    # Run tests in all possible environments
     tox -a                 # List defined environments
 
@@ -393,7 +393,7 @@ To run these tests, you'll need to:
 
 Then running::
 
-   $ CC='mpicc' HDF5_MPI=ON tox -e py38-test-deps-mpi4py
+   $ CC='mpicc' HDF5_MPI=ON tox -e py312-test-deps-mpi4py
 
 should run the tests. You may need to pass ``HDF5_DIR`` depending on the
 location of the HDF5 with MPI support. You can choose which python version to

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -142,7 +142,7 @@ The easiest way to run the tests is with
 
     pip install tox  # Get tox
 
-    tox -e py37-test-deps  # Run tests in one environment
+    tox -e py38-test-deps  # Run tests in one environment
     tox                    # Run tests in all possible environments
     tox -a                 # List defined environments
 
@@ -393,7 +393,7 @@ To run these tests, you'll need to:
 
 Then running::
 
-   $ CC='mpicc' HDF5_MPI=ON tox -e py37-test-deps-mpi4py
+   $ CC='mpicc' HDF5_MPI=ON tox -e py38-test-deps-mpi4py
 
 should run the tests. You may need to pass ``HDF5_DIR`` depending on the
 location of the HDF5 with MPI support. You can choose which python version to


### PR DESCRIPTION
This PR updates the documentation and Pull Request template to advertise the use of `tox -e py38-test-deps`  since Python3.7 is no longer supported by `h5py` and `tox -e py37-test-deps` fails.


<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py37-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->
