### PR TITLE
WHL: enable cp313t nightly builds

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -39,12 +39,13 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BEFORE_BUILD: "pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy && pip install \"Cython>=0.29.31,<4\" pkgconfig \"setuptools>=61\""
+          CIBW_BEFORE_BUILD: "pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy && pip install git+https://github.com/Cython/Cython.git pkgconfig \"setuptools>=61\""
           CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
-          CIBW_BUILD: "cp3{9,10,11,12,13}-manylinux_x86_64"
+          CIBW_BUILD: "cp3{9,10,11,12,13,13t}-manylinux_x86_64"
           CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/h5py/manylinux2014_x86_64-hdf5
           CIBW_ENVIRONMENT: "CFLAGS=-g1"
           CIBW_PRERELEASE_PYTHONS: true
+          CIBW_FREE_THREADED_SUPPORT: true
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}


### PR DESCRIPTION
Follow up to #2447, this time add cp313*t* wheels for CPython free-threading (a.k.a "no GIL") flavor.
Currently this requires building Cython from source: effort to support free-threading [is underway](https://github.com/cython/cython/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22nogil+CPython%22) but not released yet.
To my surprise, the trial run on my fork revealed no problem, so I guess we can just roll with it ?