### PR TITLE
Expose fill time property via the high-level dataset creation interface

### DIFF
--- a/docs/high/group.rst
+++ b/docs/high/group.rst
@@ -386,10 +386,10 @@ Reference
             following choices: `alloc`, write fill value before writing
             application data values or when the dataset is created; `never`,
             never write fill value; `ifset`, write fill value if it is defined.
-            Default to `alloc` for chunked storage, `ifset` for contiguous
-            storage. If the whole dataset is going to be written by the
-            application, setting this to `never` can avoid unnecessary writing
-            of fill value and potentially improve performance.
+            Default to `ifset`, which is the default of HDF5 library. If the
+            whole dataset is going to be written by the application, setting
+            this to `never` can avoid unnecessary writing of fill value and
+            potentially improve performance.
 
         :keyword track_times: Enable dataset creation timestamps (**T**/F).
 

--- a/docs/high/group.rst
+++ b/docs/high/group.rst
@@ -382,6 +382,15 @@ Reference
         :keyword fillvalue: This value will be used when reading
                             uninitialized parts of the dataset.
 
+        :keyword fill_time: Control when to write the fill value. One of the
+            following choices: `alloc`, write fill value before writing
+            application data values or when the dataset is created; `never`,
+            never write fill value; `ifset`, write fill value if it is defined.
+            Default to `alloc` for chunked storage, `ifset` for contiguous
+            storage. If the whole dataset is going to be written by the
+            application, setting this to `never` can avoid unnecessary writing
+            of fill value and potentially improve performance.
+
         :keyword track_times: Enable dataset creation timestamps (**T**/F).
 
         :keyword track_order: Track attribute creation order if

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -38,7 +38,8 @@ def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
                   fillvalue=None, scaleoffset=None, track_times=False,
                   external=None, track_order=None, dcpl=None, dapl=None,
                   efile_prefix=None, virtual_prefix=None, allow_unknown_filter=False,
-                  rdcc_nslots=None, rdcc_nbytes=None, rdcc_w0=None):
+                  rdcc_nslots=None, rdcc_nbytes=None, rdcc_w0=None, *,
+                  fill_time=None):
     """ Return a new low-level dataset identifier """
 
     # Convert data to a C-contiguous ndarray
@@ -104,7 +105,8 @@ def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
     dcpl = filters.fill_dcpl(
         dcpl or h5p.create(h5p.DATASET_CREATE), shape, dtype,
         chunks, compression, compression_opts, shuffle, fletcher32,
-        maxshape, scaleoffset, external, allow_unknown_filter)
+        maxshape, scaleoffset, external, allow_unknown_filter,
+        fill_time=fill_time)
 
     if fillvalue is not None:
         # prepare string-type dtypes for fillvalue

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -105,7 +105,7 @@ def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
     dcpl = filters.fill_dcpl(
         dcpl or h5p.create(h5p.DATASET_CREATE), shape, dtype,
         chunks, compression, compression_opts, shuffle, fletcher32,
-        maxshape, scaleoffset, external, allow_unknown_filter, fill_time)
+        maxshape, scaleoffset, external, allow_unknown_filter)
 
     if fillvalue is not None:
         # prepare string-type dtypes for fillvalue

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -35,11 +35,10 @@ MPI = h5.get_config().mpi
 def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
                   chunks=None, compression=None, shuffle=None,
                   fletcher32=None, maxshape=None, compression_opts=None,
-                  fillvalue=None, fill_time=None, scaleoffset=None,
-                  track_times=False, external=None, track_order=None,
-                  dcpl=None, dapl=None, efile_prefix=None, virtual_prefix=None,
-                  allow_unknown_filter=False, rdcc_nslots=None,
-                  rdcc_nbytes=None, rdcc_w0=None):
+                  fillvalue=None, scaleoffset=None, track_times=False,
+                  external=None, track_order=None, dcpl=None, dapl=None,
+                  efile_prefix=None, virtual_prefix=None, allow_unknown_filter=False,
+                  rdcc_nslots=None, rdcc_nbytes=None, rdcc_w0=None):
     """ Return a new low-level dataset identifier """
 
     # Convert data to a C-contiguous ndarray

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -105,7 +105,7 @@ def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
     dcpl = filters.fill_dcpl(
         dcpl or h5p.create(h5p.DATASET_CREATE), shape, dtype,
         chunks, compression, compression_opts, shuffle, fletcher32,
-        maxshape, scaleoffset, external, allow_unknown_filter)
+        maxshape, scaleoffset, external, allow_unknown_filter, write_fill)
 
     if fillvalue is not None:
         # prepare string-type dtypes for fillvalue

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -35,7 +35,7 @@ MPI = h5.get_config().mpi
 def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
                   chunks=None, compression=None, shuffle=None,
                   fletcher32=None, maxshape=None, compression_opts=None,
-                  fillvalue=None, write_fill=None, scaleoffset=None,
+                  fillvalue=None, fill_time=None, scaleoffset=None,
                   track_times=False, external=None, track_order=None,
                   dcpl=None, dapl=None, efile_prefix=None, virtual_prefix=None,
                   allow_unknown_filter=False, rdcc_nslots=None,
@@ -105,7 +105,7 @@ def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
     dcpl = filters.fill_dcpl(
         dcpl or h5p.create(h5p.DATASET_CREATE), shape, dtype,
         chunks, compression, compression_opts, shuffle, fletcher32,
-        maxshape, scaleoffset, external, allow_unknown_filter, write_fill)
+        maxshape, scaleoffset, external, allow_unknown_filter, fill_time)
 
     if fillvalue is not None:
         # prepare string-type dtypes for fillvalue

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -35,10 +35,11 @@ MPI = h5.get_config().mpi
 def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
                   chunks=None, compression=None, shuffle=None,
                   fletcher32=None, maxshape=None, compression_opts=None,
-                  fillvalue=None, scaleoffset=None, track_times=False,
-                  external=None, track_order=None, dcpl=None, dapl=None,
-                  efile_prefix=None, virtual_prefix=None, allow_unknown_filter=False,
-                  rdcc_nslots=None, rdcc_nbytes=None, rdcc_w0=None):
+                  fillvalue=None, write_fill=None, scaleoffset=None,
+                  track_times=False, external=None, track_order=None,
+                  dcpl=None, dapl=None, efile_prefix=None, virtual_prefix=None,
+                  allow_unknown_filter=False, rdcc_nslots=None,
+                  rdcc_nbytes=None, rdcc_w0=None):
     """ Return a new low-level dataset identifier """
 
     # Convert data to a C-contiguous ndarray

--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -150,7 +150,7 @@ class Gzip(FilterRefBase):
 
 def fill_dcpl(plist, shape, dtype, chunks, compression, compression_opts,
               shuffle, fletcher32, maxshape, scaleoffset, external,
-              allow_unknown_filter=False, write_fill=None):
+              allow_unknown_filter=False, fill_time=None):
     """ Generate a dataset creation property list.
 
     Undocumented and subject to change without warning.
@@ -264,22 +264,22 @@ def fill_dcpl(plist, shape, dtype, chunks, compression, compression_opts,
     if chunks is not None:
         plist.set_chunk(chunks)
 
-    if write_fill is None:
+    if fill_time is None:
         if chunks is None:
-            write_fill = 'ifset'
+            fill_time = 'ifset'
         else:
-            write_fill = 'alloc'  # prevent resize glitch
+            fill_time = 'alloc'  # prevent resize glitch
     else:
-        invalid_fill_time = (isinstance(write_fill, str) and
-                             write_fill.lower() not in
+        invalid_fill_time = (isinstance(fill_time, str) and
+                             fill_time.lower() not in
                              ('alloc', 'never', 'ifset'))
-        fill_time_not_str = not isinstance(write_fill, str)
+        fill_time_not_str = not isinstance(fill_time, str)
         if invalid_fill_time or fill_time_not_str:
-            msg = ("write_fill must be one of the following choices: 'alloc', "
-                   f"'never' or 'ifset', but it is {write_fill}.")
+            msg = ("fill_time must be one of the following choices: 'alloc', "
+                   f"'never' or 'ifset', but it is {fill_time}.")
             raise ValueError(msg)
 
-    plist.set_fill_time(_FILL_TIME_ENUM[write_fill.lower()])
+    plist.set_fill_time(_FILL_TIME_ENUM[fill_time.lower()])
 
     # scale-offset must come before shuffle and compression
     if scaleoffset is not None:

--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -150,7 +150,7 @@ class Gzip(FilterRefBase):
 
 def fill_dcpl(plist, shape, dtype, chunks, compression, compression_opts,
               shuffle, fletcher32, maxshape, scaleoffset, external,
-              allow_unknown_filter=False, fill_time=None):
+              allow_unknown_filter=False):
     """ Generate a dataset creation property list.
 
     Undocumented and subject to change without warning.

--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -146,7 +146,7 @@ class Gzip(FilterRefBase):
 
 def fill_dcpl(plist, shape, dtype, chunks, compression, compression_opts,
               shuffle, fletcher32, maxshape, scaleoffset, external,
-              allow_unknown_filter=False):
+              allow_unknown_filter=False, write_fill=None):
     """ Generate a dataset creation property list.
 
     Undocumented and subject to change without warning.

--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -275,7 +275,7 @@ def fill_dcpl(plist, shape, dtype, chunks, compression, compression_opts,
                    f"'never' or 'ifset', but it is {fill_time}.")
             raise ValueError(msg)
 
-    plist.set_fill_time(_FILL_TIME_ENUM[fill_time.lower()])
+    plist.set_fill_time(_FILL_TIME_ENUM[fill_time])
 
     # scale-offset must come before shuffle and compression
     if scaleoffset is not None:

--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -52,6 +52,10 @@ _COMP_FILTERS = {'gzip': h5z.FILTER_DEFLATE,
                 'shuffle': h5z.FILTER_SHUFFLE,
                 'fletcher32': h5z.FILTER_FLETCHER32,
                 'scaleoffset': h5z.FILTER_SCALEOFFSET }
+_FILL_TIME_ENUM = {'alloc': h5d.FILL_TIME_ALLOC,
+                   'never': h5d.FILL_TIME_NEVER,
+                   'ifset': h5d.FILL_TIME_IFSET,
+                   }
 
 DEFAULT_GZIP = 4
 DEFAULT_SZIP = ('nn', 8)

--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -150,7 +150,7 @@ class Gzip(FilterRefBase):
 
 def fill_dcpl(plist, shape, dtype, chunks, compression, compression_opts,
               shuffle, fletcher32, maxshape, scaleoffset, external,
-              allow_unknown_filter=False):
+              allow_unknown_filter=False, *, fill_time=None):
     """ Generate a dataset creation property list.
 
     Undocumented and subject to change without warning.

--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -264,18 +264,13 @@ def fill_dcpl(plist, shape, dtype, chunks, compression, compression_opts,
     if chunks is not None:
         plist.set_chunk(chunks)
 
-    if fill_time is None:
-        if chunks is None:
-            fill_time = 'ifset'
+    if fill_time is not None:
+        if (ft := _FILL_TIME_ENUM.get(fill_time)) is not None:
+            plist.set_fill_time(ft)
         else:
-            fill_time = 'alloc'  # prevent resize glitch
-    else:
-        if fill_time not in _FILL_TIME_ENUM:
             msg = ("fill_time must be one of the following choices: 'alloc', "
                    f"'never' or 'ifset', but it is {fill_time}.")
             raise ValueError(msg)
-
-    plist.set_fill_time(_FILL_TIME_ENUM[fill_time])
 
     # scale-offset must come before shuffle and compression
     if scaleoffset is not None:

--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -263,7 +263,6 @@ def fill_dcpl(plist, shape, dtype, chunks, compression, compression_opts,
 
     if chunks is not None:
         plist.set_chunk(chunks)
-        plist.set_fill_time(h5d.FILL_TIME_ALLOC)  # prevent resize glitch
 
     if write_fill is None:
         if chunks is None:
@@ -279,6 +278,8 @@ def fill_dcpl(plist, shape, dtype, chunks, compression, compression_opts,
             msg = ("write_fill must be one of the following choices: 'alloc', "
                    f"'never' or 'ifset', but it is {write_fill}.")
             raise ValueError(msg)
+
+    plist.set_fill_time(_FILL_TIME_ENUM[write_fill.lower()])
 
     # scale-offset must come before shuffle and compression
     if scaleoffset is not None:

--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -270,11 +270,7 @@ def fill_dcpl(plist, shape, dtype, chunks, compression, compression_opts,
         else:
             fill_time = 'alloc'  # prevent resize glitch
     else:
-        invalid_fill_time = (isinstance(fill_time, str) and
-                             fill_time.lower() not in
-                             ('alloc', 'never', 'ifset'))
-        fill_time_not_str = not isinstance(fill_time, str)
-        if invalid_fill_time or fill_time_not_str:
+        if fill_time not in _FILL_TIME_ENUM:
             msg = ("fill_time must be one of the following choices: 'alloc', "
                    f"'never' or 'ifset', but it is {fill_time}.")
             raise ValueError(msg)

--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -265,6 +265,21 @@ def fill_dcpl(plist, shape, dtype, chunks, compression, compression_opts,
         plist.set_chunk(chunks)
         plist.set_fill_time(h5d.FILL_TIME_ALLOC)  # prevent resize glitch
 
+    if write_fill is None:
+        if chunks is None:
+            write_fill = 'ifset'
+        else:
+            write_fill = 'alloc'  # prevent resize glitch
+    else:
+        invalid_fill_time = (isinstance(write_fill, str) and
+                             write_fill.lower() not in
+                             ('alloc', 'never', 'ifset'))
+        fill_time_not_str = not isinstance(write_fill, str)
+        if invalid_fill_time or fill_time_not_str:
+            msg = ("write_fill must be one of the following choices: 'alloc', "
+                   f"'never' or 'ifset', but it is {write_fill}.")
+            raise ValueError(msg)
+
     # scale-offset must come before shuffle and compression
     if scaleoffset is not None:
         if dtype.kind in ('u', 'i'):

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -498,6 +498,7 @@ class TestFillTime(BaseDataset):
         self.assertEqual(dset[0], 4.0)
         self.assertEqual(dset[7], 4.0)
 
+    @ut.skipIf('gzip' not in h5py.filters.encode, "DEFLATE is not installed")
     def test_compressed_default(self):
         """ Fill time is ALLOC for compressed dataset (chunked) """
         dset = self.f.create_dataset('foo', (10,), compression='gzip',

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -534,6 +534,31 @@ class TestFillTime(BaseDataset):
         with self.assertRaises(ValueError):
             dset = self.f.create_dataset('foo', (10,), fill_time=2)
 
+    def test_resize_chunk_fill_time_default(self):
+        """ The resize dataset will be filled (by default fill value 0) """
+        dset = self.f.create_dataset('foo', (50, ), maxshape=(100, ),
+                                     chunks=(5, ))
+        plist = dset.id.get_create_plist()
+        self.assertEqual(plist.get_fill_time(), h5py.h5d.FILL_TIME_IFSET)
+
+        assert np.isclose(dset[:], 0.0).all()
+
+        dset.resize((100, ))
+        assert np.isclose(dset[:], 0.0).all()
+
+    def test_resize_chunk_fill_time_never(self):
+        """ The resize dataset won't be filled """
+        dset = self.f.create_dataset('foo', (50, ), maxshape=(100, ),
+                                     fillvalue=4.0, fill_time='never',
+                                     chunks=(5, ))
+        plist = dset.id.get_create_plist()
+        self.assertEqual(plist.get_fill_time(), h5py.h5d.FILL_TIME_NEVER)
+
+        assert not np.isclose(dset[:], 4.0).any()
+
+        dset.resize((100, ))
+        assert not np.isclose(dset[:], 4.0).any()
+
 
 @pytest.mark.parametrize('dt,expected', [
     (int, 0),

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -482,29 +482,21 @@ class TestFillTime(BaseDataset):
         Feature: Datasets created with specified fill time property
     """
 
-    def test_contiguous_default(self):
-        """ Fill time default to IFSET for contiguous storage """
+    def test_fill_time_default(self):
+        """ Fill time default to IFSET """
         dset = self.f.create_dataset('foo', (10,), fillvalue=4.0)
         plist = dset.id.get_create_plist()
         self.assertEqual(plist.get_fill_time(), h5py.h5d.FILL_TIME_IFSET)
         self.assertEqual(dset[0], 4.0)
         self.assertEqual(dset[7], 4.0)
 
-    def test_chunk_default(self):
-        """ Fill time default to ALLOC for chunked storage """
-        dset = self.f.create_dataset('foo', (10,), chunks=(2,), fillvalue=4.0)
-        plist = dset.id.get_create_plist()
-        self.assertEqual(plist.get_fill_time(), h5py.h5d.FILL_TIME_ALLOC)
-        self.assertEqual(dset[0], 4.0)
-        self.assertEqual(dset[7], 4.0)
-
     @ut.skipIf('gzip' not in h5py.filters.encode, "DEFLATE is not installed")
     def test_compressed_default(self):
-        """ Fill time is ALLOC for compressed dataset (chunked) """
+        """ Fill time is IFSET for compressed dataset (chunked) """
         dset = self.f.create_dataset('foo', (10,), compression='gzip',
                                      fillvalue=4.0)
         plist = dset.id.get_create_plist()
-        self.assertEqual(plist.get_fill_time(), h5py.h5d.FILL_TIME_ALLOC)
+        self.assertEqual(plist.get_fill_time(), h5py.h5d.FILL_TIME_IFSET)
         self.assertEqual(dset[0], 4.0)
         self.assertEqual(dset[7], 4.0)
 
@@ -519,16 +511,14 @@ class TestFillTime(BaseDataset):
         self.assertNotEqual(dset[7], 4.0)
 
     def test_fill_time_alloc(self):
-        """ Fill time explicitly set to ALLOC (default is IFSET for contiguous
-        storage """
+        """ Fill time explicitly set to ALLOC """
         dset = self.f.create_dataset('foo', (10,), fillvalue=4.0,
                                      fill_time='alloc')
         plist = dset.id.get_create_plist()
         self.assertEqual(plist.get_fill_time(), h5py.h5d.FILL_TIME_ALLOC)
 
     def test_fill_time_ifset(self):
-        """ Fill time explicitly set to IFSET (default is ALLOC for chunked
-        storage """
+        """ Fill time explicitly set to IFSET """
         dset = self.f.create_dataset('foo', (10,), chunks=(2,), fillvalue=4.0,
                                      fill_time='ifset')
         plist = dset.id.get_create_plist()

--- a/news/expose_fill_time.rst
+++ b/news/expose_fill_time.rst
@@ -1,3 +1,11 @@
+Breaking Changes and Deprecations
+------------
+
+* Fill time for chunked storage was set to ``h5d.FILL_TIME_ALLOC``. Now this
+  is handled by HDF5 library where the default is ``h5d.FILL_TIME_IFSET``
+  (equivalent to ``fill_time='ifset'``). Please use ``fill_time='alloc'`` if
+  the behaviour in previous releases is wanted.
+
 Exposing HDF5 functions
 -----------------------
 

--- a/news/expose_fill_time.rst
+++ b/news/expose_fill_time.rst
@@ -1,0 +1,5 @@
+Exposing HDF5 functions
+-----------------------
+
+* Expose fill time option in dataset creation property list via the
+  ``fill_time`` parameter in ``create_dataset``.


### PR DESCRIPTION
This PR exposes the fill time property via the high-level dataset creation interface. This is my first PR to `h5py` so feel free to let me know what I could have missed. Thank you.

For the motivation of this PR, please see #2459.

Ready for review.

Upon merging, this closes #2459.