### PR TITLE
MNT: Fix hdf5 download link in CI

### DIFF
--- a/ci/get_hdf5_if_needed.sh
+++ b/ci/get_hdf5_if_needed.sh
@@ -35,7 +35,7 @@ else
         echo "building HDF5"
 
         IFS='.-' read MAJOR_V MINOR_V REL_V PATCH_V <<< "$HDF5_VERSION"
-        # the assets in GitHub (currently) has two naming conventions
+        # the assets in GitHub (currently) have two naming conventions
         if [[ -n "${PATCH_V}" ]]; then
             ASSET_FMT1="hdf5-${MAJOR_V}_${MINOR_V}_${REL_V}-${PATCH_V}"
             ASSET_FMT2="hdf5_${MAJOR_V}.${MINOR_V}.${REL_V}.${PATCH_V}"

--- a/ci/get_hdf5_if_needed.sh
+++ b/ci/get_hdf5_if_needed.sh
@@ -64,7 +64,7 @@ else
         url_base="https://github.com/HDFGroup/hdf5/archive/refs/tags/"
         curl -fsSL -o "hdf5-$HDF5_VERSION.tar.gz" "${url_base}${ASSET_FMT1}.tar.gz" || curl -fsSL -o "hdf5-$HDF5_VERSION.tar.gz" "${url_base}${ASSET_FMT2}.tar.gz"
 
-        tar -xzvf hdf5-$HDF5_VERSION.tar.gz --one-top-level --strip-components=1
+        mkdir -p hdf5-$HDF5_VERSION && tar -xzvf hdf5-$HDF5_VERSION.tar.gz --strip-components=1 -C hdf5-$HDF5_VERSION
 
         pushd hdf5-$HDF5_VERSION
 

--- a/ci/get_hdf5_if_needed.sh
+++ b/ci/get_hdf5_if_needed.sh
@@ -55,7 +55,7 @@ else
 
         pushd /tmp
         #                                   Remove trailing .*, to get e.g. '1.12' ↓
-        curl -fsSLO "https://www.hdfgroup.org/ftp/HDF5/releases/hdf5-$MAJOR_V.$MINOR_V/hdf5-$HDF5_VERSION/src/hdf5-$HDF5_VERSION.tar.gz"
+        curl -fsSLO "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-$MAJOR_V.$MINOR_V/hdf5-$HDF5_VERSION/src/hdf5-$HDF5_VERSION.tar.gz"
         tar -xzvf hdf5-$HDF5_VERSION.tar.gz
         pushd hdf5-$HDF5_VERSION
 

--- a/ci/get_hdf5_if_needed.sh
+++ b/ci/get_hdf5_if_needed.sh
@@ -61,12 +61,8 @@ else
         fi
 
         pushd /tmp
-        # temporarily turn off -e option as curl will emit non-zero exit code
-        # as only one assert format is valid
-        # (curl exits with 22 with http code >400)
-        set +e
-        curl -fsSL -o "hdf5-$HDF5_VERSION.tar.gz" "https://github.com/HDFGroup/hdf5/archive/refs/tags/{${ASSET_FMT1},${ASSET_FMT2}}.tar.gz"
-        set -e
+        url_base="https://github.com/HDFGroup/hdf5/archive/refs/tags/"
+        curl -fsSL -o "hdf5-$HDF5_VERSION.tar.gz" "${url_base}${ASSET_FMT1}.tar.gz" || curl -fsSL -o "hdf5-$HDF5_VERSION.tar.gz" "${url_base}${ASSET_FMT2}.tar.gz"
 
         tar -xzvf hdf5-$HDF5_VERSION.tar.gz --one-top-level --strip-components=1
 

--- a/ci/get_hdf5_win.py
+++ b/ci/get_hdf5_win.py
@@ -8,7 +8,7 @@ CI environment which thrown away each time
 """
 
 from os import environ, makedirs, walk, getcwd, chdir
-from os.path import join as pjoin, exists
+from os.path import join as pjoin, exists, basename, dirname
 from tempfile import TemporaryFile, TemporaryDirectory
 from sys import exit, stderr
 from shutil import copy
@@ -17,7 +17,7 @@ from subprocess import run
 from zipfile import ZipFile
 import requests
 
-HDF5_URL = "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-{series}/hdf5-{version}/src/hdf5-{version}.zip"
+HDF5_URL = "https://github.com/HDFGroup/hdf5/archive/refs/tags/{zip_file}"
 ZLIB_ROOT = environ.get('ZLIB_ROOT')
 
 CMAKE_CONFIGURE_CMD = [
@@ -36,7 +36,7 @@ CMAKE_BUILD_CMD = ["cmake", "--build"]
 CMAKE_INSTALL_ARG = ["--target", "install", '--config', 'Release']
 CMAKE_INSTALL_PATH_ARG = "-DCMAKE_INSTALL_PREFIX={install_path}"
 CMAKE_HDF5_LIBRARY_PREFIX = ["-DHDF5_EXTERNAL_LIB_PREFIX=h5py_"]
-REL_PATH_TO_CMAKE_CFG = "hdf5-{version}"
+REL_PATH_TO_CMAKE_CFG = "hdf5-{dir_suffix}"
 DEFAULT_VERSION = '1.12.2'
 VSVERSION_TO_GENERATOR = {
     "9": "Visual Studio 9 2008",
@@ -53,24 +53,33 @@ VSVERSION_TO_GENERATOR = {
 
 
 def download_hdf5(version, outfile):
-    series = '.'.join(version.split(".")[:2])
-    file = HDF5_URL.format(version=version, series=series)
+    zip_fmt1 = "hdf5-" + version.replace(".", "_") + ".zip"
+    zip_fmt2 = "hdf5_" + version.replace("-", ".") + ".zip"
+    files = [HDF5_URL.format(zip_file=zip_fmt1),
+             HDF5_URL.format(zip_file=zip_fmt2),
+             ]
 
-    print("Downloading " + file, file=stderr)
-    r = requests.get(file, stream=True)
-    try:
-        r.raise_for_status()
-    except requests.HTTPError:
-        print("Failed to download hdf5 version {version}, exiting".format(
-            version=version
-        ), file=stderr)
-        exit(1)
-    else:
-        for chunk in r.iter_content(chunk_size=None):
-            outfile.write(chunk)
+    for file in files:
+        print(f"Downloading hdf5 from {file} ...", file=stderr)
+        r = requests.get(file, stream=True)
+        try:
+            r.raise_for_status()
+        except requests.HTTPError:
+            print(f"Failed to download hdf5 from {file}", file=stderr)
+            continue
+        else:
+            for chunk in r.iter_content(chunk_size=None):
+                outfile.write(chunk)
+            print(f"Successfully downloaded hdf5 from {file}", file=stderr)
+            return file
+
+    msg = (f"Cannot download HDF5 source ({version}) from any of the "
+           f"following URLs: {[f for f in files]}")
+    raise RuntimeError(msg)
 
 
-def build_hdf5(version, hdf5_file, install_path, cmake_generator, use_prefix):
+def build_hdf5(version, hdf5_file, install_path, cmake_generator, use_prefix,
+               dl_zip):
     try:
         with TemporaryDirectory() as hdf5_extract_path:
             generator_args = (
@@ -88,7 +97,7 @@ def build_hdf5(version, hdf5_file, install_path, cmake_generator, use_prefix):
                 chdir(new_dir)
                 cfg_cmd = CMAKE_CONFIGURE_CMD + [
                     get_cmake_install_path(install_path),
-                    get_cmake_config_path(version, hdf5_extract_path),
+                    get_cmake_config_path(hdf5_extract_path, dl_zip),
                 ] + generator_args + prefix_args
                 print("Configuring HDF5 version {version}...".format(version=version))
                 print(' '.join(cfg_cmd), file=stderr)
@@ -114,8 +123,9 @@ def build_hdf5(version, hdf5_file, install_path, cmake_generator, use_prefix):
         copy(f, pjoin(install_path, 'lib'))
 
 
-def get_cmake_config_path(version, extract_point):
-    return pjoin(extract_point, REL_PATH_TO_CMAKE_CFG.format(version=version))
+def get_cmake_config_path(extract_point, zip_file):
+    dir_suffix = basename(zip_file).replace(".zip", "")
+    return pjoin(extract_point, REL_PATH_TO_CMAKE_CFG.format(dir_suffix=dir_suffix))
 
 
 def get_cmake_install_path(install_path):
@@ -150,8 +160,9 @@ def main():
 
     if not hdf5_install_cached(install_path):
         with TemporaryFile() as f:
-            download_hdf5(version, f)
-            build_hdf5(version, f, install_path, cmake_generator, use_prefix)
+            dl_zip = download_hdf5(version, f)
+            build_hdf5(version, f, install_path, cmake_generator, use_prefix,
+                       dl_zip)
     else:
         print("using cached hdf5", file=stderr)
     if install_path is not None:

--- a/ci/get_hdf5_win.py
+++ b/ci/get_hdf5_win.py
@@ -17,7 +17,7 @@ from subprocess import run
 from zipfile import ZipFile
 import requests
 
-HDF5_URL = "https://www.hdfgroup.org/ftp/HDF5/releases/hdf5-{series}/hdf5-{version}/src/hdf5-{version}.zip"
+HDF5_URL = "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-{series}/hdf5-{version}/src/hdf5-{version}.zip"
 ZLIB_ROOT = environ.get('ZLIB_ROOT')
 
 CMAKE_CONFIGURE_CMD = [


### PR DESCRIPTION
This small PR fixes the download link of hdf5 libraries, the location `https://www.hdfgroup.org/ftp/...` is not available and the source files are located under `https://support.hdfgroup.org/ftp/...`.

Ready for review.