### PR TITLE
DEP: drop support for CPython 3.8

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -51,7 +51,11 @@ jobs:
         # one for each Python version
         os: [ubuntu-latest]
         arch: [aarch64]
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python:
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
         include:
           - os: ubuntu-latest
             arch: x86_64
@@ -90,11 +94,6 @@ jobs:
       # macOS HDF5
       - run: bash ./ci/cibw_before_all_macos.sh "${{ github.workspace }}"
         if: runner.os == 'macOS'
-      # Hack for 3.8 bug (https://github.com/pypa/cibuildwheel/pull/1871#issuecomment-2161613619)
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.8
-        if: runner.os == 'macOS' && matrix.arch == 'arm64'
 
       # Linux emulation for aarch64 support
       # https://cibuildwheel.pypa.io/en/stable/faq/#emulation

--- a/.github/workflows/lowlevel-api-docs.yml
+++ b/.github/workflows/lowlevel-api-docs.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Install tox
         run: |

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@
 HDF5 for Python
 ===============
 `h5py` is a thin, pythonic wrapper around `HDF5 <https://portal.hdfgroup.org/hdf5/develop/index.html>`_,
-which runs on Python 3 (3.8+).
+which runs on Python 3 (3.9+).
 
 Websites
 --------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,8 @@ environment:
 
     ### USING HDF5 1.10 ###
 
-    - PYTHON: "C:\\Python38"
-      TOXENV: "py38-test-deps"
+    - PYTHON: "C:\\Python39"
+      TOXENV: "py39-test-deps"
       HDF5_VSVERSION: "14"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
       HDF5_VERSION: "1.10.6"
@@ -31,10 +31,10 @@ environment:
 install:
   # We need wheel installed to build wheels
   - "%PYTHON%\\python.exe -m pip install --upgrade wheel pip setuptools"
-  - "py -3.8 -m pip install --upgrade wheel pip setuptools virtualenv"
-  - "py -3.8 -m pip install requests"
-  - "py -3.8 ci\\get_hdf5_win.py"
-  - "py -3.8 -m pip install tox codecov"
+  - "py -3.9 -m pip install --upgrade wheel pip setuptools virtualenv"
+  - "py -3.9 -m pip install requests"
+  - "py -3.9 ci\\get_hdf5_win.py"
+  - "py -3.9 -m pip install tox codecov"
 
 build: off
 
@@ -43,7 +43,7 @@ test_script:
   # Note that you must use the environment variable %PYTHON% to refer to
   # the interpreter you're using - Appveyor does not do anything special
   # to put the Python evrsion you want to use on PATH.
-  - "py -3.8 -m tox run --discover %PYTHON%\\python.exe"
+  - "py -3.9 -m tox run --discover %PYTHON%\\python.exe"
 
 # This is commented out as there's no easy way to deal with numpy dropping
 # older python versions without a recent pip/setuptools.
@@ -60,4 +60,4 @@ cache:
   - "C:\\hdf5"
 
 on_success:
-  - "py -3.8 ci\\upload_coverage.py"
+  - "py -3.9 ci\\upload_coverage.py"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,23 +34,23 @@ jobs:
       # -tables : also check compatibility with pytables
     # HDF5 installed from apt on Ubuntu
     # test when we're not in a unicode locale
-      py38-Clocale:
-        python.version: '3.8'
-        TOXENV: py38-test-deps
+      py39-Clocale:
+        python.version: '3.9'
+        TOXENV: py39-test-deps
         TOX_TESTENV_PASSENV: LANG LC_ALL
         LANG: C
         LC_ALL: C
         H5PY_ENFORCE_COVERAGE: yes
     # Build HDF5 1.10 or 1.12 in the test environment
-      py38-deps-hdf51107:
-        python.version: '3.8'
-        TOXENV: py38-test-deps
+      py39-deps-hdf51107:
+        python.version: '3.9'
+        TOXENV: py39-test-deps
         HDF5_VERSION: 1.10.7
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         H5PY_ENFORCE_COVERAGE: yes
-      py38-deps-hdf51120:
-        python.version: '3.8'
-        TOXENV: py38-test-deps
+      py39-deps-hdf51120:
+        python.version: '3.9'
+        TOXENV: py39-test-deps
         HDF5_VERSION: 1.12.0
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         H5PY_ENFORCE_COVERAGE: yes
@@ -102,9 +102,9 @@ jobs:
         H5PY_ENFORCE_COVERAGE: yes
     # 64 bit - HDF5 1.12
     # Fewer combinations here; test_windows_wheels also tests HDF5 1.12
-      py38-hdf5112:
-        python.version: '3.8'
-        TOXENV: py38-test-deps
+      py39-hdf5112:
+        python.version: '3.9'
+        TOXENV: py39-test-deps
         HDF5_VERSION: 1.12.0
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         HDF5_VSVERSION: "16-64"
@@ -135,9 +135,9 @@ jobs:
       # -deps : test with default (latest) versions of dependencies
       # -mindeps : test with oldest supported version of (python) dependencies
       # -deps-pre : test pre-release versions of (python) dependencies)
-      py38:
-        python.version: '3.8'
-        TOXENV: py38-test-deps,py38-test-mindeps,py38-test-deps-pre
+      py39:
+        python.version: '3.9'
+        TOXENV: py39-test-deps,py39-test-mindeps,py39-test-deps-pre
         H5PY_ENFORCE_COVERAGE: yes
       py310:
         python.version: '3.10'

--- a/ci/azure-pipelines-steps.yml
+++ b/ci/azure-pipelines-steps.yml
@@ -75,8 +75,8 @@ steps:
       displayName: 'ensure HDF5'
 - ${{ if eq(parameters.shell, 'cmd') }}:
     - script: |
-        py -3.7 -m pip install requests
-        py -3.7 ci\\get_hdf5_win.py
+        py -3.9 -m pip install requests
+        py -3.9 ci\\get_hdf5_win.py
       displayName: 'ensure HDF5'
 
 - script: env

--- a/ci/get_hdf5_win.py
+++ b/ci/get_hdf5_win.py
@@ -125,7 +125,7 @@ def build_hdf5(version, hdf5_file, install_path, cmake_generator, use_prefix,
 
 
 def get_cmake_config_path(extract_point, zip_file):
-    dir_suffix = basename(zip_file).replace(".zip", "")
+    dir_suffix = basename(zip_file).removesuffix(".zip")
     return pjoin(extract_point, REL_PATH_TO_CMAKE_CFG.format(dir_suffix=dir_suffix))
 
 

--- a/ci/triage_build.sh
+++ b/ci/triage_build.sh
@@ -37,8 +37,8 @@ CIBW_PRERELEASE_PYTHONS=false
 # If it's a scheduled build or [pip-pre] in commit message, use pip-pre
 if [[ "$GITHUB_EVENT_NAME" == "schedule" ]] || [[ "$MSG" = *'[pip-pre]'* ]]; then
     echo "Using NumPy pip-pre wheel and (on Linux) enabling Python 3.13 for wheel building, setting CIBW_BEFORE_BUILD, CIBW_BUILD_FRONTEND, and CIBW_PRERELEASE_PYTHONS"
-    # No Python 3.9 or 3.10 on scientific-python-nightly-wheels
-    CIBW_SKIP="$CIBW_SKIP cp38-* cp39-*"
+    # No Python 3.9 on scientific-python-nightly-wheels
+    CIBW_SKIP="$CIBW_SKIP cp39-*"
     echo "CIBW_BEFORE_BUILD=pip install --pre --only-binary numpy --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \"numpy>=2.1.0.dev0\" \"Cython>=0.29.31,<4\" pkgconfig \"setuptools>=61\" wheel" | tee -a $GITHUB_ENV
     echo "CIBW_BUILD_FRONTEND=pip; args: --no-build-isolation" | tee -a $GITHUB_ENV
     # This is harder on other architectures, so only do it on Linux for now

--- a/news/dep-drop_cp38.rst
+++ b/news/dep-drop_cp38.rst
@@ -1,0 +1,6 @@
+
+Breaking Changes and Deprecations
+---------------------------------
+
+* Support for Python 3.8 was dropped. Python 3.9 or newer is now required
+  to build or install h5py from this version on.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "Cython >=0.29.31,<4",
-    "oldest-supported-numpy; python_version=='3.8'",
-    "numpy >=2.0.0rc1; python_version>='3.9'",
+    "numpy >=2.0.0, <3",
     "pkgconfig",
     "setuptools >=61",
 ]
@@ -37,7 +36,7 @@ classifiers = [
     "Topic :: Database",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dynamic = ["dependencies", "version"]
 
 [project.readme]

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ RUN_REQUIRES = [
     # But we don't want to duplicate the information in oldest-supported-numpy
     # here, and if you can build an older NumPy on a newer Python, h5py probably
     # works (assuming you build it from source too).
-    # NumPy 1.17.3 is the first with wheels for Python 3.8, our minimum Python.
-    "numpy >=1.17.3",
+    # NumPy 1.19.3 is the first with wheels for Python 3.9, our minimum Python.
+    "numpy >=1.19.3",
 ]
 
 # Packages needed to build h5py (in addition to static list in pyproject.toml)

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # We want an envlist like
 # envlist = {py36,py37,pypy3}-{test}-{deps,mindeps}-{,mpi4py}-{,pre},nightly,docs,checkreadme,pre-commit
 # but we want to skip mpi and pre by default, so this envlist is below
-envlist = {py38,py39,py310,py311,py312,pypy3}-{test}-{deps,mindeps},nightly,docs,apidocs,checkreadme,pre-commit,rever
+envlist = {py39,py310,py311,py312,pypy3}-{test}-{deps,mindeps},nightly,docs,apidocs,checkreadme,pre-commit,rever
 isolated_build = True
 
 [testenv]
@@ -12,7 +12,6 @@ deps =
     test: pytest-mpi>=0.2
 
     # For --pre, 2.0.0b1 has a header size difference that has been reverted, so avoid it
-    py38-deps: numpy>=1.17.5
     py39-deps: numpy>=1.19.3,!=2.0.0b1
     py310-deps: numpy>=1.21.3,!=2.0.0b1
     py311-deps: numpy>=1.23.2,!=2.0.0b1
@@ -59,7 +58,7 @@ pip_pre =
 
 [testenv:nightly]
 pip_pre = True
-basepython = python3.8
+basepython = python3.9
 
 [testenv:docs]
 skip_install=True


### PR DESCRIPTION
Python 3.8 will be EOL in less than 2 months, and the previous such bump happened more than a year ago (https://github.com/h5py/h5py/pull/2262), so I figured I would go for it now.