### PR TITLE
Allow for a .N patch version in HDF5_VERSION environment variable

### DIFF
--- a/setup_configure.py
+++ b/setup_configure.py
@@ -44,10 +44,11 @@ def stash_config(dct):
 
 def validate_version(s):
     """Ensure that s contains an X.Y.Z format version string, or ValueError."""
-    m = re.match('(\d+)\.(\d+)\.(\d+)$', s)
+    # HDF5 tags can have a patch version, which we'll ignore for now.
+    m = re.match('(\d+)\.(\d+)\.(\d+)(?:\.\d+)?$', s)
     if m:
         return tuple(int(x) for x in m.groups())
-    raise ValueError(f"HDF5 version string {s!r} not in X.Y.Z format")
+    raise ValueError(f"HDF5 version string {s!r} not in X.Y.Z[.P] format")
 
 
 def mpi_enabled():


### PR DESCRIPTION
I accidentally broke CI by setting HDF5_VERSION in the hdf5-manylinux images to 1.14.4.3, forgetting that this is also used in h5py's build machinery. This should ignore the `.3` patch version.