### PR TITLE
Turn down cibuildwheel verbosity setting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ packages = [
 ]
 
 [tool.cibuildwheel]
-build-verbosity = 3
+build-verbosity = 1
 build-frontend = { name = "pip", args = ["--only-binary", "numpy"] }
 manylinux-x86_64-image = "ghcr.io/h5py/manylinux2014_x86_64-hdf5"
 manylinux-aarch64-image = "ghcr.io/h5py/manylinux2014_aarch64-hdf5"


### PR DESCRIPTION
Verbosity 3 results in literally thousands of lines from pip like

```
 Skipping link: none of the wheel's tags (cp26-cp26mu-manylinux1_x86_64) are compatible (run pip debug --verbose to show compatible tags): https://files.pythonhosted.org/packages/c2/b0/83750b90ee3a65b944c67e2336fccb0486a1bca5c89e6c5f15cf640c88e7/Cython-0.17-cp26-cp26mu-manylinux1_x86_64.whl (from https://pypi.org/simple/cython/)
```

Which makes it harder to look through build logs for more common issues. So I propose to turn this setting down to 1 (i.e. `pip -v` rather than `-vvv`).