### PR TITLE
WHL: enable cp313 wheels on Windows AMD64

### DIFF
--- a/ci/triage_build.sh
+++ b/ci/triage_build.sh
@@ -47,9 +47,6 @@ if [[ "$GITHUB_EVENT_NAME" == "schedule" ]] || [[ "$MSG" = *'[pip-pre]'* ]]; the
     fi
     echo "CIBW_BEFORE_TEST=pip install --pre --only-binary numpy --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \"numpy>=2.1.0.dev0\"" | tee -a $GITHUB_ENV
 fi
-if [[ "$ARCH" == "AMD64" ]]; then
-    CIBW_SKIP="$CIBW_SKIP cp313-*"
-fi
 
 # replace dots in PYTHON with nothing, e.g., 3.8->38
 CIBW_BUILD="cp${PYTHON//./}-*_$ARCH"


### PR DESCRIPTION
Revert my temporary patch from #2470
Close #2476

I'm hoping this just works now that NumPy 2.1 is on PyPI with cp313 wheels 🤞🏻 
