### PR TITLE
BLD: add freethreading_compatible Cython markers

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -98,6 +98,7 @@ jobs:
           CIBW_BUILD_FRONTEND: ${{ env.CIBW_BUILD_FRONTEND }}
           CIBW_PRERELEASE_PYTHONS: ${{ env.CIBW_PRERELEASE_PYTHONS }}
           CIBW_BEFORE_TEST: ${{ env.CIBW_BEFORE_TEST }}
+          CIBW_ENABLE: cpython-freethreading
 
       - run: python ./ci/bundle_hdf5_whl.py wheelhouse
         if: runner.os == 'Windows'

--- a/api_gen.py
+++ b/api_gen.py
@@ -144,6 +144,7 @@ class Line:
 
 raw_preamble = """\
 # cython: language_level=3
+# cython: freethreading_compatible=True
 #
 # Warning: this file is auto-generated from api_gen.py. DO NOT EDIT!
 #
@@ -156,6 +157,7 @@ from .api_types_ext cimport *
 
 def_preamble = """\
 # cython: language_level=3
+# cython: freethreading_compatible=True
 #
 # Warning: this file is auto-generated from api_gen.py. DO NOT EDIT!
 #
@@ -169,6 +171,7 @@ from .api_types_ext cimport *
 
 imp_preamble = """\
 # cython: language_level=3
+# cython: freethreading_compatible=True
 #
 # Warning: this file is auto-generated from api_gen.py. DO NOT EDIT!
 #

--- a/ci/cibw_test_command.sh
+++ b/ci/cibw_test_command.sh
@@ -11,7 +11,7 @@ echo "PROJECT_PATH=$PROJECT_PATH"
 WHEEL_PATH=$2
 echo "WHEEL_PATH=$WHEEL_PATH"
 
-export PYVER=$(python -c "import sys; print(''.join(map(str, sys.version_info[:2])))")
+export PYVER=$(python -c "import sys; print(''.join(map(str, sys.version_info[:2])) + ('t' if (sys.version_info>=(3,13) and not sys._is_gil_enabled()) else ''))")
 ENVLIST="py$PYVER-test-deps,py$PYVER-test-mindeps,py$PYVER-test-deps-pre"
 export H5PY_TEST_CHECK_FILTERS=1
 echo "ENVLIST=$ENVLIST"

--- a/h5py/_conv.pyx
+++ b/h5py/_conv.pyx
@@ -1,5 +1,6 @@
 # cython: profile=False
 # cython: language_level=3
+# cython: freethreading_compatible=True
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/_errors.pyx
+++ b/h5py/_errors.pyx
@@ -1,3 +1,4 @@
+# cython: freethreading_compatible=True
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/_objects.pyx
+++ b/h5py/_objects.pyx
@@ -1,3 +1,4 @@
+# cython: freethreading_compatible=True
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/_proxy.pyx
+++ b/h5py/_proxy.pyx
@@ -1,4 +1,5 @@
 # cython: profile=False
+# cython: freethreading_compatible=True
 
 # This file is part of h5py, a Python interface to the HDF5 library.
 #

--- a/h5py/_selector.pyx
+++ b/h5py/_selector.pyx
@@ -1,4 +1,5 @@
 # cython: language_level=3
+# cython: freethreading_compatible=True
 """Class to efficiently select and read data from an HDF5 dataset
 
 This is written in Cython to reduce overhead when reading small amounts of

--- a/h5py/h5.pxd
+++ b/h5py/h5.pxd
@@ -1,4 +1,5 @@
 # cython: language_level=3
+# cython: freethreading_compatible=True
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5.pyx
+++ b/h5py/h5.pyx
@@ -1,4 +1,5 @@
 # cython: language_level=3
+# cython: freethreading_compatible=True
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5a.pyx
+++ b/h5py/h5a.pyx
@@ -1,4 +1,5 @@
 # cython: language_level=3
+# cython: freethreading_compatible=True
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5ac.pyx
+++ b/h5py/h5ac.pyx
@@ -1,3 +1,4 @@
+# cython: freethreading_compatible=True
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5d.pyx
+++ b/h5py/h5d.pyx
@@ -1,4 +1,5 @@
 # cython: language_level=3
+# cython: freethreading_compatible=True
 ## This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5ds.pyx
+++ b/h5py/h5ds.pyx
@@ -1,4 +1,5 @@
 # cython: language_level=3
+# cython: freethreading_compatible=True
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5f.pyx
+++ b/h5py/h5f.pyx
@@ -1,3 +1,4 @@
+# cython: freethreading_compatible=True
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5fd.pyx
+++ b/h5py/h5fd.pyx
@@ -1,3 +1,4 @@
+# cython: freethreading_compatible=True
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5g.pyx
+++ b/h5py/h5g.pyx
@@ -1,4 +1,5 @@
 # cython: language_level=3
+# cython: freethreading_compatible=True
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5i.pyx
+++ b/h5py/h5i.pyx
@@ -1,3 +1,4 @@
+# cython: freethreading_compatible=True
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5l.pyx
+++ b/h5py/h5l.pyx
@@ -1,3 +1,4 @@
+# cython: freethreading_compatible=True
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5o.pyx
+++ b/h5py/h5o.pyx
@@ -1,3 +1,4 @@
+# cython: freethreading_compatible=True
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -1,4 +1,5 @@
 # cython: language_level=3
+# cython: freethreading_compatible=True
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5pl.pyx
+++ b/h5py/h5pl.pyx
@@ -1,4 +1,5 @@
 # cython: language_level=3
+# cython: freethreading_compatible=True
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5r.pyx
+++ b/h5py/h5r.pyx
@@ -1,4 +1,5 @@
 # cython: language_level=3
+# cython: freethreading_compatible=True
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5s.pyx
+++ b/h5py/h5s.pyx
@@ -1,4 +1,5 @@
 # cython: language_level=3
+# cython: freethreading_compatible=True
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -1,4 +1,5 @@
 # cython: language_level=3
+# cython: freethreading_compatible=True
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5z.pyx
+++ b/h5py/h5z.pyx
@@ -1,3 +1,4 @@
+# cython: freethreading_compatible=True
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/utils.pyx
+++ b/h5py/utils.pyx
@@ -1,5 +1,6 @@
 # cython: language_level=3
 # cython: profile=False
+# cython: freethreading_compatible=True
 
 # This file is part of h5py, a Python interface to the HDF5 library.
 #

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # We want an envlist like
 # envlist = {py36,py37,pypy3}-{test}-{deps,mindeps}-{,mpi4py}-{,pre},nightly,docs,checkreadme,pre-commit
 # but we want to skip mpi and pre by default, so this envlist is below
-envlist = {py39,py310,py311,py312,pypy3}-{test}-{deps,mindeps},nightly,docs,apidocs,checkreadme,pre-commit,rever
+envlist = {py39,py310,py311,py312,py313,py313t,pypy3}-{test}-{deps,mindeps},nightly,docs,apidocs,checkreadme,pre-commit,rever
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
partially address #2475
All this does is avoid reenabling the GIL on import for extension modules, and on Python 3.13t: it is not a claim for complete thread-safety, rather a declaration of intention that we want to do it and make it easier for downstream testers at least try it out so we can prioritize real-world applications when we start actually implementing thread safety (if needed).