### PR TITLE
BLD: only generate Cython code that will compile against current configuration

### DIFF
--- a/setup_build.py
+++ b/setup_build.py
@@ -152,7 +152,7 @@ class h5py_build_ext(build_ext):
 
         # Refresh low-level defs if missing or stale
         print("Executing api_gen rebuild of defs")
-        api_gen.run()
+        api_gen.run(config)
 
         # Rewrite config.pxi file if needed
         s = f"""\


### PR DESCRIPTION
Build on top of #2479 and partially address #2445. This eliminates about 60% of Cython warnings related to the deprecation of `IF` in my case.