### PR TITLE
RFC: refactor some platform-dependent Cython code to avoid deprecated `IF`

### DIFF
--- a/h5py/api_types_ext.pxd
+++ b/h5py/api_types_ext.pxd
@@ -22,10 +22,12 @@ from libc.time cimport time_t
 
 from libc.stdint cimport int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t
 
-IF UNAME_SYSNAME != "Windows":
-    cdef extern from "unistd.h":
-        ctypedef long ssize_t
-ELSE:
+cdef extern from *:
+    """
+    #if !(defined(_WIN32) || defined(MS_WINDOWS) || defined(_MSC_VER))
+      #include <unistd.h>
+    #endif
+    """
     ctypedef long ssize_t
 
 # Can't use Cython defs because they keep moving them around

--- a/h5py/h5g.pyx
+++ b/h5py/h5g.pyx
@@ -14,6 +14,8 @@
 
 include "config.pxi"
 
+import sys
+
 # C-level imports
 from ._objects cimport pdefault
 from .utils cimport emalloc, efree
@@ -24,6 +26,9 @@ from ._errors cimport set_error_handler, err_cookie
 
 # Python level imports
 from ._objects import phil, with_phil
+
+
+_IS_WINDOWS = sys.platform.startswith("win")
 
 # === Public constants and data structures ====================================
 
@@ -389,9 +394,9 @@ cdef class GroupID(ObjectID):
         if statbuf.type != H5G_LINK:
             raise ValueError('"%s" is not a symbolic link.' % name)
 
-        IF UNAME_SYSNAME == "Windows":
+        if _IS_WINDOWS:
             linklen = 2049  # Windows statbuf.linklen seems broken
-        ELSE:
+        else:
             linklen = statbuf.linklen+1
         value = <char*>emalloc(sizeof(char)*linklen)
         try:


### PR DESCRIPTION
A small contribution towards closing #2445