### PR TITLE
DOC: unlimited maxshape for 1D Datasets

### DIFF
--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -214,6 +214,11 @@ axes using ``None``::
 
     >>> dset = f.create_dataset("unlimited", (10, 10), maxshape=(None, 10))
 
+While integers can be passed to ``maxshape`` for one-dimensional datasets, a tuple
+of length 1 must be passed for an unlimited maximum shape of the 1D-shaped dataset,
+i.e. ``(None,)``. Using only ``None`` instead of an integer will lead to the default 
+behaviour, having a ``maxshape`` identical to ``shape``.
+
 .. note:: Resizing an array with existing data works differently than in NumPy; if
     any axis shrinks, the data in the missing region is discarded.  Data does
     not "rearrange" itself as it does when resizing a NumPy array.

--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -214,7 +214,7 @@ axes using ``None``::
 
     >>> dset = f.create_dataset("unlimited", (10, 10), maxshape=(None, 10))
 
-For a 1D dataset, ``maxshape`` can be an integer instead of a tuple. But to make an 
+For a 1D dataset, ``maxshape`` can be an integer instead of a tuple. But to make an
 unlimited 1D dataset, ``maxshape`` must be a tuple ``(None,)``. Passing ``None`` gives
 the default behaviour, where the initial size is also the maximum.
 

--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -216,7 +216,7 @@ axes using ``None``::
 
 While integers can be passed to ``maxshape`` for one-dimensional datasets, a tuple
 of length 1 must be passed for an unlimited maximum shape of the 1D-shaped dataset,
-i.e. ``(None,)``. Using only ``None`` instead of an integer will lead to the default 
+i.e. ``(None,)``. Using only ``None`` instead of an integer will lead to the default
 behaviour, having a ``maxshape`` identical to ``shape``.
 
 .. note:: Resizing an array with existing data works differently than in NumPy; if

--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -214,10 +214,9 @@ axes using ``None``::
 
     >>> dset = f.create_dataset("unlimited", (10, 10), maxshape=(None, 10))
 
-While integers can be passed to ``maxshape`` for one-dimensional datasets, a tuple
-of length 1 must be passed for an unlimited maximum shape of the 1D-shaped dataset,
-i.e. ``(None,)``. Using only ``None`` instead of an integer will lead to the default
-behaviour, having a ``maxshape`` identical to ``shape``.
+For a 1D dataset, ``maxshape`` can be an integer instead of a tuple. But to make an 
+unlimited 1D dataset, ``maxshape`` must be a tuple ``(None,)``. Passing ``None`` gives
+the default behaviour, where the initial size is also the maximum.
 
 .. note:: Resizing an array with existing data works differently than in NumPy; if
     any axis shrinks, the data in the missing region is discarded.  Data does

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -90,8 +90,8 @@ class Group(HLObject, MutableMappingHDF5):
         maxshape
             (Tuple or int) Make the dataset resizable up to this shape. Use None for
             axes within the tuple you want to be unlimited. Integers can be used for 1D shape.
-            For 1D datsets with quasi-unlimited maxshape, a shape tuple of length 1 must be 
-            provided, ``(None,)``. Passing ``None`` sets ``maxshape` to `shape`, making the 
+            For 1D datsets with quasi-unlimited maxshape, a shape tuple of length 1 must be
+            provided, ``(None,)``. Passing ``None`` sets ``maxshape` to `shape`, making the
             dataset un-resizable, which is the default.
         compression
             (String or int) Compression strategy.  Legal values are 'gzip',

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -90,7 +90,7 @@ class Group(HLObject, MutableMappingHDF5):
         maxshape
             (Tuple or int) Make the dataset resizable up to this shape. Use None for
             axes within the tuple you want to be unlimited. Integers can be used for 1D shape.
-            For 1D datsets with quasi-unlimited maxshape, a shape tuple of length 1 must be
+            For 1D datsets with unlimited maxshape, a shape tuple of length 1 must be
             provided, ``(None,)``. Passing ``None`` sets ``maxshape` to `shape`, making the
             dataset un-resizable, which is the default.
         compression

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -89,7 +89,10 @@ class Group(HLObject, MutableMappingHDF5):
 
         maxshape
             (Tuple or int) Make the dataset resizable up to this shape. Use None for
-            axes you want to be unlimited. Integers can be used for 1D shape.
+            axes within the tuple you want to be unlimited. Integers can be used for 1D shape.
+            For 1D datsets with quasi-unlimited maxshape, a shape tuple of length 1 must be 
+            provided, ``(None,)``. Passing ``None`` sets ``maxshape` to `shape`, making the 
+            dataset un-resizable, which is the default.
         compression
             (String or int) Compression strategy.  Legal values are 'gzip',
             'szip', 'lzf'.  If an integer in range(10), this indicates gzip


### PR DESCRIPTION
I ran into a minor lack of documentation, which might actually be pretty obvious for advanced users, and I also figured it out quite fast, but I anyway wanted to ask if it is of interest, to extend the documentation on this level. Just to illustrate the problem, here a MWE:

```py
N_tsvd_iterations = 10
with h5py.File("foobar.h5", 'w-') as f:
    dset = f.create_dataset('test_data', (N_tsvd_iterations,), maxshape=None, 
                      chunks=True, dtype=np.float64)
    print(dset.shape)
    print(dset.maxshape)
    dset = f.create_dataset('test_data_2', (N_tsvd_iterations,), maxshape=(None,), 
                      chunks=True, dtype=np.float64)
    print(dset.shape)
    print(dset.maxshape)
```
The output reads as follows:
```
(10,)
(10,)
(10,)
(None,)
```

While it is somewhat obvious, since passing `maxshape=None` is identical to not passing it at all, one may anyways run into the issue when extending a finite `maxshape` to an unlimited one, i. e. naively replacing the given finite integer with `None`.

Therefore, I mentioned this case both in the docstring of `create_dataset` and in the main documentation of `Dataset`. Maybe there are better ways of handling this special case, but for the moment, I thought it would be good to just document it.

What do you think about this case?


PS: I did not run any tests as asked in the template as I didn't change any python code, only docs. Should I anyway do it? Probably it would make more sense to test build the documentation, wouldn't it?
