### PR TITLE
WHL: don't skip cp39 nightly wheels

### DIFF
--- a/ci/triage_build.sh
+++ b/ci/triage_build.sh
@@ -36,9 +36,7 @@ CIBW_SKIP="pp* *musllinux*"
 CIBW_PRERELEASE_PYTHONS=false
 # If it's a scheduled build or [pip-pre] in commit message, use pip-pre
 if [[ "$GITHUB_EVENT_NAME" == "schedule" ]] || [[ "$MSG" = *'[pip-pre]'* ]]; then
-    echo "Using NumPy pip-pre wheel and (on Linux) enabling Python 3.13 for wheel building, setting CIBW_BEFORE_BUILD, CIBW_BUILD_FRONTEND, and CIBW_PRERELEASE_PYTHONS"
-    # No Python 3.9 on scientific-python-nightly-wheels
-    CIBW_SKIP="$CIBW_SKIP cp39-*"
+    echo "Using NumPy pip-pre wheel and (on Linux), setting CIBW_BEFORE_BUILD, CIBW_BUILD_FRONTEND and CIBW_BEFORE_TEST"
     echo "CIBW_BEFORE_BUILD=pip install --pre --only-binary numpy --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \"numpy>=2.1.0.dev0\" \"Cython>=0.29.31,<4\" pkgconfig \"setuptools>=61\" wheel" | tee -a $GITHUB_ENV
     echo "CIBW_BUILD_FRONTEND=pip; args: --no-build-isolation" | tee -a $GITHUB_ENV
     # This is harder on other architectures, so only do it on Linux for now


### PR DESCRIPTION
Fix an issue in scheduled jobs where skipping cp39 wheels results in no identifier being selected on aarch64 ([example logs](https://github.com/h5py/h5py/actions/runs/10500649952/job/29089357892))
In fact the associated comment is out of date so I don't think we *need* to skip it.