### PR TITLE
WHL: remove broken job for cp313 wheels on aarch64 Linux

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -56,7 +56,6 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-          - "3.13.0rc1"
         include:
           - os: ubuntu-latest
             arch: x86_64


### PR DESCRIPTION
Follow up to #2490, revert #2469 (this never worked)