### PR TITLE
BUG: hotfix portability for ppc64(le) archs

### DIFF
--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -28,7 +28,7 @@ from .utils cimport  emalloc, efree, require_tuple, convert_dims,\
 
 # Python imports
 import codecs
-import os
+import platform
 import sys
 from collections import namedtuple
 import numpy as np
@@ -38,12 +38,9 @@ from ._objects import phil, with_phil
 
 cfg = get_config()
 
-if sys.platform.startswith("win"):
-    _IS_PPC64 = False
-    _IS_PPC64LE = False
-else:
-    _IS_PPC64 = os.uname() == "ppc64"
-    _IS_PPC64LE = os.uname() == "ppc64le"
+_UNAME_MACHINE = platform.uname()[4]
+_IS_PPC64 = _UNAME_MACHINE == "ppc64"
+_IS_PPC64LE = _UNAME_MACHINE == "ppc64le"
 
 cdef char* H5PY_PYTHON_OPAQUE_TAG = "PYTHON:OBJECT"
 


### PR DESCRIPTION
This is meant to addressed a regression caused by #2482
Hopefully I got it right this time; my main mistake was that I misread the documentation and thought `os.uname()` returned a string when it really returns a 5 elements tuple (the last of which being the string I was after) 

I switched from `os.uname` to `platform.uname` for two reasons:
- it closer mimics how `UNAME_MACHINE` is defined in Cython: https://github.com/cython/cython/blob/master/Cython/Compiler/Scanning.py#L88-L89
- it is documented as "fairly portable" (while `os.uname` is only available on UNIX)

I'll see if CI pass with the minimal patch first, but I expect I should be able to simplify the logic here by avoiding special-casing Windows.