### PR TITLE
WHL: hotfix missing dll in Windows wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -121,6 +121,9 @@ jobs:
           CIBW_BEFORE_TEST: ${{ env.CIBW_BEFORE_TEST }}
         if: steps.triage.outputs.skip != '1'
 
+      - run: python ./ci/bundle_hdf5_whl.py wheelhouse
+        if: steps.triage.outputs.skip != '1' && runner.os == 'Windows'
+
       # And upload the results
       - uses: actions/upload-artifact@v4
         with:

--- a/ci/triage_build.sh
+++ b/ci/triage_build.sh
@@ -36,10 +36,10 @@ CIBW_SKIP="pp* *musllinux*"
 # If it's a scheduled build or [pip-pre] in commit message, use pip-pre
 if [[ "$GITHUB_EVENT_NAME" == "schedule" ]] || [[ "$MSG" = *'[pip-pre]'* ]]; then
     echo "Using NumPy pip-pre wheel and (on Linux), setting CIBW_BEFORE_BUILD, CIBW_BUILD_FRONTEND and CIBW_BEFORE_TEST"
-    echo "CIBW_BEFORE_BUILD=pip install --pre --only-binary numpy --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \"numpy>=2.1.0.dev0\" \"Cython>=0.29.31,<4\" pkgconfig \"setuptools>=61\" wheel" | tee -a $GITHUB_ENV
+    echo "CIBW_BEFORE_BUILD=pip install --pre --only-binary numpy --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \"numpy>=2.0.0.dev0\" \"Cython>=0.29.31,<4\" pkgconfig \"setuptools>=61\" wheel" | tee -a $GITHUB_ENV
     echo "CIBW_BUILD_FRONTEND=pip; args: --no-build-isolation" | tee -a $GITHUB_ENV
     # This is harder on other architectures, so only do it on Linux for now
-    echo "CIBW_BEFORE_TEST=pip install --pre --only-binary numpy --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \"numpy>=2.1.0.dev0\"" | tee -a $GITHUB_ENV
+    echo "CIBW_BEFORE_TEST=pip install --pre --only-binary numpy --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \"numpy>=2.0.0.dev0\"" | tee -a $GITHUB_ENV
 fi
 
 # strip '-dev' suffix for pre-releases Pythons


### PR DESCRIPTION
This does two things to address #2505:
- tentatively fix windows wheels by running the `ci/bundle_hdf5_whl.py` script as hinted to by @takluyver (https://github.com/h5py/h5py/issues/2505#issuecomment-2375396971). This is kind of a stab in the dark as it doesn't change how the wheel is *tested*, but this aligns with how it was done for h5py 3.11 so maybe it's good enough as a hotfix ?
- adjust a broken requirement on `numpy>=2.1.0dev` for nightly wheels (which cannot work on CPython 3.9 and prevented building and uploading most of our recent nightlies)
