### PR TITLE
DOC: fix broken link in swmr documentation

### DIFF
--- a/docs/swmr.rst
+++ b/docs/swmr.rst
@@ -37,7 +37,7 @@ creating the file.
 
 
 The HDF Group has documented the SWMR features in details on the website:
-`Single-Writer/Multiple-Reader (SWMR) Documentation <https://support.hdfgroup.org/HDF5/docNewFeatures/NewFeaturesSwmrDocs.html>`_.
+`Single-Writer/Multiple-Reader (SWMR) Documentation <https://support.hdfgroup.org/releases/hdf5/v1_14/v1_14_5/documentation/doxygen/_s_w_m_r.html>`_.
 This is highly recommended reading for anyone intending to use the SWMR feature
 even through h5py. For production systems in particular pay attention to the
 file system requirements regarding POSIX I/O semantics.


### PR DESCRIPTION
Replaces a broken link in the swmr docs

- old: https://support.hdfgroup.org/HDF5/docNewFeatures/NewFeaturesSwmrDocs.html
- new: https://support.hdfgroup.org/releases/hdf5/v1_14/v1_14_5/documentation/doxygen/_s_w_m_r.html

(not sure if there is any way to link to the `latest` release for the docs, I couldn't find any)