### PR TITLE
Update HDF Group’s links

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -231,7 +231,7 @@ opening the various files as we work through the example.
 
 First, get ahold of
 the function signature; the easiest place for this is at the `online
-HDF5 Reference Manual <https://support.hdfgroup.org/HDF5/doc/RM/RM_H5Front.html>`_.
+HDF5 Reference Manual <https://support.hdfgroup.org/documentation/hdf5/latest/_r_m.htmll>`_.
 Then, add the function's C signature to the file ``api_functions.txt``::
 
   hsize_t   H5Dget_storage_size(hid_t dset_id)

--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -272,10 +272,10 @@ The ``compression_opts`` parameter will then be passed to this filter.
      A Python package of several popular filters, including Blosc, LZ4 and ZFP,
      for convenient use with h5py
 
-   `HDF5 Filter Plugins <https://portal.hdfgroup.org/display/support/HDF5+Filter+Plugins>`_
+   `HDF5 Filter Plugins <https://github.com/HDFGroup/hdf5_plugins/releases>`_
      A collection of filters as a single download from The HDF Group
 
-   `Registered filter plugins <https://portal.hdfgroup.org/display/support/Filters>`_
+   `Registered filter plugins <https://github.com/HDFGroup/hdf5_plugins/blob/master/docs/RegisteredFilterPlugins.md>`_
      The index of publicly announced filter plugins
 
 .. note:: The underlying implementation of the compression filter will have the
@@ -345,7 +345,7 @@ A MultiBlockSlice can be used in place of a slice to select a number of (count)
 blocks of multiple elements separated by a stride, rather than a set of single
 elements separated by a step.
 
-For an explanation of how this slicing works, see the `HDF5 documentation <https://support.hdfgroup.org/HDF5/Tutor/selectsimple.html>`_.
+For an explanation of how this slicing works, see the `HDF5 documentation <https://support.hdfgroup.org/documentation/hdf5/latest/_l_b_dset_sub_r_w.html>`_.
 
 For example::
 

--- a/docs/high/dims.rst
+++ b/docs/high/dims.rst
@@ -95,7 +95,7 @@ returned. There is no guarantee that the name of the dimension scale is unique.
 
 Nested dimension scales are not permitted: if a dataset has a dimension scale
 attached to it, converting the dataset to a dimension scale will fail, since the
-`HDF5 specification doesn't allow this <https://confluence.hdfgroup.org/display/HDF5/H5DS_SET_SCALE>`_. ::
+`HDF5 specification doesn't allow this <https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_d_s.html#ga508a06962e9fc11dff32ed356e0a71fa>`_. ::
 
    >>> f['data'].make_scale()
    RuntimeError: Unspecified error in H5DSset_scale (return value <0)

--- a/docs/high/file.rst
+++ b/docs/high/file.rst
@@ -381,8 +381,8 @@ chunk cache*. They apply to all datasets unless specifically changed for each on
   ``rdcc_nbytes`` bytes. For maximum performance, this value should be set
   approximately 100 times that number of chunks. The default value is 521.
 
-Chunks and caching are described in greater detail in the `HDF5 documentation (TODO link)
-<.>`_.
+Chunks and caching are described in greater detail in the `HDF5 documentation
+<https://support.hdfgroup.org/documentation/hdf5-docs/advanced_topics/chunking_in_hdf5.html>`_.
 
 .. _file_alignment:
 

--- a/docs/high/file.rst
+++ b/docs/high/file.rst
@@ -401,7 +401,7 @@ takes effect and the alignment in bytes within the file. The alignment is
 measured from the end of the user block.
 
 For more information, see the official HDF5 documentation `H5P_SET_ALIGNMENT
-<https://portal.hdfgroup.org/display/HDF5/H5P_SET_ALIGNMENT>`_.
+<https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#gab99d5af749aeb3896fd9e3ceb273677a>`_.
 
 .. _file_meta_block_size:
 
@@ -416,7 +416,7 @@ especially in combination with the ``libver`` option. This controls how the
 overall data and metadata are laid out within the file.
 
 For more information, see the official HDF5 documentation `H5P_SET_META_BLOCK_SIZE
-<https://portal.hdfgroup.org/display/HDF5/H5P_SET_META_BLOCK_SIZE>`_.
+<https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#ga8822e3dedc8e1414f20871a87d533cb1>`_.
 
 Reference
 ---------

--- a/docs/high/file.rst
+++ b/docs/high/file.rst
@@ -381,8 +381,8 @@ chunk cache*. They apply to all datasets unless specifically changed for each on
   ``rdcc_nbytes`` bytes. For maximum performance, this value should be set
   approximately 100 times that number of chunks. The default value is 521.
 
-Chunks and caching are described in greater detail in the `HDF5 documentation
-<https://portal.hdfgroup.org/display/HDF5/Chunking+in+HDF5>`_.
+Chunks and caching are described in greater detail in the `HDF5 documentation (TODO link)
+<.>`_.
 
 .. _file_alignment:
 

--- a/docs/high/lowlevel.rst
+++ b/docs/high/lowlevel.rst
@@ -8,7 +8,7 @@ h5py also provides a low-level API, which more closely follows the HDF5 C API.
 .. seealso::
 
    - `h5py Low-Level API Reference <https://api.h5py.org/>`_
-   - `HDF5 C/Fortran Reference Manual <https://confluence.hdfgroup.org/display/HDF5/Core+Library>`_
+   - `HDF5 C/Fortran Reference Manual <https://support.hdfgroup.org/documentation/hdf5/latest/_r_m.html>`_
 
 You can easily switch between the two levels in your code:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ HDF5 for Python
 
 The h5py package is a Pythonic interface to the HDF5 binary data format.
 
-`HDF5 <https://hdfgroup.org>`_ lets you store huge amounts of numerical
+`HDF5 <https://www.hdfgroup.org/solutions/hdf5/>`_ lets you store huge amounts of numerical
 data, and easily manipulate that data from NumPy. For example, you can slice
 into multi-terabyte datasets stored on disk, as if they were real NumPy
 arrays. Thousands of datasets can be stored in a single file, categorized and

--- a/docs/related_projects.rst
+++ b/docs/related_projects.rst
@@ -14,11 +14,6 @@ take advantage of some of HDF5's features. h5py provides a comparison between
 the two projects (see :ref:`h5py_pytable_cmp`), as does the
 `PyTables project <https://www.pytables.org/FAQ.html#how-does-pytables-compare-with-the-h5py-project>`_.
 
-.. seealso::
-
-   `HDF Group's list of HDF5 tools (TODO link)
-   <.>`_
-
 .. contents::
    :local:
 

--- a/docs/related_projects.rst
+++ b/docs/related_projects.rst
@@ -66,7 +66,7 @@ Exploring and Visualising HDF5 files
 h5py does not contain a tool for exploring or visualising HDF5 files, but tools
 that can display the structure of h5py include:
 
-* `HDFView <https://confluence.hdfgroup.org/display/HDFVIEW/HDFView>`_ is a
+* `HDFView <https://www.hdfgroup.org/download-hdfview/>`_ is a
   visual tool for browsing and editing HDF5 files.
 * `ViTables <https://vitables.org/>`_ is a GUI for browsing and editing files
   in both PyTables and HDF5 formats, and is built on top of PyTables.

--- a/docs/related_projects.rst
+++ b/docs/related_projects.rst
@@ -16,8 +16,8 @@ the two projects (see :ref:`h5py_pytable_cmp`), as does the
 
 .. seealso::
 
-   `HDF Group's list of HDF5 tools
-   <https://portal.hdfgroup.org/display/HDF5/HDF5+Tools+by+Category>`_
+   `HDF Group's list of HDF5 tools (TODO link)
+   <.>`_
 
 .. contents::
    :local:

--- a/docs/swmr.rst
+++ b/docs/swmr.rst
@@ -37,7 +37,7 @@ creating the file.
 
 
 The HDF Group has documented the SWMR features in details on the website:
-`Single-Writer/Multiple-Reader (SWMR) Documentation <https://support.hdfgroup.org/releases/hdf5/v1_14/v1_14_5/documentation/doxygen/_s_w_m_r.html>`_.
+`Single-Writer/Multiple-Reader (SWMR) Documentation <https://support.hdfgroup.org/documentation/hdf5/latest/_s_w_m_r.html>`_.
 This is highly recommended reading for anyone intending to use the SWMR feature
 even through h5py. For production systems in particular pay attention to the
 file system requirements regarding POSIX I/O semantics.

--- a/docs/vds.rst
+++ b/docs/vds.rst
@@ -25,11 +25,11 @@ HDF5 dataset.
 
 .. Warning::
 
-   Virtual dataset files cannot be opened with versions of the hdf5 library
+   Virtual dataset files cannot be opened with versions of the HDF5 library
    older than 1.10.
 
-The HDF Group has documented the VDS features in detail on the website:
-`Virtual Datasets (VDS) Documentation <https://support.hdfgroup.org/HDF5/docNewFeatures/NewFeaturesVirtualDatasetDocs.html>`_.
+The HDF Group has overview of the VDS features on their website:
+`Virtual Datasets (VDS) Documentation <https://support.hdfgroup.org/documentation/hdf5/latest/_v_d_s.html>`_.
 
 .. _creating_vds:
 
@@ -89,7 +89,7 @@ found in the examples folder:
 - `dataset_concatenation.py <https://github.com/h5py/h5py/blob/master/examples/dataset_concatenation.py>`_
   illustrates virtually stacking datasets together along a new axis.
 - A number of examples are based on the sample use cases presented in the
-  `virtual datasets RFC <https://support.hdfgroup.org/HDF5/docNewFeatures/VDS/HDF5-VDS-requirements-use-cases-2014-12-10.pdf>`__:
+  `virtual datasets RFC <https://support.hdfgroup.org/releases/hdf5/documentation/rfc/HDF5-VDS-requirements-use-cases-2014-12-10.pdf>`__:
 
   - `excalibur_detector_modules.py <https://github.com/h5py/h5py/blob/master/examples/excalibur_detector_modules.py>`_
   - `dual_pco_edge.py <https://github.com/h5py/h5py/blob/master/examples/dual_pco_edge.py>`_
@@ -125,7 +125,7 @@ Reference
 
    When `creating a virtual dataset <creating_vds_>`_, paths to sources present
    in the same file are changed to a ".", referring to the current file (see
-   `H5Pset_virtual <https://portal.hdfgroup.org/display/HDF5/H5P_SET_VIRTUAL>`_).
+   `H5Pset_virtual <https://support.hdfgroup.org/documentation/hdf5/latest/group___d_c_p_l.html#gadec895092dbbedb94f85d9cacf8924f5>`_).
    This will keep such sources valid in case the file is renamed.
 
    :param path_or_dataset:

--- a/docs/whatsnew/2.7.rst
+++ b/docs/whatsnew/2.7.rst
@@ -41,8 +41,8 @@ Other changes
 * Avoid errors when the Python GC runs during ``nonlocal_close()`` (:pr:`776` by Antoine Pitrou)
 * Move from ``six.PY3`` to ``six.PY2`` (:pr:`686` by James Tocknell)
 
-.. _`HDF5 Direct Chunk Write` : https://support.hdfgroup.org/HDF5/doc/Advanced/DirectChunkWrite/
-.. _`HDF5 File Image Operations` : https://support.hdfgroup.org/HDF5/doc/Advanced/FileImageOperations/HDF5FileImageOperations.pdf
+.. _`HDF5 Direct Chunk Write` : https://support.hdfgroup.org/releases/hdf5/documentation/rfc/DECTRIS%20Integration%20RFC%202012-11-29.pdf
+.. _`HDF5 File Image Operations` : https://support.hdfgroup.org/documentation/hdf5/latest/_f_i_l_e_i_m_g_o_p_s.html
 
 Acknowledgements
 ----------------

--- a/docs/whatsnew/3.8.rst
+++ b/docs/whatsnew/3.8.rst
@@ -39,8 +39,8 @@ Exposing HDF5 functions
 -----------------------
 
 * ``H5Dchunk_iter`` as :meth:`h5py.h5d.DatasetID.chunk_iter`.
-* `H5Pset_meta_block_size <https://portal.hdfgroup.org/display/HDF5/H5P_SET_META_BLOCK_SIZE>`_
-  and `H5Pget_meta_block_size <https://portal.hdfgroup.org/display/HDF5/H5P_GET_META_BLOCK_SIZE>`_
+* `H5Pset_meta_block_size <https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#ga8822e3dedc8e1414f20871a87d533cb1>`_
+  and `H5Pget_meta_block_size <https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#gac17861181246af0209c0da5209305461>`_
   (:pr:`2106`).
 
 Bug fixes


### PR DESCRIPTION
This updates the HDF Group's links in the h5py documentation. I failed to find replacements for two old links but the rest should hopefully last for a long time. 🤞