### PR TITLE
Add File.in_memory() alternative constructor

### DIFF
--- a/docs/high/file.rst
+++ b/docs/high/file.rst
@@ -532,7 +532,7 @@ Reference
 
         :param file_image: The initial file contents as bytes (or anything that
             supports the Python buffer interface). HDF5 takes a copy of this data.
-        :param block_size: Chunk size for new memory alloactions (default 1 MiB).
+        :param block_size: Chunk size for new memory alloactions (default 64 KiB).
 
         Other keyword arguments are like :class:`File`, although name, mode,
         driver and locking can't be passed.

--- a/docs/high/file.rst
+++ b/docs/high/file.rst
@@ -126,6 +126,28 @@ of supported drivers and their options:
            with ros3. Alternatively, use the :ref:`file-like object
            <file_fileobj>` support with a package like s3fs.
 
+.. _file_in_memory:
+
+In-memory 'files'
+-----------------
+
+HDF5 can make a file in memory, without reading or writing a real file.
+To do this with h5py, use the :meth:`.File.in_memory` class method::
+
+    # Start a new HDF5 file in memory
+    f = h5py.File.in_memory()
+    f['a'] = [1, 2, 3]
+
+    # Get the file data as bytes, e.g. to send over the network
+    f.flush()
+    hdf_data = f.id.get_file_image()
+
+    # Turn the bytes back into an h5py File object
+    f2 = h5py.File.in_memory(hdf_data)
+
+This uses HDF5's "core" :ref:`file driver <file_driver>`, which is likely to
+cause fewer odd problems than asking HDF5 to call back into a Python ``BytesIO``
+object (:ref:`described below <file_fileobj>`).
 
 .. _file_fileobj:
 
@@ -505,6 +527,15 @@ Reference
     :param meta_block_size: Determines the current minimum size, in bytes, of
             new metadata block allocations. See :ref:`file_meta_block_size`.
     :param kwds:    Driver-specific keywords; see :ref:`file_driver`.
+
+    .. classmethod:: in_memory(file_image=None, block_size=64*1024, **kwargs)
+
+        :param file_image: The initial file contents as bytes (or anything that
+            supports the Python buffer interface). HDF5 takes a copy of this data.
+        :param block_size: Chunk size for new memory alloactions (default 1 MiB).
+
+        Other keyword arguments are like :class:`File`, although name, mode,
+        driver and locking can't be passed.
 
     .. method:: __bool__()
 

--- a/docs/high/file.rst
+++ b/docs/high/file.rst
@@ -149,6 +149,8 @@ This uses HDF5's "core" :ref:`file driver <file_driver>`, which is likely to
 cause fewer odd problems than asking HDF5 to call back into a Python ``BytesIO``
 object (:ref:`described below <file_fileobj>`).
 
+.. versionadded:: 3.13
+
 .. _file_fileobj:
 
 Python file-like objects

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -594,7 +594,7 @@ class File(Group):
         fcpl_kwargs = {}
         for k in inspect.signature(make_fcpl).parameters:
             if k in kwargs:
-                fcpl_kwargs = kwargs.pop(k)
+                fcpl_kwargs[k] = kwargs.pop(k)
         fcpl = make_fcpl(**fcpl_kwargs)
 
         fapl = make_fapl(driver="core", backing_store=False, **kwargs)

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -581,9 +581,9 @@ class File(Group):
             The initial file contents as bytes (or anything that supports the
             Python buffer interface). HDF5 takes a copy of this data.
         block_size
-            Chunk size for new memory alloactions (default 1 MiB).
+            Chunk size for new memory alloactions (default 64 KiB).
 
-        Other keyword arguments are like :class:`File`, although name, mode,
+        Other keyword arguments are like File(), although name, mode,
         driver and locking can't be passed.
         """
         for k in ('driver', 'locking', 'backing_store'):

--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -1017,8 +1017,8 @@ cdef class PropFAID(PropInstanceID):
 
         Use the h5fd.CORE (memory-resident) file driver.
 
-        increment
-            Chunk size for new memory requests (default 1 meg)
+        block_size
+            Chunk size for new memory requests (default 64 KiB)
 
         backing_store
             If True (default), memory contents are associated with an

--- a/h5py/tests/test_file_image.py
+++ b/h5py/tests/test_file_image.py
@@ -39,7 +39,8 @@ class TestFileImage(TestCase):
 
 def test_in_memory():
     arr = np.arange(10)
-    with h5py.File.in_memory() as f1:
+    # Passing one fcpl & one fapl parameter to exercise the code splitting them:
+    with h5py.File.in_memory(track_order=True, libver='v108') as f1:
         f1['a'] = arr
         f1.flush()
         img = f1.id.get_file_image()

--- a/h5py/tests/test_file_image.py
+++ b/h5py/tests/test_file_image.py
@@ -40,7 +40,7 @@ class TestFileImage(TestCase):
 def test_in_memory():
     arr = np.arange(10)
     # Passing one fcpl & one fapl parameter to exercise the code splitting them:
-    with h5py.File.in_memory(track_order=True, libver='v108') as f1:
+    with h5py.File.in_memory(track_order=True, rdcc_nbytes=2_000_000) as f1:
         f1['a'] = arr
         f1.flush()
         img = f1.id.get_file_image()

--- a/h5py/tests/test_file_image.py
+++ b/h5py/tests/test_file_image.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 import h5py
 from h5py import h5f, h5p
 
@@ -33,3 +35,19 @@ class TestFileImage(TestCase):
         f = h5py.File(fid)
 
         self.assertTrue('test' in f)
+
+
+def test_in_memory():
+    arr = np.arange(10)
+    with h5py.File.in_memory() as f1:
+        f1['a'] = arr
+        f1.flush()
+        img = f1.id.get_file_image()
+
+        # Open while f1 is still open
+        with h5py.File.in_memory(img) as f2:
+            np.testing.assert_array_equal(f2['a'][:], arr)
+
+    # Reuse image now that previous files are closed
+    with h5py.File.in_memory(img) as f3:
+        np.testing.assert_array_equal(f3['a'][:], arr)

--- a/news/in-memory.rst
+++ b/news/in-memory.rst
@@ -1,0 +1,30 @@
+New features
+------------
+
+* New :meth:`.File.in_memory` constructor to conveniently build an HDF5 file
+  structure in memory.
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
From discussion on #2514, this adds a high-level way of working with 'files' in memory.

```python
# Start a new HDF5 file in memory
f = h5py.File.in_memory()
f['a'] = [1, 2, 3]

# Get the file data as bytes, e.g. to send over the network
f.flush()
hdf_data = f.id.get_file_image()

# Turn the bytes back into an h5py File object
f2 = h5py.File.in_memory(hdf_data)
```

Questions:

1. Looking at [the code in the core driver](https://github.com/HDFGroup/hdf5/blob/bcc795fcf66f5ce72b76dab4b4df5136f2558303/src/H5FDcore.c#L752-L754), there's an annoying check that the given filename doesn't exist on the filesystem. We bypass this when creating a new 'file', but I can't see a way to avoid it when we're passing in a file image.

```c
    if ((file_image_info.buffer != NULL) && !(H5F_ACC_CREAT & flags)) {
        if ((fd = HDopen(name, o_flags, H5_POSIX_CREATE_MODE_RW)) >= 0) {
            HDclose(fd);
            HGOTO_ERROR(H5E_FILE, H5E_FILEEXISTS, NULL, "file already exists");
        }
```

For now I just use a filename that's unlikely to exist - `h5py_in_memory_nonfile_<N>`. We could create a temporary directory to almost guarantee that we pass a filename that doesn't exist. But the aim is to avoid touching the filesystem, so that doesn't seeem ideal.

2. I found after writing this that there's an `H5LTopen_file_image()` function in the high-level library, exposed in h5py's low-level API as `h5py.h5f.open_file_image()`. This has options to avoid unnecessary copying of the file data, but these options are not yet exposed, and I didn't fancy playing with reference counts to ensure the image data is freed at the right time. Without that option, it looks like it does essentially the same as this code.
3. I haven't included a read-only option; in-memory files are always writable. It wouldn't be hard to add read-only mode if we want to.