### PR TITLE
Fix isolated build for Python 3.13 by using mpi4py==4.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ if setup_configure.mpi_enabled():
     RUN_REQUIRES.append('mpi4py >=3.1.1')
     SETUP_REQUIRES.append("mpi4py ==3.1.1; python_version<'3.11'")
     SETUP_REQUIRES.append("mpi4py ==3.1.4; python_version=='3.11.*'")
-    SETUP_REQUIRES.append("mpi4py ==3.1.6; python_version>='3.12'")
+    SETUP_REQUIRES.append("mpi4py ==3.1.6; python_version=='3.12.*'")
+    SETUP_REQUIRES.append("mpi4py ==4.0.1; python_version>='3.13'")
 
 # Set the environment variable H5PY_SETUP_REQUIRES=0 if we need to skip
 # setup_requires for any reason.


### PR DESCRIPTION
<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py312-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->

Fixes #2523 
