### PR TITLE
Use macOS-latest image on Azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -126,9 +126,9 @@ jobs:
         installer: nuget
         shell: cmd
 
-- job: 'macOS12'
+- job: 'macOS'
   pool:
-    vmImage: macOS-12
+    vmImage: macOS-latest
   timeoutInMinutes: 70  # 60 is a little short for macOS sometimes
   strategy:
     matrix:


### PR DESCRIPTION
The macOS-12 image is going away. Since we're no longer building packages to distribute on Azure, there's no need to use the oldest available version of the platform.

https://github.com/actions/runner-images/issues/10721