### PR TITLE
Update version of Cache task on Azure Pipelines CI

### DIFF
--- a/ci/azure-pipelines-steps.yml
+++ b/ci/azure-pipelines-steps.yml
@@ -3,7 +3,7 @@ parameters:
   installer: none
 
 steps:
-- task: CacheBeta@0
+- task: Cache@2
   displayName: HDF5 cache
   inputs:
     # The key should specify enough to avoid restoring an incompatible build.


### PR DESCRIPTION
Azure Pipelines started giving warnings that:

> Task 'Cache (Beta)' version 0 (CacheBeta@0) is deprecated.
> The CacheBeta@0 task is deprecated, please use the latest version of the CacheBeta task

Looking at the docs, it seems that the task is no longer a beta and the current version is 2, but the parameters still appear to work the same way. https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/cache-v2?view=azure-pipelines