### PR TITLE
Lazily load dcpl: it's not needed for reading

### DIFF
--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -108,6 +108,15 @@ def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
         maxshape, scaleoffset, external, allow_unknown_filter,
         fill_time=fill_time)
 
+    # Check that compression roundtrips correctly if it was specified
+    if compression is not None:
+        if isinstance(compression, filters.FilterRefBase):
+            compression = compression.filter_id
+        if isinstance(compression, int):
+            compression = filters.get_filter_name(compression)
+        if compression not in filters.get_filters(dcpl):
+            raise ValueError(f'compression {compression!r} not in filters {filters.get_filters(dcpl)!r}')
+
     if fillvalue is not None:
         # prepare string-type dtypes for fillvalue
         string_info = h5t.check_string_dtype(dtype)

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -656,6 +656,20 @@ class Dataset(HLObject):
         """Check if extent type is empty"""
         return self._extent_type == h5s.NULL
 
+    @cached_property
+    def _dcpl(self):
+        """
+        The dataset creation property list used when this dataset was created.
+        """
+        return self.id.get_create_plist()
+
+    @cached_property
+    def _filters(self):
+        """
+        The active filters of the dataset.
+        """
+        return filters.get_filters(self._dcpl)
+
     @with_phil
     def __init__(self, bind, *, readonly=False):
         """ Create a new Dataset object by binding to a low-level DatasetID.
@@ -664,9 +678,7 @@ class Dataset(HLObject):
             raise ValueError("%s is not a DatasetID" % bind)
         super().__init__(bind)
 
-        self._dcpl = self.id.get_create_plist()
         self._dxpl = h5p.create(h5p.DATASET_XFER)
-        self._filters = filters.get_filters(self._dcpl)
         self._readonly = readonly
         self._cache_props = {}
 

--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -308,7 +308,7 @@ def fill_dcpl(plist, shape, dtype, chunks, compression, compression_opts,
 
 def get_filter_name(code):
     """
-    Return the name of the compression filter for a given filter code.
+    Return the name of the compression filter for a given filter identifier.
 
     Undocumented and subject to change without warning.
     """

--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -306,16 +306,23 @@ def fill_dcpl(plist, shape, dtype, chunks, compression, compression_opts,
 
     return plist
 
+def get_filter_name(code):
+    """
+    Return the name of the compression filter for a given filter code.
+
+    Undocumented and subject to change without warning.
+    """
+    filters = {h5z.FILTER_DEFLATE: 'gzip', h5z.FILTER_SZIP: 'szip',
+               h5z.FILTER_SHUFFLE: 'shuffle', h5z.FILTER_FLETCHER32: 'fletcher32',
+               h5z.FILTER_LZF: 'lzf', h5z.FILTER_SCALEOFFSET: 'scaleoffset'}
+    return filters.get(code, str(code))
+
 def get_filters(plist):
     """ Extract a dictionary of active filters from a DCPL, along with
     their settings.
 
     Undocumented and subject to change without warning.
     """
-
-    filters = {h5z.FILTER_DEFLATE: 'gzip', h5z.FILTER_SZIP: 'szip',
-               h5z.FILTER_SHUFFLE: 'shuffle', h5z.FILTER_FLETCHER32: 'fletcher32',
-               h5z.FILTER_LZF: 'lzf', h5z.FILTER_SCALEOFFSET: 'scaleoffset'}
 
     pipeline = {}
 
@@ -343,7 +350,7 @@ def get_filters(plist):
             if len(vals) == 0:
                 vals = None
 
-        pipeline[filters.get(code, str(code))] = vals
+        pipeline[get_filter_name(code)] = vals
 
     return pipeline
 

--- a/news/lazy_dcpl.rst
+++ b/news/lazy_dcpl.rst
@@ -1,0 +1,29 @@
+New features
+------------
+
+* Loading a Dataset is faster since it now only loads the ``_dcpl``, the "dataset creation property list", when required.
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
Datasets have a `_dcpl` (data creation property list) field. For virtual Datasets it can be very expensive to load this list since it contains the entire virtual to underlying source mapping. Since this field is only actually needed for *writing* to the Dataset this commit defers loading the `_dcpl`.

This improves performance for opening a virtual Dataset like one created in `versioned_hdf5` quite substantially. Previously:
```
In [3]: with tempfile.TemporaryDirectory() as d:
   ...:     with h5py.File(f'{d}/data.h5', 'w') as f:
   ...:         vf = VersionedHDF5File(f)
   ...:         with vf.stage_version('r0') as sv:
   ...:             sv.create_dataset('values', data=np.random.rand(365, 12345), chunks=(10, 100))
   ...:     with h5py.File(f'{d}/data.h5', 'r') as f:
   ...:         vf = VersionedHDF5File(f)
   ...:         cv = vf[vf.current_version]
   ...:         def open_dataset():
   ...:             values = cv['values']
   ...:         print(timeit.timeit(open_dataset, number=100))
   ...:
3.910119968932122
```
With the changes in this commit:
```
In [5]: with tempfile.TemporaryDirectory() as d:
   ...:     with h5py.File(f'{d}/data.h5', 'w') as f:
   ...:         vf = VersionedHDF5File(f)
   ...:         with vf.stage_version('r0') as sv:
   ...:             sv.create_dataset('values', data=np.random.rand(365, 12345), chunks=(10, 100))
   ...:     with h5py.File(f'{d}/data.h5', 'r') as f:
   ...:         vf = VersionedHDF5File(f)
   ...:         cv = vf[vf.current_version]
   ...:         def open_dataset():
   ...:             values = cv['values']
   ...:         print(timeit.timeit(open_dataset, number=100))
   ...:
1.0834132973104715
```

Note that the performance here is still pretty poor since there are some performance issues in the underlying HDF5 library implementation as well which also copy the entire virtual "layout" when a Dataset is accessed. I also hope to fix these issues in HDF5 itself.

<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py312-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->
