### PR TITLE
Native support for Numpy 2's variable-width strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 h5py/h5*.c
 h5py/utils.c
 h5py/_conv.c
+h5py/_npystrings.c
 h5py/_proxy.c
 h5py/_objects.c
 h5py/_errors.c

--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -518,9 +518,8 @@ Reference
             >>> out = dset[:500].astype('int16')  # Typically slower
 
         In case of variable-width strings, calling ``.astype('T')``
-        (NumPy's native variable-width strings) is zero cost and
-        faster than reading the data into an object-type array;
-        read more at :ref:`npystrings`.
+        (NumPy's native variable-width strings) is more efficient than reading
+        the data into an object-type array; read more at :ref:`npystrings`.
 
         .. versionchanged:: 3.14
            Added support for NumPy variable-width strings (``dtype='T'``).

--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -504,7 +504,7 @@ Reference
 
     .. method:: astype(dtype)
 
-        Return a wrapper allowing you to read data as a particular
+        Return a read-only view allowing you to read data as a particular
         type.  Conversion is handled by HDF5 directly, on the fly::
 
             >>> dset = f.create_dataset("bigint", (1000,), dtype='int64')
@@ -517,13 +517,13 @@ Reference
 
             >>> out = dset[:500].astype('int16')  # slower
 
-        Calling ``.astype('T')`` (NumPy's native variable-width strings)
-        on a dataset returns a writable dataset with the specified dtype;
+        In case of variable-width strings, calling ``.astype('T')``
+        (NumPy's native variable-width strings) is zero cost and
+        faster than reading the data directly into an object-type array;
         read more at :ref:`npystrings`.
-        For all other dtypes, this method returns a read-only view.
 
         .. versionchanged:: 3.14
-           ``astype('T')`` returns a writeable dataset.
+           Added support for NumPy variable-width strings (``dtype='T'``).
 
         .. versionchanged:: 3.9
            :meth:`astype` can no longer be used as a context manager.

--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -508,9 +508,22 @@ Reference
         type.  Conversion is handled by HDF5 directly, on the fly::
 
             >>> dset = f.create_dataset("bigint", (1000,), dtype='int64')
-            >>> out = dset.astype('int16')[:]
+            >>> out = dset.astype('int16')[:500]
             >>> out.dtype
             dtype('int16')
+
+        This is typically faster than reading the data and then
+        converting it with NumPy:
+
+            >>> out = dset[:500].astype('int16')  # slower
+
+        Calling ``.astype('T')`` (NumPy's native variable-width strings)
+        on a dataset returns a writable dataset with the specified dtype;
+        read more at :ref:`npystrings`.
+        For all other dtypes, this method returns a read-only view.
+
+        .. versionchanged:: 3.14
+           ``astype('T')`` returns a writeable dataset.
 
         .. versionchanged:: 3.9
            :meth:`astype` can no longer be used as a context manager.
@@ -525,6 +538,12 @@ Reference
        encoding and errors work like ``bytes.decode()``, but the default
        encoding is defined by the datatype - ASCII or UTF-8.
        This is not guaranteed to be correct.
+
+       .. note::
+          If you don't require backwards compatibility with NumPy 1.x or
+          h5py <3.14, you should consider reading into NumPy native strings
+          insteads, which can be much faster, with ``Dataset.astype('T')``.
+          Read more at :ref:`npystrings`.
 
        .. versionadded:: 3.0
 

--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -512,7 +512,7 @@ Reference
             >>> out.dtype
             dtype('int16')
 
-        This is typically faster than reading the data and then
+        This can be faster than reading the data and then
         converting it with NumPy:
 
             >>> out = dset[:500].astype('int16')  # slower

--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -515,11 +515,11 @@ Reference
         This can be faster than reading the data and then
         converting it with NumPy:
 
-            >>> out = dset[:500].astype('int16')  # slower
+            >>> out = dset[:500].astype('int16')  # Typically slower
 
         In case of variable-width strings, calling ``.astype('T')``
         (NumPy's native variable-width strings) is zero cost and
-        faster than reading the data directly into an object-type array;
+        faster than reading the data into an object-type array;
         read more at :ref:`npystrings`.
 
         .. versionchanged:: 3.14
@@ -542,7 +542,8 @@ Reference
        .. note::
           If you don't require backwards compatibility with NumPy 1.x or
           h5py <3.14, you should consider reading into NumPy native strings
-          insteads, which can be much faster, with ``Dataset.astype('T')``.
+          instead, which can be much faster, with
+          :meth:`.astype('T')<astype>`.
           Read more at :ref:`npystrings`.
 
        .. versionadded:: 3.0

--- a/docs/special.rst
+++ b/docs/special.rst
@@ -28,7 +28,7 @@ Variable-length strings in NumPy 1.x
 
 .. note::
    Starting from h5py 3.14 + NumPy 2.0, you can use native NumPy variable-width
-   strings, a.k.a. NpyStrings. See :ref:`npystrings`.
+   strings, a.k.a. NpyStrings or StringDType. See :ref:`npystrings`.
 
 In HDF5, data in VL format is stored as arbitrary-length vectors of a base
 type.  In particular, strings are stored C-style in null-terminated buffers.

--- a/docs/special.rst
+++ b/docs/special.rst
@@ -11,9 +11,9 @@ types.  As of version 2.3, h5py fully supports HDF5 enums and VL types.
 How special types are represented
 ---------------------------------
 
-Since there is no direct NumPy dtype for variable-length strings, enums or
-references, h5py extends the dtype system slightly to let HDF5 know how to
-store these types.  Each type is represented by a native NumPy dtype, with a
+Since there is no direct NumPy dtype for enums or references (and, in NumPy 1.x, for
+variable-length strings), h5py extends the dtype system slightly to let HDF5 know how
+to store these types.  Each type is represented by a native NumPy dtype, with a
 small amount of metadata attached.  NumPy routines ignore the metadata, but
 h5py can use it to determine how to store the data.
 
@@ -21,14 +21,18 @@ The metadata h5py attaches to dtypes is not part of the public API,
 so it may change between versions.
 Use the functions described below to create and check for these types.
 
-Variable-length strings
------------------------
+Variable-length strings in NumPy 1.x
+------------------------------------
 
 .. seealso:: :ref:`strings`
 
+.. note::
+   Starting from h5py 3.14 + NumPy 2.0, you can use native NumPy variable-width
+   strings, a.k.a. NpyStrings. See :ref:`npystrings`.
+
 In HDF5, data in VL format is stored as arbitrary-length vectors of a base
 type.  In particular, strings are stored C-style in null-terminated buffers.
-NumPy has no native mechanism to support this.  Unfortunately, this is the
+NumPy 1.x has no native mechanism to support this.  Unfortunately, this is the
 de facto standard for representing strings in the HDF5 C API, and in many
 HDF5 applications.
 

--- a/docs/strings.rst
+++ b/docs/strings.rst
@@ -68,21 +68,24 @@ Data passed as NpyStrings is always encoded as UTF-8.
 NumPy variable-width strings
 ----------------------------
 
-Starting with NumPy 2.0 and h5py 3.14, you can also use ``dtype('T')`` to specify
-native NumPy variable-width strings. However, note that on a round-trip you will
-read object arrays of ``bytes`` again. This is to ensure that NumPy 1.x and 2.x
-behave in the same way unless the user explicitly requests native strings::
+Starting with NumPy 2.0 and h5py 3.14, you can also use ``np.dtypes.StringDType()``,
+or ``dtype('T')`` for short, to specify native NumPy variable-width string dtypes,
+a.k.a. NpyStrings.
+However, note that when you open a dataset that you created as a StringDType, its dtype
+will be object type with ``bytes`` elements again. This is because the two data types
+are identical in the HDF5 file, and to ensure that NumPy 1.x and 2.x behave in the same
+way unless the user explicitly requests native strings::
 
-    # NpyStrings (implicit)
+    # StringDType (from input data)
     npdata = np.asarray(string_data, dtype='T')
     ds = f.create_dataset('npystrings1', data=npdata)
 
-    # NpyStrings (explicit)
-    ds = f.create_dataset('npystrings2', shape=4, dtype='T')
+    # StringDType (explicit dtype parameter)
+    ds = f.create_dataset('npystrings2', shape=(4, ), dtype='T')
     ds[:] = string_data
 
-    # On a round-trip, you're back to bytes by default.
-    # Calling .astype('T') creates a writeable view with NpyStrings dtype.
+    # When you reopen the dataset, you're back to bytes by default.
+    # Calling .astype('T') creates a Dataset object with StringDType dtype.
     ds = f['npystrings1'].astype('T')
 
 What about NumPy's ``U`` type?

--- a/docs/strings.rst
+++ b/docs/strings.rst
@@ -85,7 +85,7 @@ native strings.
 In order to efficiently write NpyStrings to a dataset, simply assign a NumPy array with
 StringDType to it, either through ``__setitem__`` or :meth:`.Dataset.create_dataset`.
 To read NpyStrings out of any string-type dataset, use :meth:`.Dataset.astype('T')`.
-In both cases, there will be no intermediate conversion to object-type array, even if 
+In both cases, there will be no intermediate conversion to object-type array, even if
 the dataset's dtype is object type::
 
     # These three syntaxes are equivalent:

--- a/docs/strings.rst
+++ b/docs/strings.rst
@@ -14,10 +14,10 @@ Reading strings
 
 String data in HDF5 datasets is read as bytes by default: ``bytes`` objects
 for variable-length strings, or NumPy bytes arrays (``'S'`` dtypes) for
-fixed-length strings. On NumPy >=2.0, use :meth:`Dataset.astype('T')<.Dataset.astype>`
+fixed-length strings. On NumPy >=2.0, use :meth:`astype('T')<.astype>`
 to read into an array of native variable-width NumPy strings.
 If you need backwards compatibility with NumPy 1.x or h5py <3.14, you should instead
-call :meth:`.Dataset.asstr` to retrieve an array of ``str`` objects.
+call :meth:`.asstr` to retrieve an array of ``str`` objects.
 
 Variable-length strings in attributes are read as ``str`` objects. These are
 decoded as UTF-8 with surrogate escaping for unrecognised bytes. Fixed-length
@@ -75,25 +75,25 @@ or ``np.dtype('T')`` for short, to specify native NumPy variable-width string dt
 a.k.a. NpyStrings.
 
 However, note that when you open a dataset that you created as a StringDType, its dtype
-will be object type with ``bytes`` elements. Likewise, :meth:`.Dataset.create_dataset`
+will be object dtype with ``bytes`` elements. Likewise, :meth:`.create_dataset`
 with parameter ``dtype='T'``, or with ``data=`` set to a NumPy array with StringDType,
-will create a dataset with object type.
+will create a dataset with object dtype.
 This is because the two data types are identical on the HDF5 file; this design is to
 ensure that NumPy 1.x and 2.x behave in the same way unless the user explicitly requests
 native strings.
 
 In order to efficiently write NpyStrings to a dataset, simply assign a NumPy array with
-StringDType to it, either through ``__setitem__`` or :meth:`.Dataset.create_dataset`.
-To read NpyStrings out of any string-type dataset, use :meth:`.Dataset.astype('T')`.
-In both cases, there will be no intermediate conversion to object-type array, even if
-the dataset's dtype is object type::
+StringDType to it, either through ``__setitem__`` or :meth:`.create_dataset`.
+To read NpyStrings out of any string-type dataset, use
+:meth:`astype('T')<.astype>`. In both cases, there will be no
+intermediate conversion to object-type array, even if the dataset's dtype is object::
 
     # These three syntaxes are equivalent:
     >>> ds = f.create_dataset('x', shape=(2, ), dtype=h5py.string_dtype())
     >>> ds = f.create_dataset('x', shape=(2, ), dtype=np.dtypes.StringDType())
     >>> ds = f.create_dataset('x', shape=(2, ), dtype='T')
 
-    # They all return a dataset with object type:
+    # They all return a dataset with object dtype:
     >>> ds
     <HDF5 dataset "x": shape (2,), type "|O">
 

--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -102,6 +102,9 @@ def is_float16_dtype(dt):
 def array_for_new_object(data, specified_dtype=None):
     """Prepare an array from data used to create a new dataset or attribute"""
 
+    if not isinstance(specified_dtype, (np.dtype, type(None))):
+        specified_dtype = np.dtype(specified_dtype)
+
     # We mostly let HDF5 convert data as necessary when it's written.
     # But if we are going to a float16 datatype, pre-convert in python
     # to workaround a bug in the conversion.
@@ -120,7 +123,7 @@ def array_for_new_object(data, specified_dtype=None):
     # In most cases, this does nothing. But if data was already an array,
     # and as_dtype is a tagged h5py dtype (e.g. for an object array of strings),
     # asarray() doesn't replace its dtype object. This gives it the tagged dtype:
-    if as_dtype is not None and data.dtype.kind != "T":
+    if as_dtype is not None:
         data = data.view(dtype=as_dtype)
 
     return data

--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -120,7 +120,7 @@ def array_for_new_object(data, specified_dtype=None):
     # In most cases, this does nothing. But if data was already an array,
     # and as_dtype is a tagged h5py dtype (e.g. for an object array of strings),
     # asarray() doesn't replace its dtype object. This gives it the tagged dtype:
-    if as_dtype is not None:
+    if as_dtype is not None and data.dtype.kind != "T":
         data = data.view(dtype=as_dtype)
 
     return data

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -1162,7 +1162,7 @@ class Dataset(HLObject):
             namestr = "(anonymous)"
         else:
             name = pp.basename(pp.normpath(self.name))
-            namestr = '"{name}"' if name else "/"
+            namestr = f'"{name}"' if name else "/"
 
         if self.dtype.kind == "T":
             typestr = str(self.dtype)  # StringDType()

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -436,14 +436,6 @@ class Dataset(HLObject):
         different destination type, e.g.:
 
         >>> double_precision = dataset.astype('f8')[0:100:2]
-
-        Returns
-        -------
-        For dtype='T' (NumPy's native variable-length strings),
-        a writable dataset with the specified dtype.
-
-        For all other dtypes, a read-only view of the dataset
-        with the specified dtype.
         """
         dtype = numpy.dtype(dtype)
         if dtype == self.dtype:

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -294,14 +294,6 @@ class AsStrView(AbstractView):
         ], dtype=object).reshape(bytes_arr.shape)
 
 
-class AsNumpyVlenStringView(AbstractView):
-    @property
-    def dtype(self):
-        return numpy.dtype("T")
-
-    def __getitem__(self, idx):
-        return self._dset.__getitem__(idx, new_dtype=self.dtype)
-
 class FieldsView(AbstractView):
     """Wrapper to extract named fields from a dataset with a struct dtype"""
 
@@ -464,7 +456,6 @@ class Dataset(HLObject):
                     f"dset.astype({dtype}) can only be used on datasets with "
                     "an HDF5 string datatype"
                 )
-            return AsNumpyVlenStringView(self)
 
         return AsTypeView(self, dtype)
 

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -1173,6 +1173,7 @@ class Dataset(HLObject):
             namestr = f'"{name}"' if name else "/"
 
         if self.dtype.kind == "T":
+            # FIXME https://github.com/numpy/numpy/issues/28670
             typestr = str(self.dtype)  # StringDType()
         else:
             typestr = f'"{self.dtype.str}"'

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -698,7 +698,7 @@ class Dataset(HLObject):
             # We could use the native HDF5 strings to StringDType conversion that
             # is implemented for Dataset.__getitem__, but it would require
             # either replicating all the NpyStrings code (or making it somehow generic
-            # and probably much less legible) around 
+            # and probably much less legible) around
             # dcpl.get_fill_value -> H5Pget_fill_value.
             # Note that attrs have the same issue - they pass through object type arrays
             # for the sake of simplicity as the performance benefits from NpyStrings

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -694,7 +694,15 @@ class Dataset(HLObject):
     def fillvalue(self):
         """Fill value for this dataset (0 by default)"""
         if self.dtype.kind == "T":
-            # For the sake of simplicity, pass through object strings
+            # For the sake of simplicity, pass through object strings.
+            # We could use the native HDF5 strings to StringDType conversion that
+            # is implemented for Dataset.__getitem__, but it would require
+            # either replicating all the NpyStrings code (or making it somehow generic
+            # and probably much less legible) around 
+            # dcpl.get_fill_value -> H5Pget_fill_value.
+            # Note that attrs have the same issue - they pass through object type arrays
+            # for the sake of simplicity as the performance benefits from NpyStrings
+            # machinery would be inconsequential.
             arr = numpy.zeros((1,), dtype=self.astype(object).dtype)
             self._dcpl.get_fill_value(arr)
             return arr[0].decode("utf-8")

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -1141,15 +1141,17 @@ class Dataset(HLObject):
     @with_phil
     def __repr__(self):
         if not self:
-            return "<Closed HDF5 dataset>"
-
-        if self.name is None:
-            namestr = "(anonymous)"
+            r = '<Closed HDF5 dataset>'
         else:
-            name = pp.basename(pp.normpath(self.name))
-            namestr = f'"{name}"' if name else "/"
-
-        return f'<HDF5 dataset {namestr}: shape {self.shape}, type "{self.dtype.str}">'
+            if self.name is None:
+                namestr = '("anonymous")'
+            else:
+                name = pp.basename(pp.normpath(self.name))
+                namestr = '"%s"' % (name if name != '' else '/')
+            r = '<HDF5 dataset %s: shape %s, type "%s">' % (
+                namestr, self.shape, self.dtype.str
+            )
+        return r
 
     if hasattr(h5d.DatasetID, "refresh"):
         @with_phil

--- a/h5py/_npystrings.pyx
+++ b/h5py/_npystrings.pyx
@@ -159,7 +159,10 @@ cdef herr_t npystrings_unpack_cb(
     # Obtain a reference to the string (NOT zero-terminated) and its size
     res = NpyString_load(info[0].allocator, <npy_packed_static_string*>elem, unpacked)
     info[0].i += 1
-    return res
+    # res == -1 if unpacking the string fails, 1 if packed_string is the null string,
+    # and 0 otherwise.
+    return -1 if res == -1 else 0
+
 
 def npystrings_unpack(hid_t space, size_t contig, size_t noncontig, size_t descr,
                     size_t npoints):

--- a/h5py/_npystrings.pyx
+++ b/h5py/_npystrings.pyx
@@ -1,0 +1,254 @@
+"""Support for NpyStrings - NumPy's native variable-width strings.
+
+This module requires NumPy >=2.0 to be imported. To allow the rest of h5py
+to work with NumPy 1.x installed, this module must be imported conditionally
+and can't be cimport'ed.
+"""
+include "config.pxi"
+
+from .defs cimport *
+from numpy cimport PyArray_Descr
+import numpy as np
+
+assert NUMPY_BUILD_VERSION >= '2.0'  # See pyproject.toml
+
+# =========================================================================
+# Scatter/gather routines for vlen strings to/from Numpy StringDType arrays
+# See also: _proxy.pyx::h5py_copy, h5py_scatter_cb, h5py_gather_cb
+
+IF NUMPY_BUILD_VERSION < '2.3':
+    # Backport NpyStrings from 2.3 to 2.0
+    # The C API was available since 2.0, but the Cython API was added in 2.3.
+    # This is a copy-paste from numpy/__init__.pxd of numpy 2.3
+    cdef extern from "numpy/ndarraytypes.h":
+        ctypedef struct npy_string_allocator:
+            pass
+
+        ctypedef struct npy_packed_static_string:
+            pass
+
+        ctypedef struct npy_static_string:
+            size_t size
+            const char *buf
+
+        ctypedef struct PyArray_StringDTypeObject:
+            PyArray_Descr base
+            PyObject *na_object
+            char coerce
+            char has_nan_na
+            char has_string_na
+            char array_owned
+            npy_static_string default_string
+            npy_static_string na_name
+            npy_string_allocator *allocator
+
+    cdef extern from "numpy/arrayobject.h":
+        npy_string_allocator *NpyString_acquire_allocator(const PyArray_StringDTypeObject *descr)
+        void NpyString_acquire_allocators(size_t n_descriptors, PyArray_Descr *const descrs[], npy_string_allocator *allocators[])
+        void NpyString_release_allocator(npy_string_allocator *allocator)
+        void NpyString_release_allocators(size_t length, npy_string_allocator *allocators[])
+        int NpyString_load(npy_string_allocator *allocator, const npy_packed_static_string *packed_string, npy_static_string *unpacked_string)
+        int NpyString_pack_null(npy_string_allocator *allocator, npy_packed_static_string *packed_string)
+        int NpyString_pack(npy_string_allocator *allocator, npy_packed_static_string *packed_string, const char *buf, size_t size)
+
+ELSE:
+    from numpy cimport (
+        npy_string_allocator,
+        npy_static_string,
+        npy_packed_static_string,
+        NpyString_pack,
+        NpyString_load,
+        NpyString_acquire_allocator,
+        NpyString_release_allocator,
+        PyArray_StringDTypeObject,
+    )
+
+# Can't call sizeof(npy_packed_static_string) because the struct is
+# internal to numpy
+cdef size_t SIZEOF_NPY_PACKED_STATIC_STRING = np.dtype("T").itemsize
+
+ctypedef struct vstrings_scatter_t:
+    size_t i
+    npy_string_allocator *allocator
+    const char **contig
+
+ctypedef struct vstrings_gather_t:
+    size_t i
+    npy_string_allocator *allocator
+    npy_static_string *unpacked
+
+
+cdef herr_t vstrings_scatter_cb(
+    void* elem, hid_t type_id, unsigned ndim,
+    const hsize_t *point, void *operator_data
+) except -1:
+    cdef vstrings_scatter_t* info = <vstrings_scatter_t*>operator_data
+    cdef const char* buf = info[0].contig[info[0].i]
+    # Deep copy char* from h5py into the numpy array
+    res = NpyString_pack(
+        info[0].allocator,
+        <npy_packed_static_string*>elem,
+        buf,
+        strlen(buf),
+    )
+    info[0].i += 1
+    return res
+
+
+def vstrings_scatter(hid_t space, size_t contig, size_t noncontig, size_t descr):
+    """Pure-python API interface to _proxy.pyx. This is necessary to
+    allow this module to be conditionally imported, allowing numpy 1.x to
+    continue working everywhere else.
+    """
+    _vstrings_scatter(space, <void *>contig, <void *>noncontig, <PyArray_Descr *>descr)
+
+
+cdef void _vstrings_scatter(hid_t space, void *contig, void *noncontig,
+                            PyArray_Descr *descr):
+    """Convert a zero-terminated char**, which is the in-memory representation
+    for a HDF5 variable-width string dataset, into a NpyString array
+    (NumPy's native variable-width strings dtype).
+
+    Parameters
+    ----------
+    space : hid_t
+        HDF5 dataspace ID for the output non-contiguous buffer
+        containing packed NpyStrings
+    contig : void * (actually a char **)
+        Input buffer for the contiguous zero-terminated char **
+    noncontig : void *
+        Output buffer for the non-contiguous packed NpyStrings
+    descr : PyArray_Descr * (actually a PyArray_StringDTypeObject *)
+        NumPy dtype descriptor for the NpyStrings
+    npoints : size_t
+        Number of points to copy
+
+    Notes
+    -----
+    This function deep-copies the input zero-terminated strings.
+    Memory management for the outputs is handled by NumPy.
+    """
+    cdef vstrings_scatter_t info
+    info.i = 0
+    info.contig = <const char**>contig
+    info.allocator = NpyString_acquire_allocator(<PyArray_StringDTypeObject *>descr)
+    if info.allocator is NULL:
+        raise RuntimeError("Failed to acquire string allocator")
+
+    # Disregard mtype from _proxy::dset_rw.
+    # The memory type is actually npy_packed_static_string
+    # (an opaque struct *typically* 16 bytes per point),
+    # and not HDF5 variable length strings (char*; 8 bytes per point).
+    tid = H5Tcreate(H5T_OPAQUE, SIZEOF_NPY_PACKED_STATIC_STRING)
+
+    # Read char*[] (zero-terminated) from h5py
+    # and deep-copy to npy_packed_static_string[] for numpy
+    H5Diterate(noncontig, tid, space, vstrings_scatter_cb, &info)
+    NpyString_release_allocator(info.allocator)
+    H5Tclose(tid)
+
+
+cdef herr_t vstrings_gather_cb(
+    void *elem, hid_t type_id, unsigned ndim,
+    const hsize_t *point, void *operator_data
+) except -1:
+    cdef vstrings_gather_t *info = <vstrings_gather_t *>operator_data
+    cdef npy_static_string *unpacked = info[0].unpacked + info[0].i
+    # Obtain a reference to the string (NOT zero-terminated) and its size
+    res = NpyString_load(info[0].allocator, <npy_packed_static_string*>elem, unpacked)
+    info[0].i += 1
+    return res
+
+def vstrings_gather(hid_t space, size_t contig, size_t noncontig, size_t descr,
+                    size_t npoints):
+    """Pure-python API interface to _proxy.pyx. This is necessary to
+    allow this module to be conditionally imported, allowing numpy 1.x to
+    continue working everywhere else.
+    """
+    return <size_t>_vstrings_gather(space, <void *>contig, <void *>noncontig,
+                                    <PyArray_Descr *>descr, npoints)
+
+
+cdef char * _vstrings_gather(hid_t space, void *contig, void *noncontig,
+                             PyArray_Descr *descr, size_t npoints):
+    """Convert a NpyString array (NumPy's native variable-width strings dtype)
+    to a zero-terminated char**, which is the in-memory representation for a
+    HDF5 variable-width string dataset.
+
+    Parameters
+    ----------
+    space : hid_t
+        HDF5 dataspace ID for the input non-contiguous buffer
+        containing packed NpyStrings
+    contig : void * (actually a char **)
+        Output buffer for the contiguous zero-terminated char **
+    noncontig : void *
+        Input buffer for the non-contiguous packed NpyStrings
+    descr : PyArray_Descr * (actually a PyArray_StringDTypeObject *)
+        NumPy dtype descriptor for the NpyStrings
+    npoints : size_t
+        Number of points to copy
+
+    Returns
+    -------
+    char *
+        A temporary buffer containing the zero-terminated strings.
+        This buffer must be freed after writing to disk.
+
+        Note that this always the same as contig[0] when this
+        function returns, but H5Tconvert may change the contents
+        of contig[0] in place later on.
+    """
+    cdef vstrings_gather_t info
+    cdef size_t total_size
+    cdef size_t cur_size
+    cdef char *zero_terminated = NULL
+    cdef char *zero_terminated_cur = NULL
+    info.unpacked = NULL
+    info.i = 0
+
+    info.allocator = NpyString_acquire_allocator(<PyArray_StringDTypeObject *>descr)
+    if info.allocator is NULL:
+        raise RuntimeError("Failed to acquire string allocator")
+
+    tid = H5Tcreate(H5T_OPAQUE, SIZEOF_NPY_PACKED_STATIC_STRING)
+    try:
+        # Multiple steps needed:
+        # 1. Read npy_packed_static_string[] from numpy and unpack
+        #    to npy_static_string[]; which is
+        #    {const char* buf, size_t size}[] - NOT zero-terminated
+        info.unpacked = <npy_static_string*>malloc(
+            npoints * sizeof(npy_static_string)
+        )
+        if info.unpacked is NULL:
+            raise MemoryError("Failed to allocate memory")
+
+        H5Diterate(noncontig, tid, space, vstrings_gather_cb, &info)
+        assert info.i == npoints
+
+        # 2. Calculate total size of strings with zero termination
+        total_size = npoints  # zero termination characters
+        for i in range(npoints):
+            total_size += info.unpacked[i].size
+
+        # 3. Copy to temporary buffer which is a concatenation of
+        #    zero-terminated char* and point to it from the
+        #    output char*[] for h5py
+        zero_terminated_buf = <char *>malloc(total_size)
+        if zero_terminated_buf is NULL:
+            raise MemoryError("Failed to allocate memory")
+        zero_terminated_cur = zero_terminated_buf
+        for i in range(npoints):
+            cur_size = info.unpacked[i].size
+            memcpy(zero_terminated_cur, info.unpacked[i].buf, cur_size)
+            zero_terminated_cur[cur_size] = 0
+            (<char **>contig)[i] = zero_terminated_cur
+            zero_terminated_cur += cur_size + 1
+
+        return zero_terminated_buf
+
+    finally:
+        free(info.unpacked)
+        NpyString_release_allocator(info.allocator)
+        H5Tclose(tid)
+        # after H5Dwrite, user must free(zero_terminated_buf)

--- a/h5py/_npystrings.pyx
+++ b/h5py/_npystrings.pyx
@@ -13,13 +13,13 @@ import numpy as np
 assert NUMPY_BUILD_VERSION >= '2.0'  # See pyproject.toml
 
 # =========================================================================
-# Scatter/gather routines for vlen strings to/from Numpy StringDType arrays
+# Scatter/gather routines for vlen strings to/from NumPy StringDType arrays
 # See also: _proxy.pyx::h5py_copy, h5py_scatter_cb, h5py_gather_cb
 
 IF NUMPY_BUILD_VERSION < '2.3':
     # Backport NpyStrings from 2.3 to 2.0
     # The C API was available since 2.0, but the Cython API was added in 2.3.
-    # This is a copy-paste from numpy/__init__.pxd of numpy 2.3
+    # This is a copy-paste from numpy/__init__.pxd of NumPy 2.3
     cdef extern from "numpy/ndarraytypes.h":
         ctypedef struct npy_string_allocator:
             pass

--- a/h5py/_npystrings.pyx
+++ b/h5py/_npystrings.pyx
@@ -135,10 +135,11 @@ cdef void _vstrings_scatter(hid_t space, void *contig, void *noncontig,
     if info.allocator is NULL:
         raise RuntimeError("Failed to acquire string allocator")
 
+    # H5Diterate needs a tid of the correct size.
     # Disregard mtype from _proxy::dset_rw.
     # The memory type is actually npy_packed_static_string
-    # (an opaque struct *typically* 16 bytes per point),
-    # and not HDF5 variable length strings (char*; 8 bytes per point).
+    # (an opaque struct of arbitrary size)
+    # and not HDF5 variable length strings (char*).
     tid = H5Tcreate(H5T_OPAQUE, SIZEOF_NPY_PACKED_STATIC_STRING)
 
     # Read char*[] (zero-terminated) from h5py

--- a/h5py/_npystrings.pyx
+++ b/h5py/_npystrings.pyx
@@ -64,7 +64,7 @@ ELSE:
     )
 
 # Can't call sizeof(npy_packed_static_string) because the struct is
-# internal to numpy
+# internal to NumPy
 cdef size_t SIZEOF_NPY_PACKED_STATIC_STRING = np.dtype("T").itemsize
 
 ctypedef struct npystrings_pack_t:
@@ -84,7 +84,7 @@ cdef herr_t npystrings_pack_cb(
 ) except -1:
     cdef npystrings_pack_t* info = <npystrings_pack_t*>operator_data
     cdef const char* buf = info[0].contig[info[0].i]
-    # Deep copy char* from h5py into the numpy array
+    # Deep copy char* from h5py into the NumPy array
     res = NpyString_pack(
         info[0].allocator,
         <npy_packed_static_string*>elem,
@@ -121,7 +121,7 @@ def npystrings_pack(hid_t space, size_t contig, size_t noncontig, size_t descr):
 
     This function defines a pure-python API interface to _proxy.pyx.
     This is necessary to allow this module to be conditionally imported,
-    allowing numpy 1.x to continue working everywhere else.
+    allowing NumPy 1.x to continue working everywhere else.
     """
     _npystrings_pack(space, <void *>contig, <void *>noncontig, <PyArray_Descr *>descr)
 
@@ -144,7 +144,7 @@ cdef void _npystrings_pack(hid_t space, void *contig, void *noncontig,
     tid = H5Tcreate(H5T_OPAQUE, SIZEOF_NPY_PACKED_STATIC_STRING)
 
     # Read char*[] (zero-terminated) from h5py
-    # and deep-copy to npy_packed_static_string[] for numpy
+    # and deep-copy to npy_packed_static_string[] for NumPy
     H5Diterate(noncontig, tid, space, npystrings_pack_cb, &info)
     NpyString_release_allocator(info.allocator)
     H5Tclose(tid)
@@ -165,7 +165,7 @@ cdef herr_t npystrings_unpack_cb(
 
 
 def npystrings_unpack(hid_t space, size_t contig, size_t noncontig, size_t descr,
-                    size_t npoints):
+                      size_t npoints):
     """Convert a NpyString array (NumPy's native variable-width strings dtype)
     to a zero-terminated char**, which is the in-memory representation for a
     HDF5 variable-width string dataset.
@@ -198,14 +198,14 @@ def npystrings_unpack(hid_t space, size_t contig, size_t noncontig, size_t descr
     -----
     This function defines a pure-python API interface to _proxy.pyx.
     This is necessary to allow this module to be conditionally imported,
-    allowing numpy 1.x to continue working everywhere else.
+    allowing NumPy 1.x to continue working everywhere else.
     """
     return <size_t>_npystrings_unpack(space, <void *>contig, <void *>noncontig,
                                       <PyArray_Descr *>descr, npoints)
 
 
 cdef char * _npystrings_unpack(hid_t space, void *contig, void *noncontig,
-                             PyArray_Descr *descr, size_t npoints):
+                               PyArray_Descr *descr, size_t npoints):
     """Cython API interface of npystrings_unpack"""
     cdef npystrings_unpack_t info
     cdef size_t total_size
@@ -222,7 +222,7 @@ cdef char * _npystrings_unpack(hid_t space, void *contig, void *noncontig,
     tid = H5Tcreate(H5T_OPAQUE, SIZEOF_NPY_PACKED_STATIC_STRING)
     try:
         # Multiple steps needed:
-        # 1. Read npy_packed_static_string[] from numpy and unpack
+        # 1. Read npy_packed_static_string[] from NumPy and unpack
         #    to npy_static_string[]; which is
         #    {const char* buf, size_t size}[] - NOT zero-terminated
         info.unpacked = <npy_static_string*>malloc(

--- a/h5py/_npystrings.pyx
+++ b/h5py/_npystrings.pyx
@@ -96,15 +96,6 @@ cdef herr_t npystrings_pack_cb(
 
 
 def npystrings_pack(hid_t space, size_t contig, size_t noncontig, size_t descr):
-    """Pure-python API interface to _proxy.pyx. This is necessary to
-    allow this module to be conditionally imported, allowing numpy 1.x to
-    continue working everywhere else.
-    """
-    _npystrings_pack(space, <void *>contig, <void *>noncontig, <PyArray_Descr *>descr)
-
-
-cdef void _npystrings_pack(hid_t space, void *contig, void *noncontig,
-                            PyArray_Descr *descr):
     """Convert a zero-terminated char**, which is the in-memory representation
     for a HDF5 variable-width string dataset, into a NpyString array
     (NumPy's native variable-width strings dtype).
@@ -127,7 +118,17 @@ cdef void _npystrings_pack(hid_t space, void *contig, void *noncontig,
     -----
     This function deep-copies the input zero-terminated strings.
     Memory management for the outputs is handled by NumPy.
+
+    This function defines a pure-python API interface to _proxy.pyx.
+    This is necessary to allow this module to be conditionally imported,
+    allowing numpy 1.x to continue working everywhere else.
     """
+    _npystrings_pack(space, <void *>contig, <void *>noncontig, <PyArray_Descr *>descr)
+
+
+cdef void _npystrings_pack(hid_t space, void *contig, void *noncontig,
+                           PyArray_Descr *descr):
+    """Cython API interface of npystrings_pack"""
     cdef npystrings_pack_t info
     info.i = 0
     info.contig = <const char**>contig
@@ -162,16 +163,6 @@ cdef herr_t npystrings_unpack_cb(
 
 def npystrings_unpack(hid_t space, size_t contig, size_t noncontig, size_t descr,
                     size_t npoints):
-    """Pure-python API interface to _proxy.pyx. This is necessary to
-    allow this module to be conditionally imported, allowing numpy 1.x to
-    continue working everywhere else.
-    """
-    return <size_t>_npystrings_unpack(space, <void *>contig, <void *>noncontig,
-                                    <PyArray_Descr *>descr, npoints)
-
-
-cdef char * _npystrings_unpack(hid_t space, void *contig, void *noncontig,
-                             PyArray_Descr *descr, size_t npoints):
     """Convert a NpyString array (NumPy's native variable-width strings dtype)
     to a zero-terminated char**, which is the in-memory representation for a
     HDF5 variable-width string dataset.
@@ -199,7 +190,20 @@ cdef char * _npystrings_unpack(hid_t space, void *contig, void *noncontig,
         Note that this always the same as contig[0] when this
         function returns, but H5Tconvert may change the contents
         of contig[0] in place later on.
+
+    Notes
+    -----
+    This function defines a pure-python API interface to _proxy.pyx.
+    This is necessary to allow this module to be conditionally imported,
+    allowing numpy 1.x to continue working everywhere else.
     """
+    return <size_t>_npystrings_unpack(space, <void *>contig, <void *>noncontig,
+                                      <PyArray_Descr *>descr, npoints)
+
+
+cdef char * _npystrings_unpack(hid_t space, void *contig, void *noncontig,
+                             PyArray_Descr *descr, size_t npoints):
+    """Cython API interface of npystrings_unpack"""
     cdef npystrings_unpack_t info
     cdef size_t total_size
     cdef size_t cur_size

--- a/h5py/_proxy.pxd
+++ b/h5py/_proxy.pxd
@@ -9,10 +9,12 @@
 #           and contributor agreement.
 
 from .defs cimport *
+from numpy cimport PyArray_Descr
 
 cdef herr_t attr_rw(hid_t attr, hid_t mtype, void *progbuf, int read) except -1
 
 cdef herr_t dset_rw(hid_t dset, hid_t mtype, hid_t mspace, hid_t fspace,
-                    hid_t dxpl, void* progbuf, int read) except -1
+                    hid_t dxpl, void* progbuf, PyArray_Descr* descr,
+                    int read) except -1
 
 cdef htri_t needs_bkg_buffer(hid_t src, hid_t dst) except -1

--- a/h5py/_proxy.pyx
+++ b/h5py/_proxy.pyx
@@ -169,8 +169,12 @@ cdef herr_t dset_rw(hid_t dset, hid_t mtype, hid_t mspace, hid_t fspace,
     return 0
 
 
-cdef herr_t dset_rw_vlen_strings(hid_t dset, hid_t mspace, hid_t fspace,
-        hid_t dxpl, void* progbuf, PyArray_Descr* descr, int read) except -1:
+cdef herr_t dset_rw_vlen_strings(
+    hid_t dset, hid_t mspace, hid_t fspace, hid_t dxpl,
+    void* progbuf, PyArray_Descr* descr, int read) except -1:
+    """Variant of dset_rw for variable-width NumPy strings.
+    Note: doesn't support compound types.
+    """
 
     cdef hid_t dstype = -1      # Dataset datatype
     cdef hid_t h5_vlen_string = -1

--- a/h5py/_proxy.pyx
+++ b/h5py/_proxy.pyx
@@ -19,7 +19,7 @@ from .h5t import NUMPY_GE2
 if NUMPY_GE2:
     # Numpy native variable-width strings
     # This fails to import on NumPy < 2.0
-    from ._npystrings import vstrings_scatter, vstrings_gather
+    from ._npystrings import npystrings_pack, npystrings_unpack
 
 cdef enum copy_dir:
     H5PY_SCATTER = 0,
@@ -207,12 +207,12 @@ cdef herr_t dset_rw_vlen_strings(hid_t dset, hid_t mspace, hid_t fspace,
         if read:
             H5Dread(dset, h5_vlen_string, cspace, fspace, dxpl, conv_buf)
             # Convert contiguous char** to discontiguous NpyStrings.
-            vstrings_scatter(mspace, <size_t> conv_buf, <size_t> progbuf,
+            npystrings_pack(mspace, <size_t> conv_buf, <size_t> progbuf,
                              <size_t> descr)
             H5Dvlen_reclaim(dstype, cspace, H5P_DEFAULT, conv_buf)
         else:
             # Convert discontiguous NpyStrings to contiguous char**.
-            zero_terminated_buf = <char *> <size_t> vstrings_gather(
+            zero_terminated_buf = <char *> <size_t> npystrings_unpack(
                 mspace, <size_t> conv_buf, <size_t> progbuf, <size_t> descr,
                 npoints)
             H5Dwrite(dset, h5_vlen_string, cspace, fspace, dxpl, conv_buf)

--- a/h5py/_proxy.pyx
+++ b/h5py/_proxy.pyx
@@ -207,8 +207,7 @@ cdef herr_t dset_rw_vlen_strings(hid_t dset, hid_t mspace, hid_t fspace,
         if read:
             H5Dread(dset, h5_vlen_string, cspace, fspace, dxpl, conv_buf)
             # Convert contiguous char** to discontiguous NpyStrings.
-            npystrings_pack(mspace, <size_t> conv_buf, <size_t> progbuf,
-                             <size_t> descr)
+            npystrings_pack(mspace, <size_t> conv_buf, <size_t> progbuf, <size_t> descr)
             H5Dvlen_reclaim(dstype, cspace, H5P_DEFAULT, conv_buf)
         else:
             # Convert discontiguous NpyStrings to contiguous char**.

--- a/h5py/h5d.pxd
+++ b/h5py/h5d.pxd
@@ -13,4 +13,4 @@ from .defs cimport *
 from ._objects cimport ObjectID
 
 cdef class DatasetID(ObjectID):
-    cdef object _dtype
+    cdef public object _dtype

--- a/h5py/h5d.pyx
+++ b/h5py/h5d.pyx
@@ -18,7 +18,7 @@ include "config.pxi"
 from collections import namedtuple
 cimport cython
 from ._objects cimport pdefault
-from numpy cimport ndarray, import_array, PyArray_DATA
+from numpy cimport ndarray, import_array, PyArray_DATA, PyArray_Descr, PyArray_DESCR
 from .utils cimport  check_numpy_read, check_numpy_write, \
                      convert_tuple, convert_dims, emalloc, efree
 from .h5t cimport TypeID, typewrap, py_create
@@ -225,6 +225,7 @@ cdef class DatasetID(ObjectID):
         """
         cdef hid_t self_id, mtype_id, mspace_id, fspace_id, plist_id
         cdef void* data
+        cdef PyArray_Descr* descr
         cdef int oldflags
 
         if mtype is None:
@@ -237,8 +238,9 @@ cdef class DatasetID(ObjectID):
         fspace_id = fspace.id
         plist_id = pdefault(dxpl)
         data = PyArray_DATA(arr_obj)
+        descr = PyArray_DESCR(arr_obj)
 
-        dset_rw(self_id, mtype_id, mspace_id, fspace_id, plist_id, data, 1)
+        dset_rw(self_id, mtype_id, mspace_id, fspace_id, plist_id, data, descr, 1)
 
 
     @with_phil
@@ -265,6 +267,7 @@ cdef class DatasetID(ObjectID):
         """
         cdef hid_t self_id, mtype_id, mspace_id, fspace_id, plist_id
         cdef void* data
+        cdef PyArray_Descr* descr
         cdef int oldflags
 
         if mtype is None:
@@ -277,8 +280,9 @@ cdef class DatasetID(ObjectID):
         fspace_id = fspace.id
         plist_id = pdefault(dxpl)
         data = PyArray_DATA(arr_obj)
+        descr = PyArray_DESCR(arr_obj)
 
-        dset_rw(self_id, mtype_id, mspace_id, fspace_id, plist_id, data, 0)
+        dset_rw(self_id, mtype_id, mspace_id, fspace_id, plist_id, data, descr, 0)
 
 
     @with_phil

--- a/h5py/h5d.pyx
+++ b/h5py/h5d.pyx
@@ -254,9 +254,9 @@ cdef class DatasetID(ObjectID):
         fspace_id = fspace.id
         plist_id = pdefault(dxpl)
         data = PyArray_DATA(arr_obj)
-        descr = PyArray_DESCR(arr_obj)
 
         if _is_numpy_vlen_string(mtype_id):
+            descr = PyArray_DESCR(arr_obj)
             dset_rw_vlen_strings(self_id, mspace_id, fspace_id, plist_id, data, descr, 1)
         else:
             dset_rw(self_id, mtype_id, mspace_id, fspace_id, plist_id, data, 1)
@@ -299,9 +299,9 @@ cdef class DatasetID(ObjectID):
         fspace_id = fspace.id
         plist_id = pdefault(dxpl)
         data = PyArray_DATA(arr_obj)
-        descr = PyArray_DESCR(arr_obj)
 
         if _is_numpy_vlen_string(mtype_id):
+            descr = PyArray_DESCR(arr_obj)
             dset_rw_vlen_strings(self_id, mspace_id, fspace_id, plist_id, data, descr, 0)
         else:
             dset_rw(self_id, mtype_id, mspace_id, fspace_id, plist_id, data, 0)

--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -1795,7 +1795,7 @@ def string_dtype(encoding='utf-8', length=None):
     For variable length strings, the data should be passed as Python str objects
     if the encoding is 'utf-8', and bytes if it is 'ascii'.
     Starting from NumPy 2.0, it is preferred to pass utf-8 data as variable-width
-    numpy strings (``dtype=numpy.dtypes.StringDType`` or ``dtype=numpy.dtype("T")``
+    NumPy strings (``dtype=numpy.dtypes.StringDType()`` or ``dtype='T'``
     instead of ``dtype=h5py.string_dtype()``).
 
     For fixed length strings, the data should be numpy fixed length *bytes*
@@ -1908,7 +1908,7 @@ def check_vlen_dtype(dt):
 
     Returns None if the dtype does not represent an HDF5 vlen.
     """
-    # StringDType (numpy >=2.0)
+    # StringDType (NumPy >=2.0)
     if dt.kind == 'T':
         return str
 

--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -44,6 +44,8 @@ _IS_PPC64LE = _UNAME_MACHINE == "ppc64le"
 
 cdef char* H5PY_PYTHON_OPAQUE_TAG = "PYTHON:OBJECT"
 
+NUMPY_GE2 = int(np.__version__.split('.')[0]) >= 2
+
 # === Custom C API ============================================================
 
 cpdef TypeID typewrap(hid_t id_):
@@ -1480,7 +1482,7 @@ cdef TypeEnumID _c_enum(cnp.dtype dt, dict vals):
         if isinstance(name, bytes):
             bname = name
         else:
-            bname = unicode(name).encode('utf8')
+            bname = str(name).encode('utf8')
         out.enum_insert(bname, vals[name])
     return out
 
@@ -1618,7 +1620,7 @@ cdef TypeCompoundID _c_compound(cnp.dtype dt, int logical, int aligned):
     # (i.e. the position of the member in the struct)
     for name in sorted(dt.names, key=(lambda n: dt.fields[n][1])):
         field = dt.fields[name]
-        h5_name = name.encode('utf8') if isinstance(name, unicode) else name
+        h5_name = name.encode('utf8') if isinstance(name, str) else name
 
         # Get HDF5 data types and set the offset for each member
         member_dt = field[0]
@@ -1734,6 +1736,10 @@ cpdef TypeID py_create(object dtype_in, bint logical=0, bint aligned=0):
         elif kind == c'b':
             return _c_bool(dt)
 
+        # numpy.dtypes.StringDType
+        elif kind == c'T':
+            return _c_vlen_unicode()
+
         # Object types (including those with vlen hints)
         elif kind == c'O':
 
@@ -1741,7 +1747,7 @@ cpdef TypeID py_create(object dtype_in, bint logical=0, bint aligned=0):
                 vlen = check_vlen_dtype(dt)
                 if vlen is bytes:
                     return _c_vlen_str()
-                elif vlen is unicode:
+                elif vlen is str:
                     return _c_vlen_unicode()
                 elif vlen is not None:
                     return vlen_create(py_create(vlen, logical))
@@ -1775,7 +1781,11 @@ def string_dtype(encoding='utf-8', length=None):
     not unicode code points.
 
     For variable length strings, the data should be passed as Python str objects
-    (unicode in Python 2) if the encoding is 'utf-8', and bytes if it is 'ascii'.
+    if the encoding is 'utf-8', and bytes if it is 'ascii'.
+    Starting from NumPy 2.0, it is preferred to pass utf-8 data as variable-width
+    numpy strings (``dtype=numpy.dtypes.StringDType`` or ``dtype=numpy.dtype("T")``
+    instead of ``dtype=h5py.string_dtype()``).
+
     For fixed length strings, the data should be numpy fixed length *bytes*
     arrays, regardless of the encoding. Fixed length unicode data is not
     supported.
@@ -1794,7 +1804,8 @@ def string_dtype(encoding='utf-8', length=None):
         # Fixed length string
         return np.dtype("|S" + str(length), metadata={'h5py_encoding': encoding})
     elif length is None:
-        vlen = unicode if (encoding == 'utf-8') else bytes
+        # Variable-width Python object string
+        vlen = str if (encoding == 'utf-8') else bytes
         return np.dtype('O', metadata={'vlen': vlen})
     else:
         raise TypeError("length must be integer or None (got %r)" % length)
@@ -1885,6 +1896,10 @@ def check_vlen_dtype(dt):
 
     Returns None if the dtype does not represent an HDF5 vlen.
     """
+    # StringDType (numpy >=2.0)
+    if dt.kind == 'T':
+        return str
+
     try:
         return dt.metadata.get('vlen', None)
     except AttributeError:
@@ -1902,7 +1917,7 @@ def check_string_dtype(dt):
     Returns None if the dtype does not represent an HDF5 string.
     """
     vlen_kind = check_vlen_dtype(dt)
-    if vlen_kind is unicode:
+    if vlen_kind is str:
         return string_info('utf-8', None)
     elif vlen_kind is bytes:
         return string_info('ascii', None)
@@ -1970,6 +1985,10 @@ def check_dtype(**kwds):
 
     if name not in ('vlen', 'enum', 'ref'):
         raise TypeError('Unknown special type "%s"' % name)
+
+    # StringDType (numpy >=2.0)
+    if name == "vlen" and dt.kind == "T":
+        return str
 
     try:
         return dt.metadata[name]

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -49,12 +49,19 @@ class TestRepr(BaseDataset):
         Feature: repr(Dataset) behaves sensibly
     """
 
-    def test_repr_open(self):
+    def test_repr_basic(self):
+        ds = self.f.create_dataset('foo', (4,), dtype='int32')
+        assert repr(ds) == '<HDF5 dataset "foo": shape (4,), type "<i4">'
+
+    def test_repr_closed(self):
         """ repr() works on live and dead datasets """
         ds = self.f.create_dataset('foo', (4,))
-        self.assertIsInstance(repr(ds), str)
         self.f.close()
-        self.assertIsInstance(repr(ds), str)
+        assert repr(ds) == '<Closed HDF5 dataset>'
+
+    def test_repr_anonymous(self):
+        ds = self.f.create_dataset(None, (4,), dtype='int32')
+        assert repr(ds) == '<HDF5 dataset (anonymous): shape (4,), type "<i4">'
 
 
 class TestCreateShape(BaseDataset):

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -49,19 +49,12 @@ class TestRepr(BaseDataset):
         Feature: repr(Dataset) behaves sensibly
     """
 
-    def test_repr_basic(self):
-        ds = self.f.create_dataset('foo', (4,), dtype='int32')
-        assert repr(ds) == '<HDF5 dataset "foo": shape (4,), type "<i4">'
-
-    def test_repr_closed(self):
+    def test_repr_open(self):
         """ repr() works on live and dead datasets """
         ds = self.f.create_dataset('foo', (4,))
+        self.assertIsInstance(repr(ds), str)
         self.f.close()
-        assert repr(ds) == '<Closed HDF5 dataset>'
-
-    def test_repr_anonymous(self):
-        ds = self.f.create_dataset(None, (4,), dtype='int32')
-        assert repr(ds) == '<HDF5 dataset (anonymous): shape (4,), type "<i4">'
+        self.assertIsInstance(repr(ds), str)
 
 
 class TestCreateShape(BaseDataset):

--- a/h5py/tests/test_npystrings.py
+++ b/h5py/tests/test_npystrings.py
@@ -81,6 +81,8 @@ def test_astype_is_reversible(writable_file):
 
 
 def test_fixed_to_variable_width(writable_file):
+    # Note: this test triggers calls to H5Tconvert which are otherwise skipped.
+
     data = ["foo", "longer than 8 bytes"]
     x = writable_file.create_dataset(
         "x", data=data, dtype=h5py.string_dtype(length=20)
@@ -101,6 +103,8 @@ def test_fixed_to_variable_width(writable_file):
 
 
 def test_fixed_to_variable_width_too_short(writable_file):
+    # Note: this test triggers calls to H5Tconvert which are otherwise skipped.
+
     data = ["foo", "bar"]
     x = writable_file.create_dataset(
         "x", data=data, dtype=h5py.string_dtype(length=3)

--- a/h5py/tests/test_npystrings.py
+++ b/h5py/tests/test_npystrings.py
@@ -1,0 +1,151 @@
+import numpy as np
+import pytest
+
+import h5py
+
+NUMPY_GE2 = int(np.__version__.split('.')[0]) >= 2
+pytestmark = pytest.mark.skipif(not NUMPY_GE2, reason="requires numpy >=2.0")
+
+
+def test_roundtrip(writable_file):
+    ds = writable_file.create_dataset('x', shape=(2, 2), dtype='T')
+    # The h5py.Dataset object remembers its dtype
+    assert ds.dtype.kind == "T"
+    data = [["foo", "bar"], ["hello world", ""]]
+    ds[:] = data
+    a = ds[:]
+    assert a.dtype.kind == "T"
+    np.testing.assert_array_equal(a, data)
+
+    # Recreating the h5py.Dataset object resets the dtype to the default;
+    # because it's not stored in the HDF5 file, it's not recoverable.
+    ds = writable_file['x']
+    assert ds.dtype == object
+    np.testing.assert_array_equal(ds.asstr()[:], data)
+
+    ds = ds.astype("T")
+    assert isinstance(ds, h5py.Dataset)  # Not an AsTypeView
+    ds[0, 0] = "baz"  # Unlike an AsTypeView, it's writeable
+    data[0][0] = "baz"
+    a = ds[:]
+    assert a.dtype.kind == "T"
+    np.testing.assert_array_equal(a, data)
+
+    ds[0, 0] = np.asarray("123", dtype="O")
+    data[0][0] = "123"
+    np.testing.assert_array_equal(ds[:], data)
+
+
+def test_fromdata(writable_file):
+    data = [["foo", "bar"]]
+    np_data = np.asarray(data, dtype="T")
+    x = writable_file.create_dataset('x', data=data, dtype="T")
+    y = writable_file.create_dataset('y', data=data, dtype=np.dtypes.StringDType())
+    z = writable_file.create_dataset('z', data=np_data)
+
+    for ds in (x, y, z):
+        assert ds.dtype.kind == "T"
+        np.testing.assert_array_equal(ds[:], np_data)
+    for name in ("x", "y", "z"):
+        ds = writable_file[name]
+        assert ds.dtype == object
+        np.testing.assert_array_equal(ds.asstr()[:], data)
+        ds = ds.astype("T")
+        assert ds.dtype.kind == "T"
+        a = ds[:]
+        assert a.dtype.kind == "T"
+        np.testing.assert_array_equal(a, data)
+
+
+def test_astype_is_reversible(writable_file):
+    data = ["foo", "bar"]
+    x = writable_file.create_dataset(
+        'x', data=data, dtype=h5py.string_dtype()
+    )
+    assert x.dtype == object
+    x = x.astype("T")
+    assert x.dtype.kind == "T"
+    assert x[:].dtype.kind == "T"
+
+    y = x.astype(object)
+    z = x.astype("O")
+    assert y.dtype == object
+    assert z.dtype == object
+    assert y[:].dtype == object
+    assert z[:].dtype == object
+
+    # asstr() internally calls astype
+    w = x.asstr()
+    assert w.dtype == object
+    np.testing.assert_array_equal(w[:], data)
+
+
+def test_fixed_to_variable_width(writable_file):
+    data = ["foo", "longer than 8 bytes"]
+    x = writable_file.create_dataset(
+        'x', data=data, dtype=h5py.string_dtype(length=20)
+    )
+    assert x.dtype == "S20"
+
+    # read T <- S
+    y = x.astype("T")
+    assert isinstance(y, h5py.Dataset)
+    assert y.dtype.kind == "T"
+    assert y[:].dtype.kind == "T"
+    np.testing.assert_array_equal(y[:], data)
+
+    # write T -> S
+    x[0] = np.asarray("1234", dtype="T")
+    data[0] = "1234"
+    np.testing.assert_array_equal(y[:], data)
+
+
+def test_fixed_to_variable_width_too_short(writable_file):
+    data = ["foo", "bar"]
+    x = writable_file.create_dataset(
+        'x', data=data, dtype=h5py.string_dtype(length=3)
+    )
+    assert x.dtype == "S3"
+
+    # write T -> S
+    x[0] = np.asarray("1234", dtype="T")
+    np.testing.assert_array_equal(x[:], [b"123", b"bar"])
+
+
+def test_variable_to_fixed_width(writable_file):
+    data = ["foo", "longer than 8 bytes"]
+    bdata = [b"foo", b"longer than 8 bytes"]
+    x = writable_file.create_dataset('x', data=data, dtype="T")
+    assert x.dtype.kind == "T"
+
+    # read S <- T
+    y = x.astype("S20")
+    assert y.dtype == "S20"
+    assert y[:].dtype == "S20"
+    np.testing.assert_array_equal(y[:], bdata)
+
+    y = x.astype("S3")
+    assert y.dtype == "S3"
+    assert y[:].dtype == "S3"
+    np.testing.assert_array_equal(y[:], [b"foo", b"lon"])
+
+    # write S -> T
+    x[0] = np.asarray(b"1234", dtype="S5")
+    data[0] = "1234"
+    np.testing.assert_array_equal(x[:], data)
+
+
+def test_write_object_into_npystrings(writable_file):
+    x = writable_file.create_dataset('x', data=["foo"], dtype="T")
+    assert x.dtype.kind == "T"
+    x[0] = np.asarray("1234", dtype="O")
+    np.testing.assert_array_equal(x[:], "1234")
+
+
+def test_write_npystrings_into_object(writable_file):
+    x = writable_file.create_dataset(
+        'x', data=["foo"], dtype=h5py.string_dtype()
+    )
+    assert x.dtype == object
+    x[0] = np.asarray("1234", dtype="T")
+    np.testing.assert_array_equal(x[:], b"1234")

--- a/h5py/tests/test_npystrings.py
+++ b/h5py/tests/test_npystrings.py
@@ -155,3 +155,9 @@ def test_empty_string(writable_file):
     x[:2] = data[:2]
     np.testing.assert_array_equal(x[:], [b"c", b"", b"b"])
     np.testing.assert_array_equal(x.astype("T")[:], data)
+
+
+def test_astype_nonstring(writable_file):
+    x = writable_file.create_dataset("x", shape=(2, ), dtype="i8")
+    with pytest.raises(TypeError, match="HDF5 string datatype"):
+        x.astype("T")

--- a/h5py/tests/test_npystrings.py
+++ b/h5py/tests/test_npystrings.py
@@ -160,3 +160,29 @@ def test_repr(writable_file):
     assert repr(x) == '<HDF5 dataset "x": shape (1,), type "|O">'
     x = x.astype("T")
     assert repr(x) == '<HDF5 dataset "x": shape (1,), type StringDType()>'
+
+
+def test_fillvalue(writable_file):
+    # Create as NpyString dtype
+    x = writable_file.create_dataset("x", shape=(2,), dtype="T", fillvalue="foo")
+    assert isinstance(x.fillvalue, str)
+    assert x.fillvalue == "foo"
+    assert x[0] == "foo"
+    # Revert to object dtype
+    x = x.astype(object)
+    assert isinstance(x.fillvalue, bytes)
+    assert x.fillvalue == b"foo"
+    assert x[0] == b"foo"
+
+    # Create as object dtype
+    y = writable_file.create_dataset(
+        "y", shape=(2,), dtype=h5py.string_dtype(), fillvalue=b"foo"
+    )
+    assert isinstance(y.fillvalue, bytes)
+    assert y.fillvalue == b"foo"
+    assert y[0] == b"foo"
+    # Convert object dtype to NpyString
+    y = y.astype("T")
+    assert isinstance(y.fillvalue, str)
+    assert y.fillvalue == "foo"
+    assert y[0] == "foo"

--- a/h5py/tests/test_npystrings.py
+++ b/h5py/tests/test_npystrings.py
@@ -144,3 +144,14 @@ def test_fillvalue(writable_file):
     # Convert object dtype to NpyString
     y = y.astype("T")
     assert y[0] == "foo"
+
+
+def test_empty_string(writable_file):
+    data = np.array(["", "a", "b"], dtype="T")
+    x = writable_file.create_dataset("x", data=data)
+    np.testing.assert_array_equal(x[:], [b"", b"a", b"b"])
+    np.testing.assert_array_equal(x.astype("T")[:], data)
+    data[:2] = ["c", ""]
+    x[:2] = data[:2]
+    np.testing.assert_array_equal(x[:], [b"c", b"", b"b"])
+    np.testing.assert_array_equal(x.astype("T")[:], data)

--- a/h5py/tests/test_npystrings.py
+++ b/h5py/tests/test_npystrings.py
@@ -3,12 +3,12 @@ import pytest
 
 import h5py
 
-NUMPY_GE2 = int(np.__version__.split('.')[0]) >= 2
+NUMPY_GE2 = int(np.__version__.split(".")[0]) >= 2
 pytestmark = pytest.mark.skipif(not NUMPY_GE2, reason="requires numpy >=2.0")
 
 
 def test_roundtrip(writable_file):
-    ds = writable_file.create_dataset('x', shape=(2, 2), dtype='T')
+    ds = writable_file.create_dataset("x", shape=(2, 2), dtype="T")
     # The h5py.Dataset object remembers its dtype
     assert ds.dtype.kind == "T"
     data = [["foo", "bar"], ["hello world", ""]]
@@ -19,7 +19,7 @@ def test_roundtrip(writable_file):
 
     # Recreating the h5py.Dataset object resets the dtype to the default;
     # because it's not stored in the HDF5 file, it's not recoverable.
-    ds = writable_file['x']
+    ds = writable_file["x"]
     assert ds.dtype == object
     np.testing.assert_array_equal(ds.asstr()[:], data)
 
@@ -39,9 +39,9 @@ def test_roundtrip(writable_file):
 def test_fromdata(writable_file):
     data = [["foo", "bar"]]
     np_data = np.asarray(data, dtype="T")
-    x = writable_file.create_dataset('x', data=data, dtype="T")
-    y = writable_file.create_dataset('y', data=data, dtype=np.dtypes.StringDType())
-    z = writable_file.create_dataset('z', data=np_data)
+    x = writable_file.create_dataset("x", data=data, dtype="T")
+    y = writable_file.create_dataset("y", data=data, dtype=np.dtypes.StringDType())
+    z = writable_file.create_dataset("z", data=np_data)
 
     for ds in (x, y, z):
         assert ds.dtype.kind == "T"
@@ -60,7 +60,7 @@ def test_fromdata(writable_file):
 def test_astype_is_reversible(writable_file):
     data = ["foo", "bar"]
     x = writable_file.create_dataset(
-        'x', data=data, dtype=h5py.string_dtype()
+        "x", data=data, dtype=h5py.string_dtype()
     )
     assert x.dtype == object
     x = x.astype("T")
@@ -83,7 +83,7 @@ def test_astype_is_reversible(writable_file):
 def test_fixed_to_variable_width(writable_file):
     data = ["foo", "longer than 8 bytes"]
     x = writable_file.create_dataset(
-        'x', data=data, dtype=h5py.string_dtype(length=20)
+        "x", data=data, dtype=h5py.string_dtype(length=20)
     )
     assert x.dtype == "S20"
 
@@ -103,7 +103,7 @@ def test_fixed_to_variable_width(writable_file):
 def test_fixed_to_variable_width_too_short(writable_file):
     data = ["foo", "bar"]
     x = writable_file.create_dataset(
-        'x', data=data, dtype=h5py.string_dtype(length=3)
+        "x", data=data, dtype=h5py.string_dtype(length=3)
     )
     assert x.dtype == "S3"
 
@@ -115,7 +115,7 @@ def test_fixed_to_variable_width_too_short(writable_file):
 def test_variable_to_fixed_width(writable_file):
     data = ["foo", "longer than 8 bytes"]
     bdata = [b"foo", b"longer than 8 bytes"]
-    x = writable_file.create_dataset('x', data=data, dtype="T")
+    x = writable_file.create_dataset("x", data=data, dtype="T")
     assert x.dtype.kind == "T"
 
     # read S <- T
@@ -136,7 +136,7 @@ def test_variable_to_fixed_width(writable_file):
 
 
 def test_write_object_into_npystrings(writable_file):
-    x = writable_file.create_dataset('x', data=["foo"], dtype="T")
+    x = writable_file.create_dataset("x", data=["foo"], dtype="T")
     assert x.dtype.kind == "T"
     x[0] = np.asarray("1234", dtype="O")
     np.testing.assert_array_equal(x[:], "1234")
@@ -144,8 +144,15 @@ def test_write_object_into_npystrings(writable_file):
 
 def test_write_npystrings_into_object(writable_file):
     x = writable_file.create_dataset(
-        'x', data=["foo"], dtype=h5py.string_dtype()
+        "x", data=["foo"], dtype=h5py.string_dtype()
     )
     assert x.dtype == object
     x[0] = np.asarray("1234", dtype="T")
     np.testing.assert_array_equal(x[:], b"1234")
+
+
+def test_repr(writable_file):
+    x = writable_file.create_dataset("x", data=["foo"])
+    assert repr(x) == '<HDF5 dataset "x": shape (1,), type "|O">'
+    x = x.astype("T")
+    assert repr(x) == '<HDF5 dataset "x": shape (1,), type StringDType()>'

--- a/news/npystrings.rst
+++ b/news/npystrings.rst
@@ -2,9 +2,10 @@ New features
 ------------
 
 * On NumPy 2.x, it is now possible to read and write native NumPy variable-width
-  strings, a.k.a. NpyStrings (``'T'`` dtype), which are much faster than object
-  strings. For the sake of interoperability with NumPy 1.x, users need to
-  explicitly opt in. See :ref:`npystrings`.
+  strings, a.k.a. NpyStrings (``dtype=np.dtypes.StringDType()`` or ``dtype='T'``
+  for short), which are much faster than object strings. For the sake of
+  interoperability with NumPy 1.x, users need to explicitly opt in.
+  See :ref:`npystrings`.
 
 Deprecations
 ------------

--- a/news/npystrings.rst
+++ b/news/npystrings.rst
@@ -1,0 +1,33 @@
+New features
+------------
+
+* On NumPy 2.x, it is now possible to read and write native NumPy variable-width
+  strings, a.k.a. NpyStrings (``'T'`` dtype), which are much faster than object
+  strings. For the sake of interoperability with NumPy 1.x, users need to
+  explicitly opt in. See :ref:`npystrings`.
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* <news item>
+
+Building h5py
+-------------
+
+* NpyStrings introduce no changes in the build process: you need NumPy 2.x to build
+  (as before), and the same binary wheels are backwards compatible with NumPy 1.x.
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
Closes #2551

- [x] main implementation
- [x] performance benchmarks
- [x] no breaking changes (as discussed in #2551)
- [x] don't break compilation on numpy <2.3
- [x] don't break execution on numpy 1
- [x] compile on numpy 2.0
- [x] unit tests
- [x] documentation

# Smoke test
[npystrings_demo.py](https://github.com/crusaderky/h5py/blob/npystrings_demo/npystrings_demo.py) 

# Performance test
[npystrings_bench.py](https://github.com/crusaderky/h5py/blob/npystrings_demo/npystrings_bench.py) 

1_000_000 strings of random width 0~100 characters
(82 MiB dataset) on local NVMe

object dtype (master)
    write: 0.463s
    read : 0.529s

StringDType()
    write: 0.252s
    read : 0.390s

On-disk format is identical between the two.
