### PR TITLE
Virtual datasets with no mappings may still be virtual

### DIFF
--- a/h5py/_hl/vds.py
+++ b/h5py/_hl/vds.py
@@ -171,6 +171,7 @@ class VirtualLayout:
         self._filename = filename
         self._src_filenames = set()
         self.dcpl = h5p.create(h5p.DATASET_CREATE)
+        self.dcpl.set_layout(h5d.VIRTUAL)
 
     def __setitem__(self, key, source):
         sel = select(self.shape, key, dataset=None)
@@ -212,6 +213,7 @@ class VirtualLayout:
             # but we didn't know this when making the mapping. Copy the mappings
             # to a new property list, replacing the dest filename with '.'
             new_dcpl = h5p.create(h5p.DATASET_CREATE)
+            new_dcpl.set_layout(h5d.VIRTUAL)
             for i in range(self.dcpl.get_virtual_count()):
                 src_filename = self.dcpl.get_virtual_filename(i)
                 new_dcpl.set_virtual(

--- a/h5py/tests/test_vds/test_highlevel_vds.py
+++ b/h5py/tests/test_vds/test_highlevel_vds.py
@@ -461,5 +461,16 @@ class VDSUnlimitedTestCase(ut.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
 
+
+def test_no_mappings(writable_file):
+    with writable_file.build_virtual_dataset("foo", (10, 20), np.int32):
+        pass
+
+    dset = writable_file['foo']
+    assert dset.is_virtual
+    assert dset.virtual_sources() == []
+    np.testing.assert_array_equal(dset[()], np.zeros((10, 20), np.int32))
+
+
 if __name__ == "__main__":
     ut.main()


### PR DESCRIPTION
At present, it's impossible to create a virtual dataset with no mappings in h5py's high-level API; this will be silently converted to a normal contiguous/compact dataset instead.

I don't think there's much practical reason to do this, but it's nice for tools building a virtual dataset of 0-N pieces for the behaviour to be consistent at 0 and 1.

Discussed in #1660, but not the main focus of that issue.