### PR TITLE
Add Path to the accepted types in the high-level doc of File

### DIFF
--- a/docs/high/file.rst
+++ b/docs/high/file.rst
@@ -463,10 +463,9 @@ Reference
     listed below, :class:`File` objects inherit the full interface of
     :class:`Group`.
 
-    :param name:    Name of file (`bytes` or `str`), or an instance of
-                    :class:`h5f.FileID` to bind to an existing
-                    file identifier, or a file-like object
-                    (see :ref:`file_fileobj`).
+    :param name:    Name of file (`os.PathLike[str]`, `bytes` or `str`), or an
+                    instance of :class:`h5f.FileID` to bind to an existing file
+                    identifier, or a file-like object (see :ref:`file_fileobj`).
     :param mode:    Mode in which to open file; one of
                     ("w", "r", "r+", "a", "w-").  See :ref:`file_open`.
     :param driver:  File driver to use; see :ref:`file_driver`.


### PR DESCRIPTION
`pathlib.Path` is a valid type for `name` in `File` (see https://github.com/h5py/h5py/blob/187bb41ea2cbd0e78455d0b88de007354c3c8431/h5py/tests/test_file.py#L849) but it was not in the doc

