### PR TITLE
New style license metadata in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "Cython >=0.29.31,<4",
     "numpy >=2.0.0, <3",
     "pkgconfig",
-    "setuptools >=61",
+    "setuptools >=77",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -17,13 +17,13 @@ maintainers = [
     {name = "Thomas Kluyver", email = "thomas@kluyver.me.uk"},
     {name = "Thomas A Caswell", email = "tcaswell@bnl.gov"},
 ]
-license = {text = "BSD-3-Clause"}
+license = "BSD-3-Clause"
+license-files = ["LICENSE", "lzf/LICENSE.txt", "licenses/*"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Intended Audience :: Information Technology",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: Unix",
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",


### PR DESCRIPTION
Following [PEP 639](https://peps.python.org/pep-0639/), setuptools has started to warn about the old-style license syntax. Setuptools 77 is the minimum to use the new format, and that's compatible with Python 3.9 and upwards, matching what h5py currently supports.

I notice we have license files for hdf5, python, pytables & stdint (?) in the 'licenses' folder. For HDF5 I guess this is actually necessary, since we bundle it in the wheels, i.e. redistribute it in binary format. But I'm not sure if the others are necessary, and the commit where they were added back in 2011 (686d8fab) doesn't really give me a clue. :shrug: 

We also bundle zlib on Windows & Mac; the [zlib license](https://en.wikipedia.org/wiki/Zlib_License) doesn't appear to require a copyright notice with binaries, but perhaps it's good practice to put it there anyway?