### PR TITLE
Fix .read_direct() when one selected dimension is 0

### DIFF
--- a/h5py/_hl/selections.py
+++ b/h5py/_hl/selections.py
@@ -290,6 +290,10 @@ class SimpleSelection(Selection):
         rank = len(count)
         tshape = self.expand_shape(source_shape)
 
+        # Avoid ZeroDivisionError below (after the shape checks in expand_source)
+        if any(d == 0 for d in count):
+            return
+
         chunks = tuple(x//y for x, y in zip(count, tshape))
         nchunks = product(chunks)
 

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -264,6 +264,13 @@ class TestReadDirectly:
         with pytest.raises(TypeError):
             dset.read_direct(arr)
 
+    def test_zero_length(self, writable_file):
+        shape = (0, 20)
+        dset = writable_file.create_dataset("dset", shape, dtype=np.int64)
+        arr = np.zeros(shape, dtype=np.int64)
+        dset.read_direct(arr)
+
+
 class TestWriteDirectly:
 
     """

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -270,6 +270,11 @@ class TestReadDirectly:
         arr = np.zeros(shape, dtype=np.int64)
         dset.read_direct(arr)
 
+        # We should still get an error if the shape is wrong
+        arr2 = np.zeros((0, 25), dtype=np.int64)
+        with pytest.raises(TypeError):
+            dset.read_direct(arr2)
+
 
 class TestWriteDirectly:
 

--- a/news/read-direct-zero.rst
+++ b/news/read-direct-zero.rst
@@ -1,0 +1,29 @@
+New features
+------------
+
+* <news item>
+
+Deprecations
+------------
+
+* <news item>
+
+Exposing HDF5 functions
+-----------------------
+
+* <news item>
+
+Bug fixes
+---------
+
+* Fixed an error using :meth:`.Dataset.read_direct` with a zero-size selection.
+
+Building h5py
+-------------
+
+* <news item>
+
+Development
+-----------
+
+* <news item>


### PR DESCRIPTION
Datasets and selections with zero length on one or more dimensions are allowed and usually work (similar to numpy arrays with a zero dimension), but there was a bug causing a ZeroDivisionError in `.read_direct()`. This should fix it.

Closes #870