### PR TITLE
Bump setuptools requirement in CIBW

### DIFF
--- a/ci/triage_build.sh
+++ b/ci/triage_build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# REMEMBER TO KEEP THE VERSIONS IN THIS FILE THE SAME AS IN THE pyproject.toml
+
 set -eo pipefail
 
 if [[ "$1" == "" ]] || [[ "$2" == "" ]]; then

--- a/ci/triage_build.sh
+++ b/ci/triage_build.sh
@@ -20,7 +20,7 @@ CIBW_SKIP="pp* *musllinux*"
 # If it's a scheduled build or [pip-pre] in commit message, use pip-pre
 if [[ "$GITHUB_EVENT_NAME" == "schedule" ]] || [[ "$MSG" = *'[pip-pre]'* ]]; then
     echo "Using NumPy pip-pre wheel and (on Linux), setting CIBW_BEFORE_BUILD, CIBW_BUILD_FRONTEND and CIBW_BEFORE_TEST"
-    echo "CIBW_BEFORE_BUILD=pip install --pre --only-binary numpy --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \"numpy>=2.0.0.dev0\" \"Cython>=0.29.31,<4\" pkgconfig \"setuptools>=61\" wheel" | tee -a $GITHUB_ENV
+    echo "CIBW_BEFORE_BUILD=pip install --pre --only-binary numpy --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \"numpy>=2.0.0.dev0\" \"Cython>=0.29.31,<4\" pkgconfig \"setuptools>=77\" wheel" | tee -a $GITHUB_ENV
     echo "CIBW_BUILD_FRONTEND=pip; args: --no-build-isolation" | tee -a $GITHUB_ENV
     # This is harder on other architectures, so only do it on Linux for now
     echo "CIBW_BEFORE_TEST=pip install --pre --only-binary numpy --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \"numpy>=2.0.0.dev0\"" | tee -a $GITHUB_ENV

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,6 @@
 [build-system]
+
+# REMEMBER TO KEEP THE VERSIONS IN THIS FILE THE SAME AS IN ci/triage_build.sh
 requires = [
     "Cython >=0.29.31,<4",
     "numpy >=2.0.0, <3",


### PR DESCRIPTION
The new license format requires setuptools>=77.

Closes #2579 (hopefully).
