### PR TITLE
Make phil Lock handling fork-safe

### DIFF
--- a/h5py/_objects.pyx
+++ b/h5py/_objects.pyx
@@ -57,6 +57,25 @@ def with_phil(func):
     functools.update_wrapper(wrapper, func)
     return wrapper
 
+def _phil_before_fork():
+    """
+    Acquire the lock before forking so the current thread is the only one
+    holding the lock.
+    """
+    _phil.acquire()
+
+def _phil_after_fork():
+    """
+    Release the lock after forking in the child.
+    """
+    _phil.release()
+
+# Register fork handlers to safely handle forked child processes.
+import os
+os.register_at_fork(before=_phil_before_fork,
+                    after_in_child=_phil_after_fork,
+                    after_in_parent=_phil_after_fork)
+
 # --- End locking code --------------------------------------------------------
 
 

--- a/h5py/tests/test_objects.py
+++ b/h5py/tests/test_objects.py
@@ -6,10 +6,18 @@
 #
 # License:  Standard 3-clause BSD; see "license.txt" for full license terms
 #           and contributor agreement.
+import os
+import random
+import tempfile
+import threading
+from concurrent.futures import ThreadPoolExecutor
 
+import numpy as np
+
+import h5py
 from h5py import _objects as o
-
 from .common import TestCase
+
 
 class TestObjects(TestCase):
 
@@ -34,3 +42,48 @@ class TestObjects(TestCase):
         oid = o.ObjectID(42)
         with self.assertRaises(TypeError):
             hash(oid)
+
+    def test_phil_fork_with_threads(self):
+        # Test that handling of the phil Lock after fork is correct
+        # even when multiple threads are present.
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fns = []
+            for i in range(10):
+                fn = f'{tmpdir}/test{i}.h5'
+                with h5py.File(fn, 'w') as f:
+                    f.create_dataset('values', data=np.random.rand(1000, 1000))
+                fns.append(fn)
+
+            def f(fn):
+                with h5py.File(fn, 'r') as f:
+                    for _ in range(100):
+                        _ = f['values'][:]
+
+            # create 10 threads, each reading from an HDF5 file
+            threads = []
+            for fn in fns:
+                thread = threading.Thread(target=f, args=(fn,))
+                thread.start()
+                threads.append(thread)
+
+            # While the threads are running (and potentially holding the phil Lock)
+            # create 10 processes, each also reading from an HDF5 file
+            worker2pid = {}
+            for worker_id, fn in enumerate(fns):
+                pid = os.fork()
+                if pid == 0:
+                    # child process
+                    f(fn)
+                    os._exit(0)
+                else:
+                    # parent process
+                    worker2pid[worker_id] = pid
+
+            # Wait for all child processes to finish
+            for worker_id, pid in worker2pid.items():
+                os.waitpid(pid, 0)
+
+            # Wait for all threads to finish
+            for thread in threads:
+                thread.join()


### PR DESCRIPTION
When we use multiple threads to read
via `h5py` with forked subprocesses we
can sometimes observe the subprocess hanging.
This happens because in the parent process one
of the threads currently holds the `phil` Lock
and when we fork only the current thread is kept
in the child process.
If the child process now tries to acquire the
`phil` Lock it will hang forever.

To work around this issue we explicitly acquire
the `phil` Lock in the thread which is about to
fork *before* forking and then release it again
*after* forking in both the parent and the child
process.

There are three scenarios:
1. no thread currently holds the `phil` Lock: in this case it is just acquired for the duration of the fork and immediately released after
2. the current thread holds the `phil` Lock: since the lock is reentrant this basically just increments the lock count before forking and decrements it after the fork
3. a different thread holds the `phil` Lock: in this case we would wait until the lock is released by the other thread and only then fork.

Closes #2584

<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py312-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->
