### PR TITLE
Use H5Dwrite_chunk instead of H5DO function

### DIFF
--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -113,7 +113,7 @@ hdf5:
   herr_t H5Drefresh(hid_t dataset_id) nogil
 
   # Direct Chunk Read/Write
-  herr_t H5DOwrite_chunk(hid_t dset_id, hid_t dxpl_id, uint32_t filters, const hsize_t *offset, size_t data_size, const void *buf) nogil
+  herr_t H5Dwrite_chunk(hid_t dset_id, hid_t dxpl_id, uint32_t filters, const hsize_t *offset, size_t data_size, const void *buf) nogil
   herr_t H5Dget_chunk_storage_size(hid_t dset_id, const hsize_t *offset, hsize_t *chunk_nbytes) nogil
   herr_t H5Dread_chunk(hid_t dset_id, hid_t dxpl_id, const hsize_t *offset, uint32_t *filters, void *buf) nogil
 

--- a/h5py/h5d.pyx
+++ b/h5py/h5d.pyx
@@ -528,7 +528,7 @@ cdef class DatasetID(ObjectID):
             offset = <hsize_t*>emalloc(sizeof(hsize_t)*rank)
             convert_tuple(offsets, offset, rank)
             PyObject_GetBuffer(data, &view, PyBUF_ANY_CONTIGUOUS)
-            H5DOwrite_chunk(dset_id, dxpl_id, filter_mask, offset, view.len, view.buf)
+            H5Dwrite_chunk(dset_id, dxpl_id, filter_mask, offset, view.len, view.buf)
         finally:
             efree(offset)
             PyBuffer_Release(&view)


### PR DESCRIPTION
The read_chunk & write_chunk functions were originally added in H5DO, and later moved/copied to H5D. For some reason we were still calling write_chunk at the old name. I think we can clean this up to only use the new name now - this should exist in all versions we support.