### PR TITLE
BLD: allow building h5py in against CPyhton's limited API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
   ext_modules = [Extension('h5py.x',['x.c'])],  # To trick build into running build_ext
   install_requires = RUN_REQUIRES,
   cmdclass = CMDCLASS,
+  options = setup_build.OPTIONS,
 )
 
 # see pyproject.toml for static metadata

--- a/setup_build.py
+++ b/setup_build.py
@@ -11,6 +11,7 @@ import sysconfig
 import os
 import os.path as op
 import platform
+import warnings
 from packaging.version import Version
 from pathlib import Path
 
@@ -25,6 +26,26 @@ from setup_configure import BuildConfig
 def localpath(*args):
     return op.abspath(op.join(op.dirname(__file__), *args))
 
+
+if USE_PY_LIMITED_API := (os.getenv('H5PY_LIMITED_API', '0') == '1'):
+    if sys.version_info < (3, 11):
+        msg = (
+            "H5PY_LIMITED_API is set but will be ignored "
+            "because it is only supported for Python 3.11 and newer."
+        )
+    elif sysconfig.get_config_var("Py_GIL_DISABLED"):
+        msg = (
+            "H5PY_LIMITED_API is set but will be ignored "
+            "because it is not supported for free-threaded builds."
+        )
+    else:
+        msg = None
+    if msg is not None:
+        warnings.warn(msg)
+        USE_PY_LIMITED_API = False
+
+ABI3_TARGET_VERSION = "".join(str(_) for _ in sys.version_info[:2])
+ABI3_TARGET_HEX = hex(sys.hexversion & 0xFFFF00F0)
 
 MODULES = ['defs', '_errors', '_objects', '_proxy', 'h5fd', 'h5z',
             'h5', 'h5i', 'h5r', 'utils', '_selector',
@@ -49,6 +70,13 @@ COMPILER_SETTINGS = {
                        ('NPY_NO_DEPRECATED_API', 0),
                       ]
 }
+if USE_PY_LIMITED_API:
+    COMPILER_SETTINGS['define_macros'].append(('Py_LIMITED_API', ABI3_TARGET_HEX))
+
+    # options to be passed as setuptools.setup(..., options=...)
+    OPTIONS = {"bdist_wheel": {"py_limited_api": f"cp{ABI3_TARGET_VERSION}"}}
+else:
+    OPTIONS = {}
 
 EXTRA_SRC = {'h5z': [ localpath("lzf/lzf_filter.c") ]}
 
@@ -147,6 +175,7 @@ class h5py_build_ext(build_ext):
         sources = [localpath('h5py', module + '.pyx')] + EXTRA_SRC.get(module, [])
         settings = copy.deepcopy(settings)
         settings['libraries'] += EXTRA_LIBRARIES.get(module, [])
+        settings["py_limited_api"] = USE_PY_LIMITED_API
 
         return Extension('h5py.' + module, sources, **settings)
 

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,7 @@ commands =
 changedir =
     test: {toxworkdir}
 passenv =
+    H5PY_LIMITED_API
     H5PY_SYSTEM_LZF
     H5PY_TEST_CHECK_FILTERS
     HDF5_DIR


### PR DESCRIPTION
I realized that with Cython 3.1 now out, I don't know of any remaining blocker for building and distributing `abi3` wheels, which would greatly improve forward-compatibility of our artifacts, so, I'm giving it a try here.

Note that I encountered issues with this build for Python versions older than 3.11 on another package, so I'm limiting the scope to 3.11+ for now. Will try again on 3.10 then 3.9 as long as CI stays green.