### PR TITLE
MNT: bump windows image on azure (2019 -> 2022)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,7 +85,7 @@ jobs:
 
 - job: 'Windows'
   pool:
-    vmImage: windows-2019
+    vmImage: windows-2022
   strategy:
     matrix:
     # -deps : test with default (latest) versions of dependencies


### PR DESCRIPTION
xref: https://github.com/actions/runner-images/issues/12045
