### PR TITLE
TST: broaden scope of a warning filter on a test that otherwise fails on CPython 3.14

### DIFF
--- a/h5py/tests/test_file2.py
+++ b/h5py/tests/test_file2.py
@@ -173,9 +173,9 @@ class TestFileObj(TestCase):
             os.remove(fname)
 
     @pytest.mark.filterwarnings(
-        # on Windows, a resource warning may be emitted
+        # at least on Windows and MacOS, a resource warning may be emitted
         # when this test returns
-        "ignore:unclosed file:ResourceWarning"
+        "ignore::ResourceWarning"
     )
     def test_TemporaryFile(self):
         # in this test, we check explicitly that temp file gets


### PR DESCRIPTION
Discovered in #2595 (and reproduced locally), follow up to #2428