### PR TITLE
Speed up fancy indexing

### DIFF
--- a/h5py/_selector.pyx
+++ b/h5py/_selector.pyx
@@ -242,23 +242,22 @@ cdef class Selector:
             self.is_fancy = False
         return True
 
-    cdef build_fancy_hyperslab(self, ndarray array_arg, int array_ix, hsize_t* tmp_start, hsize_t* tmp_count):
+    cdef build_fancy_hyperslab(self, space, ndarray array_arg, int array_ix, hsize_t* tmp_start, hsize_t* tmp_count):
         """Recursive merge algorithm to help select_fancy quickly apply selection to the dataspace"""
 
         # With fewer than 16 elements, looping through fancy indices is faster
         if len(array_arg)<16:
-            space = H5Scopy(self.space)
-            H5Sselect_none(space)
             for i in array_arg:
                 tmp_start[array_ix] = i
                 H5Sselect_hyperslab(space, H5S_SELECT_OR, tmp_start, self.stride, tmp_count, self.block)
             return space
         else:
-            space1 = self.build_fancy_hyperslab(array_arg[:len(array_arg)//2], array_ix, tmp_start, tmp_count)
-            space2 = self.build_fancy_hyperslab(array_arg[len(array_arg)//2:], array_ix, tmp_start, tmp_count)
-            H5Smodify_select(space1, H5S_SELECT_OR, space2)
+            self.build_fancy_hyperslab(space, array_arg[:len(array_arg)//2], array_ix, tmp_start, tmp_count)
+            space2 = H5Screate_simple(self.rank, self.dims, NULL)
+            H5Sselect_none(space2)
+            self.build_fancy_hyperslab(space2, array_arg[len(array_arg)//2:], array_ix, tmp_start, tmp_count)
+            H5Smodify_select(space, H5S_SELECT_OR, space2)
             H5Sclose(space2)
-            return space1
 
     cdef select_fancy(self, int array_ix, ndarray array_arg):
         """Apply a 'fancy' selection (array of indices) to the dataspace"""
@@ -275,9 +274,7 @@ cdef class Selector:
             memcpy(tmp_count, self.count, sizeof(hsize_t) * self.rank)
             tmp_count[array_ix] = 1
 
-            new_space = self.build_fancy_hyperslab(array_arg, array_ix, tmp_start, tmp_count)
-            H5Sselect_copy(self.space, new_space)
-            H5Sclose(new_space)
+            self.build_fancy_hyperslab(self.space, array_arg, array_ix, tmp_start, tmp_count)
         finally:
             efree(tmp_start)
             efree(tmp_count)

--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -489,7 +489,7 @@ hdf5:
 
   hid_t     H5Scombine_hyperslab(hid_t space_id, H5S_seloper_t op,  hsize_t *start, hsize_t *_stride, hsize_t *count, hsize_t *_block)
   hid_t     H5Scombine_select(hid_t space1_id, H5S_seloper_t op, hid_t space2_id)
-  hid_t     H5Smodify_select(hid_t space1_id, H5S_seloper_t op, hid_t space2_id)
+  herr_t     H5Smodify_select(hid_t space1_id, H5S_seloper_t op, hid_t space2_id)
 
   herr_t    H5Sencode(hid_t obj_id, void *buf, size_t *nalloc)
   hid_t     H5Sdecode(void *buf)

--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -487,7 +487,6 @@ hdf5:
   herr_t    H5Sget_select_hyper_blocklist(hid_t space_id,  hsize_t startblock, hsize_t numblocks, hsize_t *buf )
   herr_t    H5Sselect_hyperslab(hid_t space_id, H5S_seloper_t op,  hsize_t *start, hsize_t *_stride, hsize_t *count, hsize_t *_block)
 
-  hid_t     H5Scombine_hyperslab(hid_t space_id, H5S_seloper_t op,  hsize_t *start, hsize_t *_stride, hsize_t *count, hsize_t *_block)
   hid_t     H5Scombine_select(hid_t space1_id, H5S_seloper_t op, hid_t space2_id)
   herr_t     H5Smodify_select(hid_t space1_id, H5S_seloper_t op, hid_t space2_id)
 

--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -475,6 +475,7 @@ hdf5:
   herr_t    H5Sget_select_bounds(hid_t space_id, hsize_t *start, hsize_t *end)
 
   herr_t    H5Sselect_all(hid_t space_id)
+  herr_t    H5Sselect_copy(hid_t dst_id, hid_t src_id)
   herr_t    H5Sselect_none(hid_t space_id)
   htri_t    H5Sselect_valid(hid_t space_id)
 
@@ -486,6 +487,9 @@ hdf5:
   herr_t    H5Sget_select_hyper_blocklist(hid_t space_id,  hsize_t startblock, hsize_t numblocks, hsize_t *buf )
   herr_t    H5Sselect_hyperslab(hid_t space_id, H5S_seloper_t op,  hsize_t *start, hsize_t *_stride, hsize_t *count, hsize_t *_block)
 
+  hid_t     H5Scombine_hyperslab(hid_t space_id, H5S_seloper_t op,  hsize_t *start, hsize_t *_stride, hsize_t *count, hsize_t *_block)
+  hid_t     H5Scombine_select(hid_t space1_id, H5S_seloper_t op, hid_t space2_id)
+  hid_t     H5Smodify_select(hid_t space1_id, H5S_seloper_t op, hid_t space2_id)
 
   herr_t    H5Sencode(hid_t obj_id, void *buf, size_t *nalloc)
   hid_t     H5Sdecode(void *buf)

--- a/h5py/h5s.pyx
+++ b/h5py/h5s.pyx
@@ -590,51 +590,6 @@ cdef class SpaceID(ObjectID):
             efree(block_array)
 
     @with_phil
-    def combine_hyperslab(self, object start, object count, object stride=None,
-                          object block=None, int op=H5S_SELECT_SET):
-        """(TUPLE start, TUPLE count, TUPLE stride=None, TUPLE block=None,
-             INT op=SELECT_SET) => SpaceID
-
-        Performs an operation on a hyperslab and an existing selection and
-        returns the resulting selection.
-        """
-        cdef int rank
-        cdef hsize_t* start_array = NULL
-        cdef hsize_t* count_array = NULL
-        cdef hsize_t* stride_array = NULL
-        cdef hsize_t* block_array = NULL
-
-        # Dataspace rank.  All provided tuples must match this.
-        rank = H5Sget_simple_extent_ndims(self.id)
-
-        require_tuple(start, 0, rank, b"start")
-        require_tuple(count, 0, rank, b"count")
-        require_tuple(stride, 1, rank, b"stride")
-        require_tuple(block, 1, rank, b"block")
-
-        try:
-            start_array = <hsize_t*>emalloc(sizeof(hsize_t)*rank)
-            count_array = <hsize_t*>emalloc(sizeof(hsize_t)*rank)
-            convert_tuple(start, start_array, rank)
-            convert_tuple(count, count_array, rank)
-
-            if stride is not None:
-                stride_array = <hsize_t*>emalloc(sizeof(hsize_t)*rank)
-                convert_tuple(stride, stride_array, rank)
-            if block is not None:
-                block_array = <hsize_t*>emalloc(sizeof(hsize_t)*rank)
-                convert_tuple(block, block_array, rank)
-
-            return SpaceID(H5Scombine_hyperslab(self.id, <H5S_seloper_t>op, start_array,
-                                         stride_array, count_array, block_array))
-
-        finally:
-            efree(start_array)
-            efree(count_array)
-            efree(stride_array)
-            efree(block_array)
-
-    @with_phil
     def combine_select(self, SpaceID space2, int op=H5S_SELECT_OR):
         """(SpaceID space2, INT op=SELECT_OR) => SpaceID
 

--- a/h5py/h5s.pyx
+++ b/h5py/h5s.pyx
@@ -413,7 +413,7 @@ cdef class SpaceID(ObjectID):
     def select_copy(self, SpaceID src_id):
         """(SpaceID src_id)
 
-        Copies a selection from one dataspace to another.
+        Copies the selection from another dataspace to this one (self).
         """
         H5Sselect_copy(self.id, src_id.id)
 
@@ -593,8 +593,9 @@ cdef class SpaceID(ObjectID):
     def combine_select(self, SpaceID space2, int op=H5S_SELECT_OR):
         """(SpaceID space2, INT op=SELECT_OR) => SpaceID
 
-        Combine two hyperslab selections with an operation, returning a dataspace
-        with the resulting selection.
+        Combine two hyperslab selections with an operation, returning a new
+        dataspace with the resulting selection. The default operation is a union,
+        so the resulting selection includes everything selected in either input.
         """
         return SpaceID(H5Scombine_select(self.id, <H5S_seloper_t>op, space2.id))
 
@@ -602,8 +603,10 @@ cdef class SpaceID(ObjectID):
     def modify_select(self, SpaceID space2, int op=H5S_SELECT_OR):
         """(SpaceID space2, INT op=SELECT_OR)
 
-        Refines a hyperslab selection with an operation, using a second hyperslab
-        to modify it.
+        Refines the hyperslab selection of this dataspace (self) using the
+        hyperslab selection from a second dataspace. The default operation
+        is a union, extending the selection to any parts selected in the second
+        dataspace.
         """
         H5Smodify_select(self.id, <H5S_seloper_t>op, space2.id)
 

--- a/h5py/h5s.pyx
+++ b/h5py/h5s.pyx
@@ -415,7 +415,7 @@ cdef class SpaceID(ObjectID):
 
         Copies a selection from one dataspace to another.
         """
-        H5Sselect_copy(self.id, src_id)
+        H5Sselect_copy(self.id, src_id.id)
 
 
     @with_phil

--- a/h5py/h5s.pyx
+++ b/h5py/h5s.pyx
@@ -645,12 +645,12 @@ cdef class SpaceID(ObjectID):
 
     @with_phil
     def modify_select(self, SpaceID space2, int op=H5S_SELECT_OR):
-        """(SpaceID space2, INT op=SELECT_OR) => SpaceID
+        """(SpaceID space2, INT op=SELECT_OR)
 
         Refines a hyperslab selection with an operation, using a second hyperslab
         to modify it.
         """
-        return SpaceID(H5Smodify_select(self.id, <H5S_seloper_t>op, space2.id))
+        H5Smodify_select(self.id, <H5S_seloper_t>op, space2.id)
 
     @with_phil
     def is_regular_hyperslab(self):

--- a/h5py/tests/test_dataset_getitem.py
+++ b/h5py/tests/test_dataset_getitem.py
@@ -384,7 +384,7 @@ class Test1DFloat(TestCase):
 
     def setUp(self):
         TestCase.setUp(self)
-        self.data = np.arange(13).astype('f')
+        self.data = np.arange(50).astype('f')
         self.dset = self.f.create_dataset('x', data=self.data)
 
     def test_ndim(self):
@@ -393,7 +393,7 @@ class Test1DFloat(TestCase):
 
     def test_shape(self):
         """ Verify shape """
-        self.assertEqual(self.dset.shape, (13,))
+        self.assertEqual(self.dset.shape, (50,))
 
     def test_ellipsis(self):
         self.assertNumpyBehavior(self.dset, self.data, np.s_[...])
@@ -453,11 +453,19 @@ class Test1DFloat(TestCase):
     def test_indexlist_numpyarray(self):
         self.assertNumpyBehavior(self.dset, self.data, np.s_[np.array([1, 2, 5])])
 
+    def test_indexlist_long(self):
+        # selection logic changes with >16 indices
+        self.assertNumpyBehavior(self.dset, self.data, np.s_[range(0, 50, 2)])
+
     def test_indexlist_single_index_ellipsis(self):
         self.assertNumpyBehavior(self.dset, self.data, np.s_[[0], ...])
 
     def test_indexlist_numpyarray_single_index_ellipsis(self):
         self.assertNumpyBehavior(self.dset, self.data, np.s_[np.array([0]), ...])
+
+    def test_indexlist_long(self):
+        # selection logic changes with >16 indices
+        self.assertNumpyBehavior(self.dset, self.data, np.s_[range(0, 50, 2), ...])
 
     def test_indexlist_numpyarray_ellipsis(self):
         self.assertNumpyBehavior(self.dset, self.data, np.s_[np.array([1, 2, 5]), ...])

--- a/h5py/tests/test_dataset_getitem.py
+++ b/h5py/tests/test_dataset_getitem.py
@@ -463,7 +463,7 @@ class Test1DFloat(TestCase):
     def test_indexlist_numpyarray_single_index_ellipsis(self):
         self.assertNumpyBehavior(self.dset, self.data, np.s_[np.array([0]), ...])
 
-    def test_indexlist_long(self):
+    def test_indexlist_long_ellipsis(self):
         # selection logic changes with >16 indices
         self.assertNumpyBehavior(self.dset, self.data, np.s_[range(0, 50, 2), ...])
 

--- a/h5py/tests/test_h5s.py
+++ b/h5py/tests/test_h5s.py
@@ -1,3 +1,4 @@
+import numpy as np
 
 from h5py import h5s
 from h5py._selector import Selector
@@ -27,8 +28,11 @@ def test_select_copy():
     s1 = h5s.create_simple((50,))
     s1.select_hyperslab((5,), (1,), block=(5,), op=h5s.SELECT_SET)
     s2 = h5s.create_simple((50,))
+    s2.select_hyperslab((23,), (1,), block=(3,), op=h5s.SELECT_SET)
     s2.select_copy(s1)
-    assert (s1.get_select_hyper_blocklist() == s2.get_select_hyper_blocklist()).all()
+    np.testing.assert_array_equal(
+        s1.get_select_hyper_blocklist(), s2.get_select_hyper_blocklist()
+    )
 
 def test_combine_select():
     # combine_select should create a new space without modifying the original
@@ -40,8 +44,12 @@ def test_combine_select():
 
     s3 = s1.combine_select(s2, op=h5s.SELECT_OR)
     s2.select_hyperslab((5,), (1,), block=(5,), op=h5s.SELECT_OR)
-    assert (s3.get_select_hyper_blocklist() == s2.get_select_hyper_blocklist()).all()
-    assert not (s3.get_select_hyper_blocklist() == s1.get_select_hyper_blocklist()).all()
+    np.testing.assert_array_equal(
+        s3.get_select_hyper_blocklist(), s2.get_select_hyper_blocklist()
+    )
+    assert not np.array_equal(
+        s3.get_select_hyper_blocklist(), s1.get_select_hyper_blocklist()
+    )
 
 def test_modify_select():
     # combine_select should create a new space without modifying the original
@@ -53,4 +61,6 @@ def test_modify_select():
 
     s1.modify_select(s2, op=h5s.SELECT_OR)
     s2.select_hyperslab((5,), (1,), block=(5,), op=h5s.SELECT_OR)
-    assert (s1.get_select_hyper_blocklist() == s2.get_select_hyper_blocklist()).all()
+    np.testing.assert_array_equal(
+        s1.get_select_hyper_blocklist(), s2.get_select_hyper_blocklist()
+    )

--- a/h5py/tests/test_h5s.py
+++ b/h5py/tests/test_h5s.py
@@ -22,3 +22,35 @@ def test_same_shape():
 
     s3 = Helper((5, 6))[:4, :3]
     assert not s1.select_shape_same(s3)
+
+def test_select_copy():
+    s1 = h5s.create_simple((50,))
+    s1.select_hyperslab((5,), (1,), block=(5,), op=h5s.SELECT_SET)
+    s2 = h5s.create_simple((50,))
+    s2.select_copy(s1)
+    assert (s1.get_select_hyper_blocklist() == s2.get_select_hyper_blocklist()).all()
+
+def test_combine_select():
+    # combine_select should create a new space without modifying the original
+    s1 = h5s.create_simple((50,))
+    s1.select_hyperslab((5,), (1,), block=(5,), op=h5s.SELECT_SET)
+
+    s2 = h5s.create_simple((50,))
+    s2.select_hyperslab((20,), (1,), block=(2,), op=h5s.SELECT_SET)
+
+    s3 = s1.combine_select(s2, op=h5s.SELECT_OR)
+    s2.select_hyperslab((5,), (1,), block=(5,), op=h5s.SELECT_OR)
+    assert (s3.get_select_hyper_blocklist() == s2.get_select_hyper_blocklist()).all()
+    assert not (s3.get_select_hyper_blocklist() == s1.get_select_hyper_blocklist()).all()
+
+def test_modify_select():
+    # combine_select should create a new space without modifying the original
+    s1 = h5s.create_simple((50,))
+    s1.select_hyperslab((5,), (1,), block=(5,), op=h5s.SELECT_SET)
+
+    s2 = h5s.create_simple((50,))
+    s2.select_hyperslab((20,), (1,), block=(2,), op=h5s.SELECT_SET)
+
+    s1.modify_select(s2, op=h5s.SELECT_OR)
+    s2.select_hyperslab((5,), (1,), block=(5,), op=h5s.SELECT_OR)
+    assert (s1.get_select_hyper_blocklist() == s2.get_select_hyper_blocklist()).all()

--- a/news/FancyIndexing.rst
+++ b/news/FancyIndexing.rst
@@ -1,0 +1,9 @@
+Exposing HDF5 functions
+-----------------------
+
+* H5Scombine_hyperslab, H5Scombine_select, H5Smodify_select, and H5Sselect_copy
+
+Bug fixes
+---------
+
+* Sped up fancy indexing for large index arrays

--- a/news/FancyIndexing.rst
+++ b/news/FancyIndexing.rst
@@ -1,7 +1,7 @@
 Exposing HDF5 functions
 -----------------------
 
-* H5Scombine_hyperslab, H5Scombine_select, H5Smodify_select, and H5Sselect_copy
+* H5Scombine_select, H5Smodify_select, and H5Sselect_copy
 
 Bug fixes
 ---------


### PR DESCRIPTION
See issue https://github.com/h5py/h5py/issues/2536

Fancy indexing goes very slowly when using a large number of indices. This is because the underlying hdf5 algorithm for adding hyperslab to a selection scales as O(n^2) since each new block must be checked for overlaps with every other block. This is especially noticeable once you have thousands of elements in a fancy index array. The problem and fortunately also a solution are laid out here: https://forum.hdfgroup.org/t/quadratic-runtime-of-selecting-n-hyperslabs/12555

Instead of iterating through each element in the fancy index array and adding a hyperslab one at a time, we can use a merge algorithm, since combining two non-overlapping selections is still linear in the size of the selection. This results in  O(nlogn) complexity.

To implement this, I exposed H5Scombine_hyperslab, H5Scombine_select, H5Smodify_select, and H5Sselect_copy to the low level h5s interface (only modify_select and select_copy were needed for this speedup though). These functions were introduced in hdf5 version 1.10.6. I then modified the Selector to use a recursive algorithm to build up the selection by splitting the array in two and using combine_select to merge the resulting h5s objects. If the size of the fancy index is <16, it will iterate through the list of indices as previously (I tested a few limits here and found 16 to perform best).

![FancyIndexTiming_slow](https://github.com/user-attachments/assets/c818371e-17f1-48e7-9cc7-2a77fced5478)
![FancyIndexTiming_fast](https://github.com/user-attachments/assets/4e109507-b9d2-4c04-9fa7-c177c4c715a7)

The resulting algorithm is dramatically faster than the old one. The above test used a dataspace of size 1000000 and tested different sizes of randomly selected fancy index arrays. This test can be repeated with:
```
def test_fancy_index(n_space, n_samps):
    entries = sorted(random.sample(range(n_space), n_samps))
    h5s_src = h5py.h5s.create_simple((n_space,))
    h5s_src.select_none()
    
    t0 = time.time()
    sel = h5py._selector.Selector(h5s_src)
    sel.make_selection((entries,))
    return time.time() - t0
```

I have not yet added/modified any tests; I'm unsure of what is needed for exposed low level functions, and if any changes are needed to existing tests of fancy indexing. As suggested, I tried running `tox -e pre-commit` but got an error immediately due to distutils being removed. Running the tests, all passed except test_file.TestDrivers, which was not caused by this change.