### PR TITLE
DEP: declare dev-only dependencies as PEP 735 dependency-groups

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,7 +63,7 @@ jobs:
     # do mpi tests
       py39-deps-hdf51122-mpi:
         python.version: '3.9'
-        TOXENV: py39-test-mindeps-mpi4py
+        TOXENV: py39-test-mindeps-mpi
         HDF5_VERSION: 1.12.2
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         HDF5_MPI: ON

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -393,7 +393,7 @@ To run these tests, you'll need to:
 
 Then running::
 
-   $ CC='mpicc' HDF5_MPI=ON tox -e py312-test-deps-mpi4py
+   $ CC='mpicc' HDF5_MPI=ON tox -e py312-test-deps-mpi
 
 should run the tests. You may need to pass ``HDF5_DIR`` depending on the
 location of the HDF5 with MPI support. You can choose which python version to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,37 @@ packages = [
     "h5py.tests.test_vds",
 ]
 
+[dependency-groups]
+check-manifest = [
+    "check-manifest>=0.50",
+]
+check-readme = [
+    "build>=1.2.2",
+    "twine>=6.1.0",
+]
+docs = [
+    "sphinx>=7.4.7",
+]
+lint = [
+    "pre-commit>=4.2.0",
+]
+mpi = [
+    "mpi4py>=3.1.1",
+]
+tables = [
+    "tables>=3.4.4",
+]
+test = [
+    "pytest>=8.2.2",
+    "pytest-cov>=5.0.0",
+    "pytest-mpi>=0.2",
+]
+wheels = [
+    "codecov>=2.1.13",
+    "coverage>=7.9.1",
+    "tox>=4.26.0",
+]
+
 [tool.cibuildwheel]
 skip = [
     "*musllinux*",
@@ -91,11 +122,7 @@ build-verbosity = 1
 build-frontend = { name = "pip", args = ["--only-binary", "numpy"] }
 manylinux-x86_64-image = "ghcr.io/h5py/manylinux_2_28_x86_64-hdf5"
 manylinux-aarch64-image = "ghcr.io/h5py/manylinux_2_28_aarch64-hdf5"
-test-requires = [
-    "tox",
-    "codecov",
-    "coverage",
-]
+test-groups = ["wheels"]
 test-command = "bash {project}/ci/cibw_test_command.sh {project} {wheel}"
 
 [tool.cibuildwheel.linux]

--- a/tox.ini
+++ b/tox.ini
@@ -1,36 +1,27 @@
 [tox]
 # We want an envlist like
-# envlist = {py36,py37,pypy3}-{test}-{deps,mindeps}-{,mpi4py}-{,pre},nightly,docs,checkreadme,pre-commit
+# envlist = {py36,py37,pypy3}-{test}-{deps,mindeps}-{,mpi}-{,pre},nightly,docs,checkreadme,pre-commit
 # but we want to skip mpi and pre by default, so this envlist is below
 envlist = {py39,py310,py311,py312,pypy3}-{test}-{deps,mindeps},nightly,docs,apidocs,checkreadme,pre-commit
 isolated_build = True
+minversion = 4.22.0 # for dependency_groups
 
 [testenv]
 deps =
-    test: pytest
-    test: pytest-cov
-    test: pytest-mpi>=0.2
-
-    # For --pre, 2.0.0b1 has a header size difference that has been reverted, so avoid it
-    py39-deps: numpy>=1.19.3,!=2.0.0b1
-    py310-deps: numpy>=1.21.3,!=2.0.0b1
-    py311-deps: numpy>=1.23.2,!=2.0.0b1
-    py312-deps: numpy>=1.26.0,!=2.0.0b1
-
     mindeps: oldest-supported-numpy
 
-    mpi4py: mpi4py>=3.1.1
-
-    tables-deps: tables>=3.4.4
-    tables-mindeps: tables==3.4.4
+dependency_groups =
+    test: test
+    tables: tables
+    mpi: mpi
 
 # see pytest.ini for additional common options to pytest
 commands =
     test: python -c "import sys; print('64 bit?', sys.maxsize > 2**32)"
     test: python {toxinidir}/ci/fix_paths.py
     test: python -c "from h5py.version import info; print(info)"
-    test-!mpi4py: python -m pytest --pyargs h5py --cov=h5py -rxXs --cov-config={toxinidir}/.coveragerc {posargs}
-    test-mpi4py: mpirun --use-hwthread-cpus -n {env:MPI_N_PROCS:2} {envpython} -m pytest --pyargs h5py -rxXs --with-mpi {posargs}
+    test-!mpi: python -m pytest --pyargs h5py --cov=h5py -rxXs --cov-config={toxinidir}/.coveragerc {posargs}
+    test-mpi: mpirun --use-hwthread-cpus -n {env:MPI_N_PROCS:2} {envpython} -m pytest --pyargs h5py -rxXs --with-mpi {posargs}
 changedir =
     test: {toxworkdir}
 passenv =
@@ -73,8 +64,8 @@ commands=
 
 [testenv:apidocs]
 changedir=docs_api
-deps=
-    sphinx
+dependency_groups =
+    docs
 commands=
     sphinx-build -W -b html -d {envtmpdir}/doctrees .  _build/html
 
@@ -82,9 +73,8 @@ commands=
 skip_install=True
 # Work around https://github.com/tox-dev/tox/issues/2442
 package_env = DUMMY NON-EXISTENT ENV NAME
-deps=
-    build
-    twine
+dependency_groups =
+    check-readme
 commands=
     python -m build --sdist
     twine check --strict dist/*
@@ -93,7 +83,7 @@ commands=
 skip_install=True
 # Work around https://github.com/tox-dev/tox/issues/2442
 package_env = DUMMY NON-EXISTENT ENV NAME
-deps=
+dependency_groups=
     check-manifest
 commands=
     check-manifest -v
@@ -102,7 +92,8 @@ commands=
 skip_install=True
 # Work around https://github.com/tox-dev/tox/issues/2442
 package_env = DUMMY NON-EXISTENT ENV NAME
-deps=pre-commit
+dependency_groups =
+    lint
 passenv =
     HOMEPATH
     SSH_AUTH_SOCK


### PR DESCRIPTION
Both `tox` and `cibuildwheel` support this standard. This move improves integration with other standard-compliant tools like `pip` or `uv`.