### PR TITLE
Remove check-manifest pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,10 +7,5 @@ repos:
     -   id: trailing-whitespace
         exclude: .+\.patch
 
--   repo: https://github.com/mgedmin/check-manifest
-    rev: "0.39"
-    hooks:
-    -   id: check-manifest
-
 ci:
     autoupdate_schedule: monthly

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ jobs:
   pool:
     vmImage: ubuntu-22.04
   variables:
-    TOXENV: docs,checkreadme
+    TOXENV: checkreadme,checkmanifest
   steps:
     - task: UsePythonVersion@0
       inputs:

--- a/tox.ini
+++ b/tox.ini
@@ -89,6 +89,15 @@ commands=
     python -m build --sdist
     twine check --strict dist/*
 
+[testenv:checkmanifest]
+skip_install=True
+# Work around https://github.com/tox-dev/tox/issues/2442
+package_env = DUMMY NON-EXISTENT ENV NAME
+deps=
+    check-manifest
+commands=
+    check-manifest -v
+
 [testenv:pre-commit]
 skip_install=True
 # Work around https://github.com/tox-dev/tox/issues/2442


### PR DESCRIPTION
The old version we're stuck on doesn't work with recent Python versions (as mentioned again in #2603), and newer versions aren't great in CI (see #2046) as well as being slower to run locally. I don't remember this hook actually catching any problems, so let's drop it.

Closes #2046.