### PR TITLE
Run pre-commit in static_checks on Azure pipelines again

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ jobs:
   pool:
     vmImage: ubuntu-22.04
   variables:
-    TOXENV: checkreadme,checkmanifest
+    TOXENV: checkreadme,checkmanifest,pre-commit
   steps:
     - task: UsePythonVersion@0
       inputs:


### PR DESCRIPTION
So we can avoid having a service (pre-commit.ci) with push access to the repo.

cc @tacaswell 