### PR TITLE
MNT: upgrade cibuildwheel to 3.1.2

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -88,7 +88,7 @@ jobs:
       - run: bash ./ci/triage_build.sh "${{ matrix.arch }}" "${{ github.event.pull_request.head.sha || github.sha }}" "${{ matrix.python }}"
 
       # Now actually build the wheels
-      - uses: pypa/cibuildwheel@v3.1.1
+      - uses: pypa/cibuildwheel@v3.1.2
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: ${{ env.CIBW_BUILD }}


### PR DESCRIPTION
This is a non-critical upgrade, but it fixes a mistake I made in 3.1.1, so I care about it :-)
