### PR TITLE
MNT: migrate all github actions pins to shas

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -55,7 +55,7 @@ jobs:
           - os: macos-13
             arch: x86_64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0  # get the non-merge commit for PRs
 
@@ -65,15 +65,15 @@ jobs:
 
       # Cache HDF5
       - name: Cache built HDF5
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           key: ${{ matrix.os }}-${{ matrix.arch }}-6
           path: cache/hdf5
 
       # Windows HDF5
-      - uses: nuget/setup-nuget@v2
+      - uses: nuget/setup-nuget@323ab0502cd38fdc493335025a96c8fdb0edc71f # v2.0.1
         if: runner.os == 'Windows'
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 3.12
         if: runner.os == 'Windows'
@@ -88,7 +88,7 @@ jobs:
       - run: bash ./ci/triage_build.sh "${{ matrix.arch }}" "${{ github.event.pull_request.head.sha || github.sha }}" "${{ matrix.python }}"
 
       # Now actually build the wheels
-      - uses: pypa/cibuildwheel@v3.1.1
+      - uses: pypa/cibuildwheel@9e4e50bd76b3190f55304387e333f6234823ea9b # v3.1.2
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: ${{ env.CIBW_BUILD }}
@@ -100,7 +100,7 @@ jobs:
         if: runner.os == 'Windows'
 
       # And upload the results
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
@@ -113,7 +113,7 @@ jobs:
       run:
         shell: bash -el {0}
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: cibw-wheels-*
           merge-multiple: true
@@ -145,7 +145,7 @@ jobs:
           echo "generate=$GENERATE" >> $GITHUB_OUTPUT
 
       - name: Upload to GitHub releases
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
         # https://github.com/softprops/action-gh-release?tab=readme-ov-file#inputs
         with:
           name: ${{ steps.vars.outputs.release_name }}

--- a/.github/workflows/lowlevel-api-docs.yml
+++ b/.github/workflows/lowlevel-api-docs.yml
@@ -17,10 +17,10 @@ jobs:
       HDF5_DIR: ${{ github.workspace }}/cache/hdf5
       TOXENV: apidocs
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Cache HDF5
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ${{ env.HDF5_DIR }}
           key: ${{ runner.os }}-hdf5-${{ env.HDF5_VERSION }}
@@ -30,7 +30,7 @@ jobs:
           ./ci/get_hdf5_if_needed.sh
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
@@ -45,13 +45,13 @@ jobs:
           echo -n "api.h5py.org" > docs_api/_build/html/CNAME
 
       - name: Upload built docs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: docs-html
           path: docs_api/_build/html
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         if: github.repository == 'h5py/h5py' && github.ref == 'refs/heads/master' && github.event_name == 'push'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replace #2623

For reference, this patch was performed automatically using [`gha-update`](https://pypi.org/project/gha-update/)