### PR TITLE
Add dataset flush/refresh SWMR methods to reference docs

### DIFF
--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -588,6 +588,18 @@ Reference
 
         Return the size of the first axis.
 
+    .. method:: refresh
+
+        Refresh the dataset metadata by reloading from the file.
+        This is part of the :doc:`swmr` features.
+
+    .. method:: flush
+
+        Flush the dataset data and metadata to the file.
+        If the dataset is chunked, raw data chunks are written to the file.
+        This is part of the :doc:`swmr` features. Use it in SWMR write mode to
+        allow readers to be updated with the dataset changes.
+
     .. method:: make_scale(name='')
 
        Make this dataset an HDF5 :ref:`dimension scale <dimension_scales>`.

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -1143,27 +1143,23 @@ class Dataset(HLObject):
 
         return f'<HDF5 dataset {name}: shape {self.shape}, type "{self.dtype.str}">'
 
-    if hasattr(h5d.DatasetID, "refresh"):
-        @with_phil
-        def refresh(self):
-            """ Refresh the dataset metadata by reloading from the file.
+    @with_phil
+    def refresh(self):
+        """ Refresh the dataset metadata by reloading from the file.
 
-            This is part of the SWMR features and only exist when the HDF5
-            library version >=1.9.178
-            """
-            self._id.refresh()
-            self._cache_props.clear()
+        This is part of the SWMR features.
+        """
+        self._id.refresh()
+        self._cache_props.clear()
 
-    if hasattr(h5d.DatasetID, "flush"):
-        @with_phil
-        def flush(self):
-            """ Flush the dataset data and metadata to the file.
-            If the dataset is chunked, raw data chunks are written to the file.
+    @with_phil
+    def flush(self):
+        """ Flush the dataset data and metadata to the file.
+        If the dataset is chunked, raw data chunks are written to the file.
 
-            This is part of the SWMR features and only exist when the HDF5
-            library version >=1.9.178
-            """
-            self._id.flush()
+        This is part of the SWMR features.
+        """
+        self._id.flush()
 
     if vds_support:
         @property

--- a/h5py/h5d.pyx
+++ b/h5py/h5d.pyx
@@ -464,8 +464,6 @@ cdef class DatasetID(ObjectID):
 
         Use this in SWMR write mode to allow readers to be updated with the
         dataset changes.
-
-        Feature requires: 1.9.178 HDF5
         """
         H5Dflush(self.id)
 
@@ -483,8 +481,6 @@ cdef class DatasetID(ObjectID):
         The reopened dataset is automatically re-registered with the same ID.
 
         Use this in SWMR read mode to poll for dataset changes.
-
-        Feature requires: 1.9.178 HDF5
         """
         H5Drefresh(self.id)
 


### PR DESCRIPTION
While looking at #2625, I noticed that the SWMR methods on datasets aren't in the reference section of the documentation.

I also removed some notes in docstrings about them being conditional on the HDF5 version, since we no longer support pre-SWMR versions, and cleared up conditions in the code which are now always true.