### PR TITLE
Fix segfault on converting unallocated string data to Numpy strings.

### DIFF
--- a/h5py/_npystrings.pyx
+++ b/h5py/_npystrings.pyx
@@ -87,7 +87,9 @@ cdef herr_t npystrings_pack_cb(
     cdef npystrings_pack_t* info = <npystrings_pack_t*>operator_data
     cdef const char* buf = info[0].contig[info[0].i]
     if buf is NULL:
-        NpyString_pack_null(info[0].allocator, <npy_packed_static_string*>elem)
+        # Special case of default values created by resize(). Regular empty strings
+        # are valid char* with strlen(buf) == 0.
+        res = NpyString_pack_null(info[0].allocator, <npy_packed_static_string*>elem)
     else:
         # Deep copy char* from h5py into the NumPy array
         res = NpyString_pack(

--- a/h5py/_npystrings.pyx
+++ b/h5py/_npystrings.pyx
@@ -58,6 +58,7 @@ ELSE:
         npy_static_string,
         npy_packed_static_string,
         NpyString_pack,
+        NpyString_pack_null,
         NpyString_load,
         NpyString_acquire_allocator,
         NpyString_release_allocator,
@@ -85,13 +86,16 @@ cdef herr_t npystrings_pack_cb(
 ) except -1:
     cdef npystrings_pack_t* info = <npystrings_pack_t*>operator_data
     cdef const char* buf = info[0].contig[info[0].i]
-    # Deep copy char* from h5py into the NumPy array
-    res = NpyString_pack(
-        info[0].allocator,
-        <npy_packed_static_string*>elem,
-        buf,
-        strlen(buf),
-    )
+    if buf is NULL:
+        NpyString_pack_null(info[0].allocator, <npy_packed_static_string*>elem)
+    else:
+        # Deep copy char* from h5py into the NumPy array
+        res = NpyString_pack(
+            info[0].allocator,
+            <npy_packed_static_string*>elem,
+            buf,
+            strlen(buf),
+        )
     info[0].i += 1
     return res
 

--- a/h5py/tests/test_npystrings.py
+++ b/h5py/tests/test_npystrings.py
@@ -161,3 +161,15 @@ def test_astype_nonstring(writable_file):
     x = writable_file.create_dataset("x", shape=(2, ), dtype="i8")
     with pytest.raises(TypeError, match="HDF5 string datatype"):
         x.astype("T")
+
+
+def test_resized_read(writable_file):
+    l = ["string1", "string2", "string3"]
+    data = np.array(l, dtype='T')
+    d = writable_file.create_dataset("dset", data=data, maxshape=(None,))
+    d.resize((10,))
+
+    np.testing.assert_array_equal(d[:], np.array(
+        [s.encode() for s in l] + [b''] * 7, dtype=object
+    ))
+    np.testing.assert_array_equal(d.astype('T')[:], np.array(l + [''] * 7, dtype='T'))

--- a/h5py/tests/test_npystrings.py
+++ b/h5py/tests/test_npystrings.py
@@ -164,6 +164,9 @@ def test_astype_nonstring(writable_file):
 
 
 def test_resized_read(writable_file):
+    """Read default values created by resize(). This triggers a special case
+    where libhdf5 returns a char** containing NULL pointers.
+    """
     l = ["string1", "string2", "string3"]
     data = np.array(l, dtype='T')
     d = writable_file.create_dataset("dset", data=data, maxshape=(None,))


### PR DESCRIPTION
Fixes #2615.

@crusaderky could you have a look and see if this fix looks right? I don't feel like I have a great understanding of the numpy strings API, but this change seems to prevent the segfault reported.