### PR TITLE
TST: fix minimal env testing using `uv` + `tox-uv`

### DIFF
--- a/ci/cibw_test_command.sh
+++ b/ci/cibw_test_command.sh
@@ -12,14 +12,7 @@ WHEEL_PATH=$2
 echo "WHEEL_PATH=$WHEEL_PATH"
 
 export PYVER=$(python -c "import sys; print(''.join(map(str, sys.version_info[:2])))")
-ENVLIST="py$PYVER-test-deps,py$PYVER-test-deps-pre"
-
-if ! ( [[ "$AUDITWHEEL_PLAT" == musllinux_* ]] && [[ "$PYVER" == "39" || "$PYVER" == "310" || "$PYVER" == "311" ]] ); then
-    # skip mindeps on musllinux + python 3.9 to 3.11 because oldest supported numpy versions
-    # are higher for this target (1.25.0) and there's no way (that I found) to specify it
-    # directly in package metadata.
-    ENVLIST="py$PYVER-test-mindeps,$ENVLIST"
-fi
+ENVLIST="py$PYVER-test-mindeps,py$PYVER-test-deps,py$PYVER-test-deps-pre"
 
 export H5PY_TEST_CHECK_FILTERS=1
 echo "ENVLIST=$ENVLIST"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "Cython >=3.0.0,<4",
     "numpy >=2.0.0, <3",
     "pkgconfig",
-    "setuptools >=77",
+    "setuptools >=77.0.1",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -111,12 +111,13 @@ tables = [
 test = [
     "pytest>=8.2.2",
     "pytest-cov>=5.0.0",
-    "pytest-mpi>=0.2",
+    "pytest-mpi>=0.6",
 ]
 wheels = [
     "codecov>=2.1.13",
     "coverage>=7.9.1",
     "tox>=4.26.0",
+    "tox-uv>=1.27.0",
 ]
 
 [tool.cibuildwheel]
@@ -149,3 +150,7 @@ delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel} \
 [tool.cibuildwheel.macos.environment]
 H5PY_ROS3 = "0"
 H5PY_DIRECT_VFD = "0"
+
+[tool.uv]
+# never build numpy from source
+no-build-package = ["numpy"]

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,13 @@
 envlist = {py310,py311,py312,py313,pypy3}-{test}-{deps,mindeps},nightly,docs,apidocs,checkreadme,pre-commit
 isolated_build = True
 minversion = 4.22.0 # for dependency_groups
+# tox-uv is required for `mindeps` and `pre` factors, however, we allow for it
+# to be missing because of a puzzling build error that only happens when tox-uv
+# is present, specifically on Azure CI (Windows), where we don't need `mindeps` or `pre`.
+#requires =
+#    tox-uv >= 1.27.0
 
 [testenv]
-deps =
-    mindeps: oldest-supported-numpy; platform_machine != "ARM64" or sys_platform != "win32"
-
 dependency_groups =
     test: test
     tables: tables
@@ -42,9 +44,11 @@ allowlist_externals =
     mpirun
 setenv =
     COVERAGE_FILE={toxinidir}/.coverage_dir/coverage-{envname} # needed otherwise coverage cannot find the file when reporting
-    pre: PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-    pre: PIP_ONLY_BINARY=numpy
-
+    pre: UV_INDEX=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    pre: UV_INDEX_STRATEGY=unsafe-best-match  # match pip's behavior
+uv_resolution =
+    mindeps: lowest-direct
+    !mindeps: highest
 pip_pre =
     pre: True
 


### PR DESCRIPTION
I think I found the missing piece of the puzzle in uv's static configuration. Let's see how this pans out.
If this works, close #2601
