### PR TITLE
WHL: enable musllinux wheels

### DIFF
--- a/ci/cibw_test_command.sh
+++ b/ci/cibw_test_command.sh
@@ -12,7 +12,14 @@ WHEEL_PATH=$2
 echo "WHEEL_PATH=$WHEEL_PATH"
 
 export PYVER=$(python -c "import sys; print(''.join(map(str, sys.version_info[:2])))")
-ENVLIST="py$PYVER-test-deps,py$PYVER-test-mindeps,py$PYVER-test-deps-pre"
+ENVLIST="py$PYVER-test-deps,py$PYVER-test-deps-pre"
+
+if ! ( [[ "$AUDITWHEEL_PLAT" == musllinux_* ]] && [[ "$PYVER" == "39" || "$PYVER" == "310" || "$PYVER" == "311" ]] ); then
+    # skip mindeps on musllinux + python 3.9 to 3.11 because oldest supported numpy versions
+    # are higher for this target (1.25.0) and there's no way (that I found) to specify it
+    # directly in package metadata.
+    ENVLIST="py$PYVER-test-mindeps,$ENVLIST"
+fi
 
 export H5PY_TEST_CHECK_FILTERS=1
 echo "ENVLIST=$ENVLIST"

--- a/news/musllinux-support.rst
+++ b/news/musllinux-support.rst
@@ -1,0 +1,4 @@
+New features
+------------
+
+* Added support for building and distributing h5py python wheels for `musllinux` plaform with both `x86_64` and `aarch64` architectures.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,6 @@ wheels = [
 
 [tool.cibuildwheel]
 skip = [
-    "*musllinux*",
     "cp314t-*",
     "cp310-win_arm64", #Skipped due to unavailability of Python binary and NumPy for Win-ARM64
 ]
@@ -129,6 +128,8 @@ build-verbosity = 1
 build-frontend = { name = "pip", args = ["--only-binary", "numpy"] }
 manylinux-x86_64-image = "ghcr.io/h5py/manylinux_2_28_x86_64-hdf5"
 manylinux-aarch64-image = "ghcr.io/h5py/manylinux_2_28_aarch64-hdf5"
+musllinux-x86_64-image = "ghcr.io/h5py/musllinux_1_2_x86_64-hdf5"
+musllinux-aarch64-image = "ghcr.io/h5py/musllinux_1_2_aarch64-hdf5"
 test-groups = ["wheels"]
 test-command = "bash {project}/ci/cibw_test_command.sh {project} {wheel}"
 


### PR DESCRIPTION
This is an experiment. I suspsect our only reason for skipping these was that NumPy *used to* not ship `musllinux` wheels, but that hasn't been true for a little while so let's try it out.