### PR TITLE
MNT: move static version declaration to static metadata (`pyproject.toml`)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "h5py"
+version = '3.14.0'
 description = "Read and write HDF5 files from Python"
 authors = [
     {name = "Andrew Collette", email = "andrew.collette@gmail.com"},
@@ -39,7 +40,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 requires-python = ">=3.9"
-dynamic = ["dependencies", "version"]
+dynamic = ["dependencies"]
 
 [project.readme]
 text = """\

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,6 @@ if '' not in sys.path:
 import setup_build, setup_configure
 
 
-VERSION = '3.14.0'
-
 
 # these are required to use h5py
 RUN_REQUIRES = [
@@ -69,7 +67,6 @@ if os.name == 'nt':
 
 setup(
   name = 'h5py',
-  version = VERSION,
   package_data = package_data,
   ext_modules = [Extension('h5py.x',['x.c'])],  # To trick build into running build_ext
   install_requires = RUN_REQUIRES,

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,6 @@ if os.name == 'nt':
     package_data['h5py'].append('*.dll')
 
 setup(
-  name = 'h5py',
   package_data = package_data,
   ext_modules = [Extension('h5py.x',['x.c'])],  # To trick build into running build_ext
   install_requires = RUN_REQUIRES,


### PR DESCRIPTION
A small quality of life improvement, reducing the number of indirections needed to find where the version is defined.