### PR TITLE
TST: run all tests envs against CPython 3.14

### DIFF
--- a/ci/cibw_test_command.sh
+++ b/ci/cibw_test_command.sh
@@ -12,10 +12,8 @@ WHEEL_PATH=$2
 echo "WHEEL_PATH=$WHEEL_PATH"
 
 export PYVER=$(python -c "import sys; print(''.join(map(str, sys.version_info[:2])))")
-ENVLIST="py$PYVER-test-deps-pre"
-if [[ "$PYVER" != "314" ]]; then
-    ENVLIST="py$PYVER-test-deps,py$PYVER-test-mindeps,"$ENVLIST
-fi
+ENVLIST="py$PYVER-test-deps,py$PYVER-test-mindeps,py$PYVER-test-deps-pre"
+
 export H5PY_TEST_CHECK_FILTERS=1
 echo "ENVLIST=$ENVLIST"
 cd $PROJECT_PATH


### PR DESCRIPTION
Given numpy now has stable wheels for CPython 3.14, we shouldn't need this workaround any more.