### PR TITLE
RFC: drop Python 2 `__nonzero__` protocol (replace with `__bool__`) in >10 y.o. Cython code

### DIFF
--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -354,7 +354,6 @@ class HLObject(CommonStateObject):
     def __bool__(self):
         with phil:
             return bool(self.id)
-    __nonzero__ = __bool__
 
     def __getnewargs__(self):
         """Disable pickle.

--- a/h5py/_objects.pyx
+++ b/h5py/_objects.pyx
@@ -251,7 +251,7 @@ cdef class ObjectID:
         # which have nonlocal effects should override this.
         self._close()
 
-    def __nonzero__(self):
+    def __bool__(self):
         return self.valid
 
     def __copy__(self):

--- a/h5py/h5.pyx
+++ b/h5py/h5.pyx
@@ -35,9 +35,6 @@ class ByteStringContext:
     def __bool__(self):
         return self._readbytes
 
-    def __nonzero__(self):
-        return self.__bool__()
-
     def __enter__(self):
         self._readbytes = True
 

--- a/h5py/h5r.pyx
+++ b/h5py/h5r.pyx
@@ -171,7 +171,7 @@ cdef class Reference:
         self.typecode = H5R_OBJECT
         self.typesize = sizeof(hobj_ref_t)
 
-    def __nonzero__(self):
+    def __bool__(self):
         cdef int i
         for i in range(self.typesize):
             if (<unsigned char*>&self.ref)[i] != 0: return True


### PR DESCRIPTION
I discovered while working on #2637 that Cython has been emmitting warnings against this, but they were virtually invisible in the ocean of deprecation warnings about `IF`.