### PR TITLE
DEP: drop support for Python 3.9, require 3.10 or newer

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2  # Required
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.9"
+    python: "3.10"
 
 sphinx:
    configuration: docs/conf.py

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@
 HDF5 for Python
 ===============
 `h5py` is a thin, pythonic wrapper around `HDF5 <https://www.hdfgroup.org/solutions/hdf5/>`_,
-which runs on Python 3 (3.9+).
+which runs on Python 3 (3.10+).
 
 Websites
 --------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,16 +8,16 @@ environment:
 
     ### USING HDF5 1.10 ###
 
-    - PYTHON: "C:\\Python39"
-      TOXENV: "py39-test-deps"
+    - PYTHON: "C:\\Python310"
+      TOXENV: "py310-test-deps"
       HDF5_VSVERSION: "14"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
       HDF5_VERSION: "1.10.7"
 
     ### USING HDF5 1.12 ###
 
-    - PYTHON: "C:\\Python39"
-      TOXENV: "py39-test-deps"
+    - PYTHON: "C:\\Python310"
+      TOXENV: "py310-test-deps"
       HDF5_VSVERSION: "14"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
       HDF5_VERSION: "1.12.1"
@@ -31,10 +31,10 @@ environment:
 install:
   # We need wheel installed to build wheels
   - "%PYTHON%\\python.exe -m pip install --upgrade wheel pip setuptools"
-  - "py -3.9 -m pip install --upgrade wheel pip setuptools virtualenv"
-  - "py -3.9 -m pip install requests"
-  - "py -3.9 ci\\get_hdf5_win.py"
-  - "py -3.9 -m pip install tox codecov"
+  - "py -3.10 -m pip install --upgrade wheel pip setuptools virtualenv"
+  - "py -3.10 -m pip install requests"
+  - "py -3.10 ci\\get_hdf5_win.py"
+  - "py -3.10 -m pip install tox codecov"
 
 build: off
 
@@ -43,7 +43,7 @@ test_script:
   # Note that you must use the environment variable %PYTHON% to refer to
   # the interpreter you're using - Appveyor does not do anything special
   # to put the Python evrsion you want to use on PATH.
-  - "py -3.9 -m tox run --discover %PYTHON%\\python.exe"
+  - "py -3.10 -m tox run --discover %PYTHON%\\python.exe"
 
 # This is commented out as there's no easy way to deal with numpy dropping
 # older python versions without a recent pip/setuptools.
@@ -60,4 +60,4 @@ cache:
   - "C:\\hdf5"
 
 on_success:
-  - "py -3.9 ci\\upload_coverage.py"
+  - "py -3.10 ci\\upload_coverage.py"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
   steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '3.9'
+        versionSpec: '3.10'
         architecture: 'x64'
     - script: |
         pip install tox
@@ -34,23 +34,23 @@ jobs:
       # -tables : also check compatibility with pytables
     # HDF5 installed from apt on Ubuntu
     # test when we're not in a unicode locale
-      py39-Clocale:
-        python.version: '3.9'
-        TOXENV: py39-test-deps
+      py310-Clocale:
+        python.version: '3.10'
+        TOXENV: py310-test-deps
         TOX_TESTENV_PASSENV: LANG LC_ALL
         LANG: C
         LC_ALL: C
         H5PY_ENFORCE_COVERAGE: yes
     # Build HDF5 1.10 or 1.12 in the test environment
-      py39-deps-hdf51107:
-        python.version: '3.9'
-        TOXENV: py39-test-deps
+      py310-deps-hdf51107:
+        python.version: '3.10'
+        TOXENV: py310-test-deps
         HDF5_VERSION: 1.10.7
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         H5PY_ENFORCE_COVERAGE: yes
-      py39-deps-hdf51122:
-        python.version: '3.9'
-        TOXENV: py39-test-deps
+      py310-deps-hdf51122:
+        python.version: '3.10'
+        TOXENV: py310-test-deps
         HDF5_VERSION: 1.12.2
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         H5PY_ENFORCE_COVERAGE: yes
@@ -61,9 +61,9 @@ jobs:
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         H5PY_ENFORCE_COVERAGE: yes
     # do mpi tests
-      py39-deps-hdf51122-mpi:
-        python.version: '3.9'
-        TOXENV: py39-test-mindeps-mpi
+      py310-deps-hdf51122-mpi:
+        python.version: '3.10'
+        TOXENV: py310-test-mindeps-mpi
         HDF5_VERSION: 1.12.2
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         HDF5_MPI: ON
@@ -87,18 +87,18 @@ jobs:
     # -deps-pre : test pre-release versions of (python) dependencies)
     #
     # 64 bit - HDF5 1.10
-      py39-hdf5110:
-        python.version: '3.9'
-        TOXENV: py39-test-deps,py39-test-mindeps,py39-test-deps-pre
+      py310-hdf5110:
+        python.version: '3.10'
+        TOXENV: py310-test-deps,py310-test-mindeps,py310-test-deps-pre
         HDF5_VERSION: 1.10.7
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         HDF5_VSVERSION: "17-64"
         H5PY_ENFORCE_COVERAGE: yes
     # 64 bit - HDF5 1.12
     # Fewer combinations here; test_windows_wheels also tests HDF5 1.12
-      py39-hdf5112:
-        python.version: '3.9'
-        TOXENV: py39-test-deps
+      py310-hdf5112:
+        python.version: '3.10'
+        TOXENV: py310-test-deps
         HDF5_VERSION: 1.12.1
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         HDF5_VSVERSION: "17-64"
@@ -129,9 +129,9 @@ jobs:
       # -deps : test with default (latest) versions of dependencies
       # -mindeps : test with oldest supported version of (python) dependencies
       # -deps-pre : test pre-release versions of (python) dependencies)
-      py39:
-        python.version: '3.9'
-        TOXENV: py39-test-deps,py39-test-mindeps,py39-test-deps-pre
+      py310:
+        python.version: '3.10'
+        TOXENV: py310-test-deps,py310-test-mindeps,py310-test-deps-pre
         H5PY_ENFORCE_COVERAGE: yes
       py310:
         python.version: '3.10'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -131,10 +131,6 @@ jobs:
       # -deps-pre : test pre-release versions of (python) dependencies)
       py310:
         python.version: '3.10'
-        TOXENV: py310-test-deps,py310-test-mindeps,py310-test-deps-pre
-        H5PY_ENFORCE_COVERAGE: yes
-      py310:
-        python.version: '3.10'
         TOXENV: py310-test-deps
         H5PY_ENFORCE_COVERAGE: yes
     maxParallel: 4

--- a/ci/azure-pipelines-steps.yml
+++ b/ci/azure-pipelines-steps.yml
@@ -75,8 +75,8 @@ steps:
       displayName: 'ensure HDF5'
 - ${{ if eq(parameters.shell, 'cmd') }}:
     - script: |
-        py -3.9 -m pip install requests
-        py -3.9 ci\\get_hdf5_win.py
+        py -3.10 -m pip install requests
+        py -3.10 ci\\get_hdf5_win.py
       displayName: 'ensure HDF5'
 
 - script: env

--- a/news/dep-drop_cp39.rst
+++ b/news/dep-drop_cp39.rst
@@ -1,0 +1,6 @@
+
+Breaking Changes and Deprecations
+---------------------------------
+
+* Support for Python 3.9 was dropped. Python 3.10 or newer is now required
+  to build or install h5py from this version on.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,12 +34,17 @@ classifiers = [
     "Programming Language :: Cython",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering",
     "Topic :: Database",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dynamic = ["dependencies"]
 
 [project.readme]
@@ -98,10 +103,10 @@ lint = [
     "pre-commit>=4.2.0",
 ]
 mpi = [
-    "mpi4py>=3.1.1",
+    "mpi4py>=3.1.2",
 ]
 tables = [
-    "tables>=3.4.4",
+    "tables>=3.7.0",
 ]
 test = [
     "pytest>=8.2.2",

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,8 @@ RUN_REQUIRES = [
     # But we don't want to duplicate the information in oldest-supported-numpy
     # here, and if you can build an older NumPy on a newer Python, h5py probably
     # works (assuming you build it from source too).
-    # NumPy 1.19.3 is the first with wheels for Python 3.9, our minimum Python.
-    "numpy >=1.19.3",
+    # NumPy 1.21.2 is the first release with any wheels for Python 3.10, our minimum Python.
+    "numpy >=1.21.2",
 ]
 
 # Packages needed to build h5py (in addition to static list in pyproject.toml)
@@ -43,8 +43,9 @@ SETUP_REQUIRES = []
 if setup_configure.mpi_enabled():
     # mpi4py 3.1.1 fixed a typo in python_requires, which made older versions
     # incompatible with newer setuptools.
-    RUN_REQUIRES.append('mpi4py >=3.1.1')
-    SETUP_REQUIRES.append("mpi4py ==3.1.1; python_version<'3.11'")
+    # 3.1.2 is the first release with any wheels for Python 3.10
+    RUN_REQUIRES.append('mpi4py >=3.1.2')
+    SETUP_REQUIRES.append("mpi4py ==3.1.2; python_version=='3.10.*'")
     SETUP_REQUIRES.append("mpi4py ==3.1.4; python_version=='3.11.*'")
     SETUP_REQUIRES.append("mpi4py ==3.1.6; python_version=='3.12.*'")
     SETUP_REQUIRES.append("mpi4py ==4.0.1; python_version=='3.13.*'")

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # We want an envlist like
 # envlist = {py36,py37,pypy3}-{test}-{deps,mindeps}-{,mpi}-{,pre},nightly,docs,checkreadme,pre-commit
 # but we want to skip mpi and pre by default, so this envlist is below
-envlist = {py39,py310,py311,py312,pypy3}-{test}-{deps,mindeps},nightly,docs,apidocs,checkreadme,pre-commit
+envlist = {py310,py311,py312,py313,pypy3}-{test}-{deps,mindeps},nightly,docs,apidocs,checkreadme,pre-commit
 isolated_build = True
 minversion = 4.22.0 # for dependency_groups
 
@@ -50,7 +50,7 @@ pip_pre =
 
 [testenv:nightly]
 pip_pre = True
-basepython = python3.9
+basepython = python3.10
 
 [testenv:docs]
 skip_install=True


### PR DESCRIPTION
Nothing urgent, but as I'm currently spending lots of time waiting for wheels to build, I figure it may be time to remove these.

For reference, the previous such PR, #2471, was merged almost a year ago.
