### PR TITLE
New default chunk cache size in HDF5 2.0

### DIFF
--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -407,8 +407,9 @@ class File(Group):
         swmr
             Open the file in SWMR read mode. Only used when mode = 'r'.
         rdcc_nbytes
-            Total size of the dataset chunk cache in bytes. The default size
-            is 1024**2 (1 MiB) per dataset. Applies to all datasets unless individually changed.
+            Total size of the dataset chunk cache in bytes. The default size per
+            dataset is 1024**2 (1 MiB) for HDF5 before 2.0 and 8 MiB for HDF5
+            2.0 and later. Applies to all datasets unless individually changed.
         rdcc_w0
             The chunk preemption policy for all datasets.  This must be
             between 0 and 1 inclusive and indicates the weighting according to

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -150,7 +150,7 @@ class Group(HLObject, MutableMappingHDF5):
             compresses the data before handing it to h5py.
         rdcc_nbytes
             Total size of the dataset's chunk cache in bytes. The default size
-            is 1024**2 (1 MiB).
+            is 1024**2 (1 MiB) for HDF5 before 2.0 and 8 MiB for HDF5 2.0 or later.
         rdcc_w0
             The chunk preemption policy for this dataset.  This must be
             between 0 and 1 inclusive and indicates the weighting according to

--- a/h5py/tests/test_file2.py
+++ b/h5py/tests/test_file2.py
@@ -109,11 +109,18 @@ class TestDriverRegistration(TestCase):
 
 
 class TestCache(TestCase):
+    def setUp(self):
+        MiB = 1024 * 1024
+        if h5py.version.hdf5_version_tuple < (2, 0, 0):
+            self.dflt_chunk_cache = MiB
+        else:
+            self.dflt_chunk_cache = 8 * MiB
+
     def test_defaults(self):
         fname = self.mktemp()
         f = h5py.File(fname, 'w')
         self.assertEqual(list(f.id.get_access_plist().get_cache()),
-                         [0, 521, 1048576, 0.75])
+                         [0, 521, self.dflt_chunk_cache, 0.75])
 
     def test_nbytes(self):
         fname = self.mktemp()
@@ -125,13 +132,13 @@ class TestCache(TestCase):
         fname = self.mktemp()
         f = h5py.File(fname, 'w', rdcc_nslots=125)
         self.assertEqual(list(f.id.get_access_plist().get_cache()),
-                         [0, 125, 1048576, 0.75])
+                         [0, 125, self.dflt_chunk_cache, 0.75])
 
     def test_w0(self):
         fname = self.mktemp()
         f = h5py.File(fname, 'w', rdcc_w0=0.25)
         self.assertEqual(list(f.id.get_access_plist().get_cache()),
-                         [0, 521, 1048576, 0.25])
+                         [0, 521, self.dflt_chunk_cache, 0.25])
 
 
 class TestFileObj(TestCase):


### PR DESCRIPTION
The default chunk cache size is increased to 8 MiB in HDF5 2.0. Updated tests and documentation.