### PR TITLE
BLD: add back support for building against numpy 1.x

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -38,7 +38,7 @@ permissions:
 
 jobs:
   build_wheels:
-    name: 'Wheels: ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.python }}'
+    name: 'Wheels: ${{ matrix.os }} ${{ matrix.arch }}'
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     strategy:
@@ -90,7 +90,7 @@ jobs:
         if: runner.os == 'macOS'
 
       # Triage build
-      - run: bash ./ci/triage_build.sh "${{ matrix.arch }}" "${{ github.event.pull_request.head.sha || github.sha }}" "${{ matrix.python }}"
+      - run: bash ./ci/triage_build.sh "${{ matrix.arch }}" "${{ github.event.pull_request.head.sha || github.sha }}"
 
       # Now actually build the wheels
       - uses: pypa/cibuildwheel@c923d83ad9c1bc00211c5041d0c3f73294ff88f6 # v3.1.4
@@ -104,9 +104,44 @@ jobs:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
+
+  check-minimal-build:
+    # this job isn't meant to upload anything, it's only a sanity check
+    name: Check minimal build requirements (${{ matrix.label }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+            cibw_before_build: pip install --only-binary ':all:' 'numpy==1.25.0' 'Cython==3.0.0' 'setuptools==77.0.1' 'pkgconfig==1.5.5'
+            label: 'numpy-min'
+          - os: ubuntu-latest
+            arch: x86_64
+            cibw_before_build: pip install --only-binary ':all:' 'numpy==2.0.0' 'Cython==3.0.0' 'setuptools==77.0.1' 'pkgconfig==1.5.5'
+            label: 'cython-min + numpy 2.0'
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0  # get the non-merge commit for PRs
+
+      # Triage build
+      - run: bash ./ci/triage_build.sh "${{ matrix.arch }}" "${{ github.event.pull_request.head.sha || github.sha }}"
+
+      # Now actually build the wheels
+      - uses: pypa/cibuildwheel@352e01339f0a173aa2a3eb57f01492e341e83865 # v3.1.3
+        env:
+          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_BUILD: "cp310-*"
+          CIBW_BEFORE_BUILD: ${{ matrix.cibw_before_build }}
+          CIBW_BUILD_FRONTEND: 'pip; args: --no-build-isolation'
+          ONLY_MINDEPS_TESTS: "1"
+
   upload_wheels:
     name: Upload wheels
-    needs: build_wheels
+    needs:
+      - build_wheels
+      - check-minimal-build
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/ci/cibw_test_command.sh
+++ b/ci/cibw_test_command.sh
@@ -12,7 +12,11 @@ WHEEL_PATH=$2
 echo "WHEEL_PATH=$WHEEL_PATH"
 
 export PYVER=$(python -c "import sys; print(''.join(map(str, sys.version_info[:2])))")
-ENVLIST="py$PYVER-test-mindeps,py$PYVER-test-deps,py$PYVER-test-deps-pre"
+
+ENVLIST="py$PYVER-test-mindeps"
+if [[ "$ONLY_MINDEPS_TESTS" != "1" ]] ; then
+    ENVLIST="$ENVLIST,py$PYVER-test-deps,py$PYVER-test-deps-pre"
+fi
 
 export H5PY_TEST_CHECK_FILTERS=1
 echo "ENVLIST=$ENVLIST"

--- a/news/bld-new-mindeps.rst
+++ b/news/bld-new-mindeps.rst
@@ -1,0 +1,9 @@
+Building h5py
+-------------
+
+* The minimum versions build-time Python requirements were updated to
+  ``Cython==3.0.0`` (up from ``0.29.1``), and ``numpy==1.25.0`` (down from
+  ``2.0.0``). We still recommend building with numpy 2 or newer whenever
+  possible, this is done to improve support for external package ecosystems,
+  not controlled by h5py's maintainers, where numpy 2 might not be available
+  yet.

--- a/news/bld-new-mindeps.rst
+++ b/news/bld-new-mindeps.rst
@@ -5,5 +5,5 @@ Building h5py
   ``Cython==3.0.0`` (up from ``0.29.1``), and ``numpy==1.25.0`` (down from
   ``2.0.0``). We still recommend building with numpy 2 or newer whenever
   possible, this is done to improve support for external package ecosystems,
-  not controlled by h5py's maintainers, where numpy 2 might not be available
-  yet.
+  where the system uses the same version of packages for building and
+  installation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,9 @@
 
 # REMEMBER TO KEEP THE VERSIONS IN THIS FILE THE SAME AS IN ci/triage_build.sh
 requires = [
-    "Cython >=3.0.0,<4",
-    "numpy >=2.0.0, <3",
-    "pkgconfig",
+    "Cython >=3.0.0, <4",
+    "numpy >=1.25.0, <3",
+    "pkgconfig >=1.5.5",
     "setuptools >=77.0.1",
 ]
 build-backend = "setuptools.build_meta"
@@ -135,7 +135,10 @@ test-groups = ["wheels"]
 test-command = "bash {project}/ci/cibw_test_command.sh {project} {wheel}"
 
 [tool.cibuildwheel.linux]
-environment-pass = ["GITHUB_ACTIONS"]
+environment-pass = [
+    "GITHUB_ACTIONS",
+    "ONLY_MINDEPS_TESTS",
+]
 
 [tool.cibuildwheel.linux.environment]
 CFLAGS = "-g1"


### PR DESCRIPTION
Close #2644
At the time of opening, there's a missing piece: I haven't implemented a warning for `h5py._npystrings` being missing in this configuration yet.