### PR TITLE
NpyStrings segfault on Cython <3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 # REMEMBER TO KEEP THE VERSIONS IN THIS FILE THE SAME AS IN ci/triage_build.sh
 requires = [
-    "Cython >=0.29.31,<4",
+    "Cython >=3.0.0,<4",
     "numpy >=2.0.0, <3",
     "pkgconfig",
     "setuptools >=77",


### PR DESCRIPTION
`test_npystrings.py` segfaults on

python=3.10
numpy=2.0.0
cython=0.29.31 ~ 0.29.37

Everything works correctly with Cython=3.0.0.
I did not spend time investigating the issue. cython 3.0 is over 2 years old now so it should be a non-issue to upgrade the minimum dependency?