### PR TITLE
MAINT: Remove redundant `#cython: language_level=3`

### DIFF
--- a/api_gen.py
+++ b/api_gen.py
@@ -143,7 +143,6 @@ class Line:
 
 
 raw_preamble = """\
-# cython: language_level=3
 #
 # Warning: this file is auto-generated from api_gen.py. DO NOT EDIT!
 #
@@ -155,7 +154,6 @@ from .api_types_ext cimport *
 """
 
 def_preamble = """\
-# cython: language_level=3
 #
 # Warning: this file is auto-generated from api_gen.py. DO NOT EDIT!
 #
@@ -168,7 +166,6 @@ from .api_types_ext cimport *
 """
 
 imp_preamble = """\
-# cython: language_level=3
 #
 # Warning: this file is auto-generated from api_gen.py. DO NOT EDIT!
 #

--- a/h5py/_conv.pxd
+++ b/h5py/_conv.pxd
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/_conv.pyx
+++ b/h5py/_conv.pyx
@@ -1,5 +1,4 @@
 # cython: profile=False
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/_errors.pxd
+++ b/h5py/_errors.pxd
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/_proxy.pxd
+++ b/h5py/_proxy.pxd
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/_selector.pyx
+++ b/h5py/_selector.pyx
@@ -1,4 +1,3 @@
-# cython: language_level=3
 """Class to efficiently select and read data from an HDF5 dataset
 
 This is written in Cython to reduce overhead when reading small amounts of

--- a/h5py/api_types_hdf5.pxd
+++ b/h5py/api_types_hdf5.pxd
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5.pxd
+++ b/h5py/h5.pxd
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5.pyx
+++ b/h5py/h5.pyx
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5a.pxd
+++ b/h5py/h5a.pxd
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5a.pyx
+++ b/h5py/h5a.pyx
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5ac.pxd
+++ b/h5py/h5ac.pxd
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5d.pxd
+++ b/h5py/h5d.pxd
@@ -1,4 +1,3 @@
-# cython: language_level=3
 ## This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5d.pyx
+++ b/h5py/h5d.pyx
@@ -1,4 +1,3 @@
-# cython: language_level=3
 ## This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5ds.pxd
+++ b/h5py/h5ds.pxd
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5ds.pyx
+++ b/h5py/h5ds.pyx
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5f.pxd
+++ b/h5py/h5f.pxd
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5fd.pxd
+++ b/h5py/h5fd.pxd
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5g.pxd
+++ b/h5py/h5g.pxd
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5g.pyx
+++ b/h5py/h5g.pyx
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5i.pxd
+++ b/h5py/h5i.pxd
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5l.pxd
+++ b/h5py/h5l.pxd
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5o.pxd
+++ b/h5py/h5o.pxd
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5p.pxd
+++ b/h5py/h5p.pxd
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5p.pyx
+++ b/h5py/h5p.pyx
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5pl.pxd
+++ b/h5py/h5pl.pxd
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5pl.pyx
+++ b/h5py/h5pl.pyx
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5r.pxd
+++ b/h5py/h5r.pxd
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5r.pyx
+++ b/h5py/h5r.pyx
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5s.pxd
+++ b/h5py/h5s.pxd
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5s.pyx
+++ b/h5py/h5s.pyx
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5t.pxd
+++ b/h5py/h5t.pxd
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5t.pyx
+++ b/h5py/h5t.pyx
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/h5z.pxd
+++ b/h5py/h5z.pxd
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/utils.pxd
+++ b/h5py/utils.pxd
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # This file is part of h5py, a Python interface to the HDF5 library.
 #
 # http://www.h5py.org

--- a/h5py/utils.pyx
+++ b/h5py/utils.pyx
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # cython: profile=False
 
 # This file is part of h5py, a Python interface to the HDF5 library.


### PR DESCRIPTION
This flag is already defined centrally in setup_build.py:
https://github.com/h5py/h5py/blob/ad92ec229f19646b32428d793c064054aff48a5e/setup_build.py#L189