### PR TITLE
BLD: Fix crash in local docs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,6 +7,7 @@ build:
 
 sphinx:
    configuration: docs/conf.py
+   fail_on_warning: true
 
 python:
    install:

--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -591,13 +591,13 @@ Reference
     .. method:: refresh
 
         Refresh the dataset metadata by reloading from the file.
-        This is part of the :doc:`swmr` features.
+        This is part of the :doc:`../swmr` features.
 
     .. method:: flush
 
         Flush the dataset data and metadata to the file.
         If the dataset is chunked, raw data chunks are written to the file.
-        This is part of the :doc:`swmr` features. Use it in SWMR write mode to
+        This is part of the :doc:`../swmr` features. Use it in SWMR write mode to
         allow readers to be updated with the dataset changes.
 
     .. method:: make_scale(name='')


### PR DESCRIPTION
- Fix crash when calling `cd docs && make`, due to warnings being treated as errors
- Align CI to Makefile