### PR TITLE
WHL: Enable support for building windows arm64 wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -50,6 +50,8 @@ jobs:
             arch: aarch64
           - os: windows-latest
             arch: AMD64
+          - os: windows-11-arm
+            arch: ARM64
           - os: macos-14
             arch: arm64
           - os: macos-13
@@ -78,6 +80,8 @@ jobs:
           python-version: 3.12
         if: runner.os == 'Windows'
       - run: bash ./ci/cibw_before_all_windows.sh "${{ github.workspace }}"
+        env:
+          ARCH: ${{ runner.arch }}
         if: runner.os == 'Windows'
 
       # macOS HDF5

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -81,7 +81,7 @@ jobs:
         if: runner.os == 'Windows'
       - run: bash ./ci/cibw_before_all_windows.sh "${{ github.workspace }}"
         env:
-          ARCH: ${{ runner.arch }}
+          ARCH: ${{ matrix.arch }}
         if: runner.os == 'Windows'
 
       # macOS HDF5

--- a/ci/bundle_hdf5_whl.py
+++ b/ci/bundle_hdf5_whl.py
@@ -28,7 +28,7 @@ def find_dlls():
         elif arch in ("amd64", "x86_64"):
             yield os.path.join(zlib_root, 'bin_release', 'zlib.dll')
         else:
-            raise RuntimeError(f"Unexpected architecture detected: {arch}")
+            raise RuntimeError(f"Unexpected architecture detected: {platform.machine()=}")
 
 def file_sha256(path):
     h = hashlib.sha256()

--- a/ci/bundle_hdf5_whl.py
+++ b/ci/bundle_hdf5_whl.py
@@ -11,6 +11,7 @@ import os
 import os.path as osp
 import shutil
 import sys
+import platform
 import tempfile
 from zipfile import ZipFile, ZIP_DEFLATED
 
@@ -21,7 +22,11 @@ def find_dlls():
     zlib_root = os.environ.get("ZLIB_ROOT")
     if zlib_root:
         print("ZLIB_ROOT", zlib_root)
-        yield os.path.join(zlib_root, 'bin_release', 'zlib.dll')
+        arch = platform.machine().lower()
+        if arch in ("arm64", "aarch64"):
+            yield os.path.join(zlib_root, 'bin', 'zlib1.dll')
+        elif arch in ("amd64", "x86_64"):
+            yield os.path.join(zlib_root, 'bin_release', 'zlib.dll')
 
 def file_sha256(path):
     h = hashlib.sha256()

--- a/ci/bundle_hdf5_whl.py
+++ b/ci/bundle_hdf5_whl.py
@@ -27,6 +27,8 @@ def find_dlls():
             yield os.path.join(zlib_root, 'bin', 'zlib1.dll')
         elif arch in ("amd64", "x86_64"):
             yield os.path.join(zlib_root, 'bin_release', 'zlib.dll')
+        else:
+            raise RuntimeError(f"Unexpected architecture detected: {arch}")
 
 def file_sha256(path):
     h = hashlib.sha256()

--- a/ci/cibw_before_all_windows.sh
+++ b/ci/cibw_before_all_windows.sh
@@ -31,7 +31,7 @@ elif [[ "$ARCH" == "x86_64" ]]; then
     export HDF5_VSVERSION="17-64"
 else
     echo "Got unexpected arch $ARCH"
-    exit(1)
+    exit 1
 fi
 
 export PATH="$PATH:$EXTRA_PATH"

--- a/ci/cibw_before_all_windows.sh
+++ b/ci/cibw_before_all_windows.sh
@@ -29,6 +29,9 @@ else
     export CL="/I$ZLIB_ROOT/include"
     export LINK="/LIBPATH:$ZLIB_ROOT/lib_release"
     export HDF5_VSVERSION="17-64"
+else
+    echo "Got unexpected arch $ARCH"
+    exit(1)
 fi
 
 export PATH="$PATH:$EXTRA_PATH"

--- a/ci/cibw_before_all_windows.sh
+++ b/ci/cibw_before_all_windows.sh
@@ -12,7 +12,8 @@ if [[ "$ARCH" == "ARM64" ]]; then
     #Use vcpkg for Windows ARM64, since Nuget\Chocolatey doesn't provide zlib package for Windows ARM64
     VCPKG_ROOT="$PROJECT_PATH/vcpkg"
     VCPKG_SHA="dd3097e305afa53f7b4312371f62058d2e665320"  # 2025.07.25
-    git clone https://github.com/microsoft/vcpkg@"$VCPKG_SHA" "$VCPKG_ROOT"
+    git clone https://github.com/microsoft/vcpkg.git "$VCPKG_ROOT"
+    (cd "$VCPKG_ROOT" && git checkout "$VCPKG_SHA")
     $VCPKG_ROOT/bootstrap-vcpkg.bat -disableMetrics
     VCPKG_TRIPLET="arm64-windows"
     $VCPKG_ROOT/vcpkg.exe install zlib:$VCPKG_TRIPLET

--- a/ci/cibw_before_all_windows.sh
+++ b/ci/cibw_before_all_windows.sh
@@ -9,7 +9,7 @@ fi
 PROJECT_PATH="$1"
 
 if [[ "$ARCH" == "ARM64" ]]; then
-    # vcpkg for Windows ARM64
+    #Use vcpkg for Windows ARM64, since Nuget\Chocolatey doesn't provide zlib package for Windows ARM64
     VCPKG_ROOT="$PROJECT_PATH/vcpkg"
     VCPKG_SHA="dd3097e305afa53f7b4312371f62058d2e665320"  # 2025.07.25
     git clone https://github.com/microsoft/vcpkg@"$VCPKG_SHA" "$VCPKG_ROOT"

--- a/ci/cibw_before_all_windows.sh
+++ b/ci/cibw_before_all_windows.sh
@@ -11,7 +11,8 @@ PROJECT_PATH="$1"
 if [[ "$ARCH" == "ARM64" ]]; then
     # vcpkg for Windows ARM64
     VCPKG_ROOT="$PROJECT_PATH/vcpkg"
-    git clone https://github.com/microsoft/vcpkg "$VCPKG_ROOT"
+    VCPKG_SHA="dd3097e305afa53f7b4312371f62058d2e665320"  # 2025.07.25
+    git clone https://github.com/microsoft/vcpkg@"$VCPKG_SHA" "$VCPKG_ROOT"
     $VCPKG_ROOT/bootstrap-vcpkg.bat -disableMetrics
     VCPKG_TRIPLET="arm64-windows"
     $VCPKG_ROOT/vcpkg.exe install zlib:$VCPKG_TRIPLET

--- a/ci/cibw_before_all_windows.sh
+++ b/ci/cibw_before_all_windows.sh
@@ -22,7 +22,7 @@ if [[ "$ARCH" == "ARM64" ]]; then
     export CL="/I$ZLIB_ROOT/include"
     export LINK="/LIBPATH:$ZLIB_ROOT/lib"
     export HDF5_VSVERSION="17-arm64"
-elif [[ "$ARCH" == "x86_64" ]]; then
+elif [[ "$ARCH" == "AMD64" ]]; then
     # NuGet for Windows x64
     nuget install zlib-msvc-x64 -ExcludeVersion -OutputDirectory "$PROJECT_PATH"
     ZLIB_ROOT="$PROJECT_PATH/zlib-msvc-x64/build/native"

--- a/ci/cibw_before_all_windows.sh
+++ b/ci/cibw_before_all_windows.sh
@@ -21,7 +21,7 @@ if [[ "$ARCH" == "ARM64" ]]; then
     export CL="/I$ZLIB_ROOT/include"
     export LINK="/LIBPATH:$ZLIB_ROOT/lib"
     export HDF5_VSVERSION="17-arm64"
-else
+elif [[ "$ARCH" == "x86_64" ]]; then
     # NuGet for Windows x64
     nuget install zlib-msvc-x64 -ExcludeVersion -OutputDirectory "$PROJECT_PATH"
     ZLIB_ROOT="$PROJECT_PATH/zlib-msvc-x64/build/native"

--- a/ci/cibw_before_all_windows.sh
+++ b/ci/cibw_before_all_windows.sh
@@ -8,17 +8,33 @@ if [[ "$1" == "" ]] ; then
 fi
 PROJECT_PATH="$1"
 
-# nuget
-nuget install zlib-msvc-x64 -ExcludeVersion -OutputDirectory "$PROJECT_PATH"
-EXTRA_PATH="$PROJECT_PATH\zlib-msvc-x64\build\native\bin_release"
+if [[ "$ARCH" == "ARM64" ]]; then
+    # vcpkg for Windows ARM64
+    VCPKG_ROOT="$PROJECT_PATH/vcpkg"
+    git clone https://github.com/microsoft/vcpkg "$VCPKG_ROOT"
+    $VCPKG_ROOT/bootstrap-vcpkg.bat -disableMetrics
+    VCPKG_TRIPLET="arm64-windows"
+    $VCPKG_ROOT/vcpkg.exe install zlib:$VCPKG_TRIPLET
+    ZLIB_ROOT="$VCPKG_ROOT/installed/$VCPKG_TRIPLET"
+    EXTRA_PATH="$ZLIB_ROOT/bin"
+    export CL="/I$ZLIB_ROOT/include"
+    export LINK="/LIBPATH:$ZLIB_ROOT/lib"
+    export HDF5_VSVERSION="17-arm64"
+else
+    # NuGet for Windows x64
+    nuget install zlib-msvc-x64 -ExcludeVersion -OutputDirectory "$PROJECT_PATH"
+    ZLIB_ROOT="$PROJECT_PATH/zlib-msvc-x64/build/native"
+    EXTRA_PATH="$ZLIB_ROOT/bin_release"
+    export CL="/I$ZLIB_ROOT/include"
+    export LINK="/LIBPATH:$ZLIB_ROOT/lib_release"
+    export HDF5_VSVERSION="17-64"
+fi
+
 export PATH="$PATH:$EXTRA_PATH"
-export CL="/I$PROJECT_PATH\zlib-msvc-x64\build\native\include"
-export LINK="/LIBPATH:$PROJECT_PATH\zlib-msvc-x64\build\native\lib_release"
-export ZLIB_ROOT="$PROJECT_PATH\zlib-msvc-x64\build\native"
+export ZLIB_ROOT
 
 # HDF5
 export HDF5_VERSION="1.14.6"
-export HDF5_VSVERSION="17-64"
 export HDF5_DIR="$PROJECT_PATH/cache/hdf5/$HDF5_VERSION"
 
 pip install requests

--- a/ci/cibw_before_all_windows.sh
+++ b/ci/cibw_before_all_windows.sh
@@ -30,7 +30,7 @@ elif [[ "$ARCH" == "x86_64" ]]; then
     export LINK="/LIBPATH:$ZLIB_ROOT/lib_release"
     export HDF5_VSVERSION="17-64"
 else
-    echo "Got unexpected arch $ARCH"
+    echo "Got unexpected arch '$ARCH'"
     exit 1
 fi
 

--- a/ci/fix_paths.py
+++ b/ci/fix_paths.py
@@ -31,7 +31,7 @@ def main():
             elif arch in ("amd64", "x86_64"):
                 f = pjoin(zlib_root, 'bin_release', 'zlib.dll')
             else:
-                raise RuntimeError(f"Unexpected architecture detected: {arch}")
+                raise RuntimeError(f"Unexpected architecture detected: {platform.machine()=}")
             copy(f, pjoin(sitepackagesdir, 'h5py', basename(f)))
             print("Copied", f)
 

--- a/ci/fix_paths.py
+++ b/ci/fix_paths.py
@@ -1,9 +1,10 @@
 import os
 import sysconfig
+import platform
 from glob import glob
 from os.path import join as pjoin, basename
 from shutil import copy
-from sys import platform
+from sys import platform as sys_platform
 
 def main():
     """
@@ -17,15 +18,19 @@ def main():
 
     # HDF5_DIR is not set when we're testing wheels; these should already have
     # the necessary libraries bundled in.
-    if platform.startswith('win') and hdf5_path is not None:
+    if sys_platform.startswith('win') and hdf5_path is not None:
         for f in glob(pjoin(hdf5_path, 'lib/*.dll')):
             copy(f, pjoin(sitepackagesdir, 'h5py', basename(f)))
             print("Copied", f)
 
         zlib_root = os.environ.get("ZLIB_ROOT")
         if zlib_root:
-            f = pjoin(zlib_root, 'bin_release', 'zlib.dll')
-            copy(f, pjoin(sitepackagesdir, 'h5py', 'zlib.dll'))
+            arch = platform.machine().lower()
+            if arch in ("arm64", "aarch64"):
+                f = pjoin(zlib_root, 'bin', 'zlib1.dll')
+            elif arch in ("amd64", "x86_64"):
+                f = pjoin(zlib_root, 'bin_release', 'zlib.dll')
+            copy(f, pjoin(sitepackagesdir, 'h5py', basename(f)))
             print("Copied", f)
 
         print("In installed h5py:", sorted(os.listdir(pjoin(sitepackagesdir, 'h5py'))))

--- a/ci/fix_paths.py
+++ b/ci/fix_paths.py
@@ -30,6 +30,8 @@ def main():
                 f = pjoin(zlib_root, 'bin', 'zlib1.dll')
             elif arch in ("amd64", "x86_64"):
                 f = pjoin(zlib_root, 'bin_release', 'zlib.dll')
+            else:
+                raise RuntimeError(f"Unexpected architecture detected: {arch}")
             copy(f, pjoin(sitepackagesdir, 'h5py', basename(f)))
             print("Copied", f)
 

--- a/ci/get_hdf5_win.py
+++ b/ci/get_hdf5_win.py
@@ -38,7 +38,7 @@ if ZLIB_ROOT:
             f"-DZLIB_LIBRARY_RELEASE={ZLIB_ROOT}\\lib\\zlib.lib",
             f"-DZLIB_LIBRARY_DEBUG={ZLIB_ROOT}\\debug\\lib\\zlibd.lib",
         ]
-    else:
+    elif arch in ("amd64", "x86_64"):
         ## ZLIB includes based on nuget layout
         CMAKE_CONFIGURE_CMD += [
             "-DHDF5_ENABLE_Z_LIB_SUPPORT=ON",

--- a/ci/get_hdf5_win.py
+++ b/ci/get_hdf5_win.py
@@ -47,7 +47,7 @@ if ZLIB_ROOT:
             f"-DZLIB_LIBRARY_DEBUG={ZLIB_ROOT}\\lib_debug\\zlibd.lib",
         ]
     else:
-        raise RuntimeError(f"Unexpected architecture detected: {arch}")
+        raise RuntimeError(f"Unexpected architecture detected: {platform.machine()=}")
 
 CMAKE_BUILD_CMD = ["cmake", "--build"]
 CMAKE_INSTALL_ARG = ["--target", "install", '--config', 'Release']

--- a/ci/get_hdf5_win.py
+++ b/ci/get_hdf5_win.py
@@ -46,6 +46,9 @@ if ZLIB_ROOT:
             f"-DZLIB_LIBRARY_RELEASE={ZLIB_ROOT}\\lib_release\\zlib.lib",
             f"-DZLIB_LIBRARY_DEBUG={ZLIB_ROOT}\\lib_debug\\zlibd.lib",
         ]
+    else:
+        raise RuntimeError(f"Unexpected architecture detected: {arch}")
+
 CMAKE_BUILD_CMD = ["cmake", "--build"]
 CMAKE_INSTALL_ARG = ["--target", "install", '--config', 'Release']
 CMAKE_INSTALL_PATH_ARG = "-DCMAKE_INSTALL_PREFIX={install_path}"

--- a/news/h5py-for-winarm64.rst
+++ b/news/h5py-for-winarm64.rst
@@ -1,0 +1,4 @@
+New features
+------------
+
+* Added support for building and distributing h5py python wheels for Windows on ARM devices.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,9 @@ wheels = [
 skip = [
     "*musllinux*",
     "cp314t-*",
+    "cp38-win_arm64", 
+    "cp39-win_arm64",
+    "cp310-win_arm64",
 ]
 build-verbosity = 1
 build-frontend = { name = "pip", args = ["--only-binary", "numpy"] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,8 +123,6 @@ wheels = [
 skip = [
     "*musllinux*",
     "cp314t-*",
-    "cp38-win_arm64", 
-    "cp39-win_arm64",
     "cp310-win_arm64",
 ]
 build-verbosity = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ wheels = [
 skip = [
     "*musllinux*",
     "cp314t-*",
-    "cp310-win_arm64",
+    "cp310-win_arm64", #Skipped due to unavailability of Python binary and NumPy for Win-ARM64
 ]
 build-verbosity = 1
 build-frontend = { name = "pip", args = ["--only-binary", "numpy"] }

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,8 @@ minversion = 4.22.0 # for dependency_groups
 
 [testenv]
 deps =
-    mindeps: oldest-supported-numpy
+    mindeps: numpy; platform_machine == "ARM64" and sys_platform == "win32"
+    mindeps: oldest-supported-numpy; platform_machine != "ARM64" and sys_platform != "win32"
 
 dependency_groups =
     test: test


### PR DESCRIPTION
<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py312-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->
PR Description:

* The adoption of Windows on ARM (WoA) devices is steadily increasing, yet many Python wheels are still not available for this platform.
* GitHub Actions now offer native CI runners for Windows on ARM devices (windows-11-arm), enabling automated builds and testing.
* Currently, official h5py Python wheels are not provided for Windows ARM64 and thus users/developers were facing difficulties using popular h5py library natively.
* This PR introduces support for building h5py wheels on Windows ARM64, improving accessibility for developers and end users on this emerging platform.

Closes: https://github.com/h5py/h5py/issues/2578