### PR TITLE
TST: improve parallel-robustness of the test suite itself using unique ids (v2)

### DIFF
--- a/h5py/tests/test_attribute_create.py
+++ b/h5py/tests/test_attribute_create.py
@@ -14,7 +14,7 @@
 import numpy as np
 from .. import h5t, h5a
 
-from .common import TestCase
+from .common import TestCase, make_name
 
 class TestArray(TestCase):
 
@@ -24,63 +24,68 @@ class TestArray(TestCase):
 
     def test_int(self):
         # See issue 498
-
+        name = make_name()
         dt = np.dtype('(3,)i')
         data = np.arange(3, dtype='i')
 
-        self.f.attrs.create('x', data=data, dtype=dt)
+        self.f.attrs.create(name, data=data, dtype=dt)
 
-        aid = h5a.open(self.f.id, b'x')
+        aid = h5a.open(self.f.id, name.encode('utf-8'))
 
         htype = aid.get_type()
         self.assertEqual(htype.get_class(), h5t.ARRAY)
 
-        out = self.f.attrs['x']
+        out = self.f.attrs[name]
 
         self.assertArrayEqual(out, data)
 
     def test_string_dtype(self):
         # See issue 498 discussion
 
-        self.f.attrs.create('x', data=42, dtype='i8')
+        self.f.attrs.create(make_name(), data=42, dtype='i8')
 
     def test_str(self):
         # See issue 1057
-        self.f.attrs.create('x', chr(0x03A9))
-        out = self.f.attrs['x']
+        name = make_name()
+        self.f.attrs.create(name, chr(0x03A9))
+        out = self.f.attrs[name]
         self.assertEqual(out, chr(0x03A9))
         self.assertIsInstance(out, str)
 
     def test_tuple_of_unicode(self):
         # Test that a tuple of unicode strings can be set as an attribute. It will
         # be converted to a numpy array of vlen unicode type:
+        name = make_name()
         data = ('a', 'b')
-        self.f.attrs.create('x', data=data)
-        result = self.f.attrs['x']
+        self.f.attrs.create(name, data=data)
+        result = self.f.attrs[name]
         self.assertTrue(all(result == data))
         self.assertEqual(result.dtype, np.dtype('O'))
 
+    def test_unicode_np_array(self):
         # However, a numpy array of type U being passed in will not be
         # automatically converted, and should raise an error as it does
         # not map to a h5py dtype
-        data_as_U_array = np.array(data)
-        self.assertEqual(data_as_U_array.dtype, np.dtype('U1'))
+        data = np.array(['a', 'b'], dtype='U1')
         with self.assertRaises(TypeError):
-            self.f.attrs.create('y', data=data_as_U_array)
+            self.f.attrs.create('x', data=data)
 
-    def test_shape(self):
-        self.f.attrs.create('x', data=42, shape=1)
-        result = self.f.attrs['x']
+    def test_shape_scalar(self):
+        name = make_name()
+        self.f.attrs.create(name, data=42, shape=1)
+        result = self.f.attrs[name]
         self.assertEqual(result.shape, (1,))
 
-        self.f.attrs.create('y', data=np.arange(3), shape=3)
-        result = self.f.attrs['y']
+    def test_shape_array(self):
+        name = make_name()
+        self.f.attrs.create(name, data=np.arange(3), shape=3)
+        result = self.f.attrs[name]
         self.assertEqual(result.shape, (3,))
 
     def test_dtype(self):
         dt = np.dtype('(3,)i')
         array = np.arange(3, dtype='i')
-        self.f.attrs.create('x', data=array, dtype=dt)
+        self.f.attrs.create(make_name(), data=array, dtype=dt)
         # Array dtype shape is incompatible with data shape
         array = np.arange(4, dtype='i')
         with self.assertRaises(ValueError):

--- a/h5py/tests/test_base.py
+++ b/h5py/tests/test_base.py
@@ -15,7 +15,7 @@
 
 from h5py import File
 from h5py._hl.base import is_hdf5, Empty
-from .common import ut, TestCase, UNICODE_FILENAMES
+from .common import ut, TestCase, UNICODE_FILENAMES, make_name
 
 import numpy as np
 import os
@@ -42,24 +42,27 @@ class TestName(BaseTest):
         grp = self.f.create_group(None)
         self.assertIs(grp.name, None)
 
+
 class TestParent(BaseTest):
 
     """
         test the parent group of the high-level interface objects
     """
-
-    def test_object_parent(self):
+    def test_object_parent_anonymous(self):
         # Anonymous objects
         grp = self.f.create_group(None)
         # Parent of an anonymous object is undefined
         with self.assertRaises(ValueError):
             grp.parent
 
+    def test_object_parent_named(self):
         # Named objects
-        grp = self.f.create_group("bar")
+        name = make_name()
+        grp = self.f.create_group(name)
         sub_grp = grp.create_group("foo")
         parent = sub_grp.parent.name
-        self.assertEqual(parent, "/bar")
+        self.assertEqual(parent, "/" + name)
+
 
 class TestMapping(BaseTest):
 
@@ -106,18 +109,19 @@ class TestRepr(BaseTest):
 
     def test_group(self):
         """ Group repr() with unicode """
-        grp = self.f.create_group(self.USTRING)
+        grp = self.f.create_group(make_name(self.USTRING))
         self._check_type(grp)
 
     def test_dataset(self):
         """ Dataset repr() with unicode """
-        dset = self.f.create_dataset(self.USTRING, (1,))
+        dset = self.f.create_dataset(make_name(self.USTRING), (1,))
         self._check_type(dset)
 
     def test_namedtype(self):
         """ Named type repr() with unicode """
-        self.f['type'] = np.dtype('f')
-        typ = self.f['type']
+        name = make_name(self.USTRING)
+        self.f[name] = np.dtype('f')
+        typ = self.f[name]
         self._check_type(typ)
 
     def test_empty(self):

--- a/h5py/tests/test_big_endian_file.py
+++ b/h5py/tests/test_big_endian_file.py
@@ -1,7 +1,7 @@
 
 import numpy as np
 from h5py import File
-from .common import TestCase
+from .common import TestCase, make_name
 from .data_files import get_data_file_path
 
 
@@ -37,13 +37,14 @@ def test_vlen_big_endian():
 
 class TestEndianess(TestCase):
     def test_simple_int_be(self):
+        name = make_name()
         fname = self.mktemp()
 
         arr = np.ndarray(shape=(1,), dtype=">i4", buffer=bytearray([0, 1, 3, 2]))
         be_number = 0 * 256 ** 3 + 1 * 256 ** 2 + 3 * 256 ** 1 + 2 * 256 ** 0
 
         with File(fname, mode="w") as f:
-            f.create_dataset("int", data=arr)
+            f.create_dataset(name, data=arr)
 
         with File(fname, mode="r") as f:
-            assert f["int"][()][0] == be_number
+            assert f[name][()][0] == be_number

--- a/h5py/tests/test_completions.py
+++ b/h5py/tests/test_completions.py
@@ -1,30 +1,36 @@
-from .common import TestCase
+import h5py
+
+from .common import TestCase, make_name
 
 
 class TestCompletions(TestCase):
 
-    def test_group_completions(self):
+    def test_root_group_completions(self):
         # Test completions on top-level file.
-        g = self.f.create_group('g')
-        self.f.create_group('h')
-        self.f.create_dataset('data', [1, 2, 3])
-        self.assertEqual(
-            self.f._ipython_key_completions_(),
-            ['data', 'g', 'h'],
-        )
+        with h5py.File(self.mktemp(), 'w') as f:
+            f.create_group('h')
+            f.create_group('g')
+            f.create_dataset('data', [1, 2, 3])
+            self.assertEqual(
+            f._ipython_key_completions_(),
+                ['data', 'g', 'h'],
+            )
 
-        self.f.create_group('data2', [1, 2, 3])
-        self.assertEqual(
-            self.f._ipython_key_completions_(),
-            ['data', 'data2', 'g', 'h'],
-        )
+            f.create_group('data2')
+            # Test that order is alphabetical, and that there is no
+            # internal ordering between groups and datasets.
+            self.assertEqual(
+                f._ipython_key_completions_(),
+                ['data', 'data2', 'g', 'h'],
+            )
 
-        # Test on subgroup.
-        g.create_dataset('g_data1', [1, 2, 3])
+    def test_subgroup_completions(self):
+        g = self.f.create_group(make_name())
         g.create_dataset('g_data2', [4, 5, 6])
+        g.create_dataset('g_data1', [1, 2, 3])
         self.assertEqual(
             g._ipython_key_completions_(),
-            ['g_data1', 'g_data2'],
+            ['g_data1', 'g_data2'],  # Order is alphabetical
         )
 
         g.create_dataset('g_data3', [7, 8, 9])
@@ -34,7 +40,8 @@ class TestCompletions(TestCase):
         )
 
     def test_attrs_completions(self):
-        attrs = self.f.attrs
+        # In pytest-run-parallel, let every thread run on a different set of attrs
+        attrs = self.f.create_group(make_name()).attrs
 
         # Write out of alphabetical order to test that completions come back in
         # alphabetical order, as opposed to, say, insertion order.

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -25,13 +25,14 @@ import pytest
 import threading
 from concurrent.futures import ThreadPoolExecutor
 
-from .common import ut, TestCase
-from .data_files import get_data_file_path
 from h5py import File, Dataset
 from h5py._hl.base import is_empty_dataspace, product
 from h5py import h5f, h5t
 import h5py
-from h5py.tests.common import NUMPY_RELEASE_VERSION
+
+from .common import ut, TestCase, NUMPY_RELEASE_VERSION, is_main_thread, make_name
+from .data_files import get_data_file_path
+
 
 class BaseDataset(TestCase):
     def setUp(self):
@@ -49,12 +50,14 @@ class TestRepr(BaseDataset):
     endian_mark = '>' if sys.byteorder=='big' else '<'
 
     def test_repr_basic(self):
-        ds = self.f.create_dataset('foo', (4,), dtype='int32')
-        assert repr(ds) == f'<HDF5 dataset "foo": shape (4,), type "{self.endian_mark}i4">'
+        name = make_name()
+        ds = self.f.create_dataset(name, (4,), dtype='int32')
+        assert repr(ds) == f'<HDF5 dataset "{name}": shape (4,), type "{self.endian_mark}i4">'
 
+    @pytest.mark.thread_unsafe
     def test_repr_closed(self):
         """ repr() works on live and dead datasets """
-        ds = self.f.create_dataset('foo', (4,))
+        ds = self.f.create_dataset(make_name(), (4,))
         self.f.close()
         assert repr(ds) == '<Closed HDF5 dataset>'
 
@@ -71,50 +74,50 @@ class TestCreateShape(BaseDataset):
 
     def test_create_scalar(self):
         """ Create a scalar dataset """
-        dset = self.f.create_dataset('foo', ())
+        dset = self.f.create_dataset(make_name(), ())
         self.assertEqual(dset.shape, ())
 
     def test_create_simple(self):
         """ Create a size-1 dataset """
-        dset = self.f.create_dataset('foo', (1,))
+        dset = self.f.create_dataset(make_name(), (1,))
         self.assertEqual(dset.shape, (1,))
 
     def test_create_integer(self):
         """ Create a size-1 dataset with integer shape"""
-        dset = self.f.create_dataset('foo', 1)
+        dset = self.f.create_dataset(make_name(), 1)
         self.assertEqual(dset.shape, (1,))
 
-    def test_create_extended(self):
-        """ Create an extended dataset """
-        dset = self.f.create_dataset('foo', (63,))
+    def test_create_extended_1d(self):
+        """ Create an extended dataset with tuple shape """
+        dset = self.f.create_dataset(make_name(), (63,))
         self.assertEqual(dset.shape, (63,))
         self.assertEqual(dset.size, 63)
-        dset = self.f.create_dataset('bar', (6, 10))
+
+    def test_create_extended_2d(self):
+        """ Create an extended dataset with 2 dimensions """
+        dset = self.f.create_dataset(make_name(), (6, 10))
         self.assertEqual(dset.shape, (6, 10))
         self.assertEqual(dset.size, (60))
 
     def test_create_integer_extended(self):
-        """ Create an extended dataset """
-        dset = self.f.create_dataset('foo', 63)
+        """ Create an extended dataset with integer shape """
+        dset = self.f.create_dataset(make_name(), 63)
         self.assertEqual(dset.shape, (63,))
         self.assertEqual(dset.size, 63)
-        dset = self.f.create_dataset('bar', (6, 10))
-        self.assertEqual(dset.shape, (6, 10))
-        self.assertEqual(dset.size, (60))
 
     def test_default_dtype(self):
         """ Confirm that the default dtype is float """
-        dset = self.f.create_dataset('foo', (63,))
+        dset = self.f.create_dataset(make_name(), (63,))
         self.assertEqual(dset.dtype, np.dtype('=f4'))
 
     def test_missing_shape(self):
         """ Missing shape raises TypeError """
         with self.assertRaises(TypeError):
-            self.f.create_dataset('foo')
+            self.f.create_dataset(make_name())
 
     def test_long_double(self):
         """ Confirm that the default dtype is float """
-        dset = self.f.create_dataset('foo', (63,), dtype=np.longdouble)
+        dset = self.f.create_dataset(make_name(), (63,), dtype=np.longdouble)
         if platform.machine() in ['ppc64le']:
             pytest.xfail("Storage of long double deactivated on %s" % platform.machine())
         self.assertEqual(dset.dtype, np.longdouble)
@@ -122,15 +125,15 @@ class TestCreateShape(BaseDataset):
     @ut.skipIf(not hasattr(np, "complex256"), "No support for complex256")
     def test_complex256(self):
         """ Confirm that the default dtype is float """
-        dset = self.f.create_dataset('foo', (63,),
+        dset = self.f.create_dataset(make_name(), (63,),
                                      dtype=np.dtype('complex256'))
         self.assertEqual(dset.dtype, np.dtype('complex256'))
 
     def test_name_bytes(self):
-        dset = self.f.create_dataset(b'foo', (1,))
+        dset = self.f.create_dataset(make_name("foo").encode('utf-8'), (1,))
         self.assertEqual(dset.shape, (1,))
 
-        dset2 = self.f.create_dataset(b'bar/baz', (2,))
+        dset2 = self.f.create_dataset((make_name("bar{}/baz")).encode('utf-8'), (2,))
         self.assertEqual(dset2.shape, (2,))
 
 class TestCreateData(BaseDataset):
@@ -142,25 +145,26 @@ class TestCreateData(BaseDataset):
     def test_create_scalar(self):
         """ Create a scalar dataset from existing array """
         data = np.ones((), 'f')
-        dset = self.f.create_dataset('foo', data=data)
+        dset = self.f.create_dataset(make_name(), data=data)
         self.assertEqual(dset.shape, data.shape)
 
     def test_create_extended(self):
         """ Create an extended dataset from existing data """
         data = np.ones((63,), 'f')
-        dset = self.f.create_dataset('foo', data=data)
+        dset = self.f.create_dataset(make_name(), data=data)
         self.assertEqual(dset.shape, data.shape)
 
     def test_dataset_intermediate_group(self):
         """ Create dataset with missing intermediate groups """
-        ds = self.f.create_dataset("/foo/bar/baz", shape=(10, 10), dtype='<i4')
+        name = make_name("/foo{}/bar/baz")
+        ds = self.f.create_dataset(name, shape=(10, 10), dtype='<i4')
         self.assertIsInstance(ds, h5py.Dataset)
-        self.assertTrue("/foo/bar/baz" in self.f)
+        self.assertTrue(name in self.f)
 
     def test_reshape(self):
         """ Create from existing data, and make it fit a new shape """
         data = np.arange(30, dtype='f')
-        dset = self.f.create_dataset('foo', shape=(10, 3), data=data)
+        dset = self.f.create_dataset(make_name(), shape=(10, 3), data=data)
         self.assertEqual(dset.shape, (10, 3))
         self.assertArrayEqual(dset[...], data.reshape((10, 3)))
 
@@ -183,43 +187,45 @@ class TestCreateData(BaseDataset):
         """ Creating dataset with byte string yields vlen ASCII dataset """
         def check_vlen_ascii(dset):
             self.check_h5_string(dset, h5t.CSET_ASCII, length=None)
-        check_vlen_ascii(self.f.create_dataset('a', data=b'abc'))
-        check_vlen_ascii(self.f.create_dataset('b', data=[b'abc', b'def']))
-        check_vlen_ascii(self.f.create_dataset('c', data=[[b'abc'], [b'def']]))
+        check_vlen_ascii(self.f.create_dataset(make_name("a"), data=b'abc'))
+        check_vlen_ascii(self.f.create_dataset(make_name("b"), data=[b'abc', b'def']))
+        check_vlen_ascii(self.f.create_dataset(make_name("c"), data=[[b'abc'], [b'def']]))
         check_vlen_ascii(self.f.create_dataset(
-            'd', data=np.array([b'abc', b'def'], dtype=object)
+            make_name("d"), data=np.array([b'abc', b'def'], dtype=object)
         ))
 
     def test_create_np_s(self):
-        dset = self.f.create_dataset('a', data=np.array([b'abc', b'def'], dtype='S3'))
+        dset = self.f.create_dataset(make_name(), data=np.array([b'abc', b'def'], dtype='S3'))
         self.check_h5_string(dset, h5t.CSET_ASCII, length=3)
 
     def test_create_strings(self):
         def check_vlen_utf8(dset):
             self.check_h5_string(dset, h5t.CSET_UTF8, length=None)
-        check_vlen_utf8(self.f.create_dataset('a', data='abc'))
-        check_vlen_utf8(self.f.create_dataset('b', data=['abc', 'def']))
-        check_vlen_utf8(self.f.create_dataset('c', data=[['abc'], ['def']]))
+        check_vlen_utf8(self.f.create_dataset(make_name("a"), data='abc'))
+        check_vlen_utf8(self.f.create_dataset(make_name("b"), data=['abc', 'def']))
+        check_vlen_utf8(self.f.create_dataset(make_name("c"), data=[['abc'], ['def']]))
         check_vlen_utf8(self.f.create_dataset(
-            'd', data=np.array(['abc', 'def'], dtype=object)
+            make_name("d"), data=np.array(['abc', 'def'], dtype=object)
         ))
 
     def test_create_np_u(self):
         with self.assertRaises(TypeError):
-            self.f.create_dataset('a', data=np.array([b'abc', b'def'], dtype='U3'))
+            self.f.create_dataset(make_name(), data=np.array([b'abc', b'def'], dtype='U3'))
 
     def test_empty_create_via_None_shape(self):
-        self.f.create_dataset('foo', dtype='f')
-        self.assertTrue(is_empty_dataspace(self.f['foo'].id))
+        name = make_name()
+        self.f.create_dataset(name, dtype='f')
+        self.assertTrue(is_empty_dataspace(self.f[name].id))
 
     def test_empty_create_via_Empty_class(self):
-        self.f.create_dataset('foo', data=h5py.Empty(dtype='f'))
-        self.assertTrue(is_empty_dataspace(self.f['foo'].id))
+        name = make_name()
+        self.f.create_dataset(name, data=h5py.Empty(dtype='f'))
+        self.assertTrue(is_empty_dataspace(self.f[name].id))
 
     def test_create_incompatible_data(self):
         # Shape tuple is incompatible with data
         with self.assertRaises(ValueError):
-            self.f.create_dataset('bar', shape=4, data= np.arange(3))
+            self.f.create_dataset(make_name(), shape=4, data= np.arange(3))
 
 
 class TestReadDirectly:
@@ -238,7 +244,7 @@ class TestReadDirectly:
         ])
     def test_read_direct(self, writable_file, source_shape, dest_shape, source_sel, dest_sel):
         source_values = np.arange(product(source_shape), dtype="int64").reshape(source_shape)
-        dset = writable_file.create_dataset("dset", source_shape, data=source_values)
+        dset = writable_file.create_dataset(make_name(), source_shape, data=source_values)
         arr = np.full(dest_shape, -1, dtype="int64")
         expected = arr.copy()
         expected[dest_sel] = source_values[source_sel]
@@ -247,32 +253,32 @@ class TestReadDirectly:
         np.testing.assert_array_equal(arr, expected)
 
     def test_no_sel(self, writable_file):
-        dset = writable_file.create_dataset("dset", (10,), data=np.arange(10, dtype="int64"))
+        dset = writable_file.create_dataset(make_name(), (10,), data=np.arange(10, dtype="int64"))
         arr = np.ones((10,), dtype="int64")
         dset.read_direct(arr)
         np.testing.assert_array_equal(arr, np.arange(10, dtype="int64"))
 
     def test_empty(self, writable_file):
-        empty_dset = writable_file.create_dataset("edset", dtype='int64')
+        empty_dset = writable_file.create_dataset(make_name(), dtype='int64')
         arr = np.ones((100,), 'int64')
         with pytest.raises(TypeError):
             empty_dset.read_direct(arr, np.s_[0:10], np.s_[50:60])
 
     def test_wrong_shape(self, writable_file):
-        dset = writable_file.create_dataset("dset", (100,), dtype='int64')
+        dset = writable_file.create_dataset(make_name(), (100,), dtype='int64')
         arr = np.ones((200,))
         with pytest.raises(TypeError):
             dset.read_direct(arr)
 
     def test_not_c_contiguous(self, writable_file):
-        dset = writable_file.create_dataset("dset", (10, 10), dtype='int64')
+        dset = writable_file.create_dataset(make_name(), (10, 10), dtype='int64')
         arr = np.ones((10, 10), order='F')
         with pytest.raises(TypeError):
             dset.read_direct(arr)
 
     def test_zero_length(self, writable_file):
         shape = (0, 20)
-        dset = writable_file.create_dataset("dset", shape, dtype=np.int64)
+        dset = writable_file.create_dataset(make_name(), shape, dtype=np.int64)
         arr = np.zeros(shape, dtype=np.int64)
         dset.read_direct(arr)
 
@@ -297,7 +303,7 @@ class TestWriteDirectly:
             ((5, 7, 9), (6,), np.s_[2, :6, 3], np.s_[:]),
         ])
     def test_write_direct(self, writable_file, source_shape, dest_shape, source_sel, dest_sel):
-        dset = writable_file.create_dataset('dset', dest_shape, dtype='int32', fillvalue=-1)
+        dset = writable_file.create_dataset(make_name(), dest_shape, dtype='int32', fillvalue=-1)
         arr = np.arange(product(source_shape)).reshape(source_shape)
         expected = np.full(dest_shape, -1, dtype='int32')
         expected[dest_sel] = arr[source_sel]
@@ -305,18 +311,18 @@ class TestWriteDirectly:
         np.testing.assert_array_equal(dset[:], expected)
 
     def test_empty(self, writable_file):
-        empty_dset = writable_file.create_dataset("edset", dtype='int64')
+        empty_dset = writable_file.create_dataset(make_name(), dtype='int64')
         with pytest.raises(TypeError):
             empty_dset.write_direct(np.ones((100,)), np.s_[0:10], np.s_[50:60])
 
     def test_wrong_shape(self, writable_file):
-        dset = writable_file.create_dataset("dset", (100,), dtype='int64')
+        dset = writable_file.create_dataset(make_name(), (100,), dtype='int64')
         arr = np.ones((200,))
         with pytest.raises(TypeError):
             dset.write_direct(arr)
 
     def test_not_c_contiguous(self, writable_file):
-        dset = writable_file.create_dataset("dset", (10, 10), dtype='int64')
+        dset = writable_file.create_dataset(make_name(), (10, 10), dtype='int64')
         arr = np.ones((10, 10), order='F')
         with pytest.raises(TypeError):
             dset.write_direct(arr)
@@ -330,61 +336,78 @@ class TestCreateRequire(BaseDataset):
 
     def test_create(self):
         """ Create new dataset with no conflicts """
-        dset = self.f.require_dataset('foo', (10, 3), 'f')
+        dset = self.f.require_dataset(make_name(), (10, 3), 'f')
         self.assertIsInstance(dset, Dataset)
         self.assertEqual(dset.shape, (10, 3))
 
     def test_create_existing(self):
         """ require_dataset yields existing dataset """
-        dset = self.f.require_dataset('foo', (10, 3), 'f')
-        dset2 = self.f.require_dataset('foo', (10, 3), 'f')
+        name = make_name()
+        dset = self.f.require_dataset(name, (10, 3), 'f')
+        dset[0, 0] = 123
+        dset2 = self.f.require_dataset(name, (10, 3), 'f')
         self.assertEqual(dset, dset2)
 
-    def test_create_1D(self):
+    def test_create_1D_integer(self):
         """ require_dataset with integer shape yields existing dataset"""
-        dset = self.f.require_dataset('foo', 10, 'f')
-        dset2 = self.f.require_dataset('foo', 10, 'f')
+        name = make_name()
+        dset = self.f.require_dataset(name, 10, 'f')
+        dset[0] = 123
+        dset2 = self.f.require_dataset(name, 10, 'f')
         self.assertEqual(dset, dset2)
 
-        dset = self.f.require_dataset('bar', (10,), 'f')
-        dset2 = self.f.require_dataset('bar', 10, 'f')
+    def test_create_1D_tuple(self):
+        name = make_name()
+        dset = self.f.require_dataset(name, (10,), 'f')
+        dset[0] = 123
+        dset2 = self.f.require_dataset(name, 10, 'f')
         self.assertEqual(dset, dset2)
 
-        dset = self.f.require_dataset('baz', 10, 'f')
-        dset2 = self.f.require_dataset(b'baz', (10,), 'f')
+    def test_create_1D_binary(self):
+        name = make_name()
+        dset = self.f.require_dataset(name, 10, 'f')
+        dset[0] = 123
+        dset2 = self.f.require_dataset(name.encode('utf-8'), (10,), 'f')
         self.assertEqual(dset, dset2)
 
     def test_shape_conflict(self):
         """ require_dataset with shape conflict yields TypeError """
-        self.f.create_dataset('foo', (10, 3), 'f')
+        name = make_name()
+        self.f.create_dataset(name, (10, 3), 'f')
         with self.assertRaises(TypeError):
-            self.f.require_dataset('foo', (10, 4), 'f')
+            self.f.require_dataset(name, (10, 4), 'f')
 
     def test_type_conflict(self):
         """ require_dataset with object type conflict yields TypeError """
-        self.f.create_group('foo')
+        name = make_name()
+        self.f.create_group(name)
         with self.assertRaises(TypeError):
-            self.f.require_dataset('foo', (10, 3), 'f')
+            self.f.require_dataset(name, (10, 3), 'f')
 
     def test_dtype_conflict(self):
         """ require_dataset with dtype conflict (strict mode) yields TypeError
         """
-        dset = self.f.create_dataset('foo', (10, 3), 'f')
+        name = make_name()
+        dset = self.f.create_dataset(name, (10, 3), 'f')
         with self.assertRaises(TypeError):
-            self.f.require_dataset('foo', (10, 3), 'S10')
+            self.f.require_dataset(name, (10, 3), 'S10')
 
     def test_dtype_exact(self):
         """ require_dataset with exactly dtype match """
-
-        dset = self.f.create_dataset('foo', (10, 3), 'f')
-        dset2 = self.f.require_dataset('foo', (10, 3), 'f', exact=True)
+        name = make_name()
+        dset = self.f.create_dataset(name, (10, 3), 'f')
+        dset[0, 0] = 123
+        dset2 = self.f.require_dataset(name, (10, 3), 'f', exact=True)
         self.assertEqual(dset, dset2)
 
     def test_dtype_close(self):
         """ require_dataset with convertible type succeeds (non-strict mode)
         """
-        dset = self.f.create_dataset('foo', (10, 3), 'i4')
-        dset2 = self.f.require_dataset('foo', (10, 3), 'i2', exact=False)
+        name = make_name()
+        dset = self.f.create_dataset(name, (10, 3), 'i4')
+        # Set a value too large for i2 to test for spurious intermediate conversions
+        dset[0, 0] = 98765
+        dset2 = self.f.require_dataset(name, (10, 3), 'i2', exact=False)
         self.assertEqual(dset, dset2)
         self.assertEqual(dset2.dtype, np.dtype('i4'))
 
@@ -397,43 +420,43 @@ class TestCreateChunked(BaseDataset):
 
     def test_create_chunks(self):
         """ Create via chunks tuple """
-        dset = self.f.create_dataset('foo', shape=(100,), chunks=(10,))
+        dset = self.f.create_dataset(make_name(), shape=(100,), chunks=(10,))
         self.assertEqual(dset.chunks, (10,))
 
     def test_create_chunks_integer(self):
         """ Create via chunks integer """
-        dset = self.f.create_dataset('foo', shape=(100,), chunks=10)
+        dset = self.f.create_dataset(make_name(), shape=(100,), chunks=10)
         self.assertEqual(dset.chunks, (10,))
 
     def test_chunks_mismatch(self):
         """ Illegal chunk size raises ValueError """
         with self.assertRaises(ValueError):
-            self.f.create_dataset('foo', shape=(100,), chunks=(200,))
+            self.f.create_dataset(make_name(), shape=(100,), chunks=(200,))
 
     def test_chunks_false(self):
         """ Chunked format required for given storage options """
         with self.assertRaises(ValueError):
-            self.f.create_dataset('foo', shape=(10,), maxshape=100, chunks=False)
+            self.f.create_dataset(make_name(), shape=(10,), maxshape=100, chunks=False)
 
     def test_chunks_scalar(self):
         """ Attempting to create chunked scalar dataset raises TypeError """
         with self.assertRaises(TypeError):
-            self.f.create_dataset('foo', shape=(), chunks=(50,))
+            self.f.create_dataset(make_name(), shape=(), chunks=(50,))
 
     def test_auto_chunks(self):
         """ Auto-chunking of datasets """
-        dset = self.f.create_dataset('foo', shape=(20, 100), chunks=True)
+        dset = self.f.create_dataset(make_name(), shape=(20, 100), chunks=True)
         self.assertIsInstance(dset.chunks, tuple)
         self.assertEqual(len(dset.chunks), 2)
 
     def test_auto_chunks_abuse(self):
         """ Auto-chunking with pathologically large element sizes """
-        dset = self.f.create_dataset('foo', shape=(3,), dtype='S100000000', chunks=True)
+        dset = self.f.create_dataset(make_name(), shape=(3,), dtype='S100000000', chunks=True)
         self.assertEqual(dset.chunks, (1,))
 
     def test_scalar_assignment(self):
         """ Test scalar assignment of chunked dataset """
-        dset = self.f.create_dataset('foo', shape=(3, 50, 50),
+        dset = self.f.create_dataset(make_name(), shape=(3, 50, 50),
                                      dtype=np.int32, chunks=(1, 50, 50))
         # test assignment of selection smaller than chunk size
         dset[1, :, 40] = 10
@@ -449,11 +472,12 @@ class TestCreateChunked(BaseDataset):
 
     def test_auto_chunks_no_shape(self):
         """ Auto-chunking of empty datasets not allowed"""
+        name = make_name()
         with pytest.raises(TypeError, match='Empty') as err:
-            self.f.create_dataset('foo', dtype='S100', chunks=True)
+            self.f.create_dataset(name, dtype='S100', chunks=True)
 
         with pytest.raises(TypeError, match='Empty') as err:
-            self.f.create_dataset('foo', dtype='S100', maxshape=20)
+            self.f.create_dataset(name, dtype='S100', maxshape=20)
 
 
 class TestCreateFillvalue(BaseDataset):
@@ -464,33 +488,33 @@ class TestCreateFillvalue(BaseDataset):
 
     def test_create_fillval(self):
         """ Fill value is reflected in dataset contents """
-        dset = self.f.create_dataset('foo', (10,), fillvalue=4.0)
+        dset = self.f.create_dataset(make_name(), (10,), fillvalue=4.0)
         self.assertEqual(dset[0], 4.0)
         self.assertEqual(dset[7], 4.0)
 
     def test_property(self):
         """ Fill value is recoverable via property """
-        dset = self.f.create_dataset('foo', (10,), fillvalue=3.0)
+        dset = self.f.create_dataset(make_name(), (10,), fillvalue=3.0)
         self.assertEqual(dset.fillvalue, 3.0)
         self.assertNotIsInstance(dset.fillvalue, np.ndarray)
 
     def test_property_none(self):
         """ .fillvalue property works correctly if not set """
-        dset = self.f.create_dataset('foo', (10,))
+        dset = self.f.create_dataset(make_name(), (10,))
         self.assertEqual(dset.fillvalue, 0)
 
     def test_compound(self):
         """ Fill value works with compound types """
         dt = np.dtype([('a', 'f4'), ('b', 'i8')])
         v = np.ones((1,), dtype=dt)[0]
-        dset = self.f.create_dataset('foo', (10,), dtype=dt, fillvalue=v)
+        dset = self.f.create_dataset(make_name(), (10,), dtype=dt, fillvalue=v)
         self.assertEqual(dset.fillvalue, v)
         self.assertAlmostEqual(dset[4], v)
 
     def test_exc(self):
         """ Bogus fill value raises ValueError """
         with self.assertRaises(ValueError):
-            dset = self.f.create_dataset('foo', (10,),
+            dset = self.f.create_dataset(make_name(), (10,),
                     dtype=[('a', 'i'), ('b', 'f')], fillvalue=42)
 
 
@@ -502,7 +526,7 @@ class TestFillTime(BaseDataset):
 
     def test_fill_time_default(self):
         """ Fill time default to IFSET """
-        dset = self.f.create_dataset('foo', (10,), fillvalue=4.0)
+        dset = self.f.create_dataset(make_name(), (10,), fillvalue=4.0)
         plist = dset.id.get_create_plist()
         self.assertEqual(plist.get_fill_time(), h5py.h5d.FILL_TIME_IFSET)
         self.assertEqual(dset[0], 4.0)
@@ -511,7 +535,7 @@ class TestFillTime(BaseDataset):
     @ut.skipIf('gzip' not in h5py.filters.encode, "DEFLATE is not installed")
     def test_compressed_default(self):
         """ Fill time is IFSET for compressed dataset (chunked) """
-        dset = self.f.create_dataset('foo', (10,), compression='gzip',
+        dset = self.f.create_dataset(make_name(), (10,), compression='gzip',
                                      fillvalue=4.0)
         plist = dset.id.get_create_plist()
         self.assertEqual(plist.get_fill_time(), h5py.h5d.FILL_TIME_IFSET)
@@ -520,7 +544,7 @@ class TestFillTime(BaseDataset):
 
     def test_fill_time_never(self):
         """ Fill time set to NEVER """
-        dset = self.f.create_dataset('foo', (10,), fillvalue=4.0,
+        dset = self.f.create_dataset(make_name(), (10,), fillvalue=4.0,
                                      fill_time='never')
         plist = dset.id.get_create_plist()
         self.assertEqual(plist.get_fill_time(), h5py.h5d.FILL_TIME_NEVER)
@@ -530,14 +554,14 @@ class TestFillTime(BaseDataset):
 
     def test_fill_time_alloc(self):
         """ Fill time explicitly set to ALLOC """
-        dset = self.f.create_dataset('foo', (10,), fillvalue=4.0,
+        dset = self.f.create_dataset(make_name(), (10,), fillvalue=4.0,
                                      fill_time='alloc')
         plist = dset.id.get_create_plist()
         self.assertEqual(plist.get_fill_time(), h5py.h5d.FILL_TIME_ALLOC)
 
     def test_fill_time_ifset(self):
         """ Fill time explicitly set to IFSET """
-        dset = self.f.create_dataset('foo', (10,), chunks=(2,), fillvalue=4.0,
+        dset = self.f.create_dataset(make_name(), (10,), chunks=(2,), fillvalue=4.0,
                                      fill_time='ifset')
         plist = dset.id.get_create_plist()
         self.assertEqual(plist.get_fill_time(), h5py.h5d.FILL_TIME_IFSET)
@@ -545,16 +569,16 @@ class TestFillTime(BaseDataset):
     def test_invalid_fill_time(self):
         """ Choice of fill_time is 'alloc', 'never', 'ifset' """
         with self.assertRaises(ValueError):
-            dset = self.f.create_dataset('foo', (10,), fill_time='fill_bad')
+            dset = self.f.create_dataset(make_name(), (10,), fill_time='fill_bad')
 
     def test_non_str_fill_time(self):
         """ fill_time must be a string """
         with self.assertRaises(ValueError):
-            dset = self.f.create_dataset('foo', (10,), fill_time=2)
+            dset = self.f.create_dataset(make_name(), (10,), fill_time=2)
 
     def test_resize_chunk_fill_time_default(self):
         """ The resize dataset will be filled (by default fill value 0) """
-        dset = self.f.create_dataset('foo', (50, ), maxshape=(100, ),
+        dset = self.f.create_dataset(make_name(), (50, ), maxshape=(100, ),
                                      chunks=(5, ))
         plist = dset.id.get_create_plist()
         self.assertEqual(plist.get_fill_time(), h5py.h5d.FILL_TIME_IFSET)
@@ -566,7 +590,7 @@ class TestFillTime(BaseDataset):
 
     def test_resize_chunk_fill_time_never(self):
         """ The resize dataset won't be filled """
-        dset = self.f.create_dataset('foo', (50, ), maxshape=(100, ),
+        dset = self.f.create_dataset(make_name(), (50, ), maxshape=(100, ),
                                      fillvalue=4.0, fill_time='never',
                                      chunks=(5, ))
         plist = dset.id.get_create_plist()
@@ -593,7 +617,7 @@ class TestFillTime(BaseDataset):
 
 ])
 def test_get_unset_fill_value(dt, expected, writable_file):
-    dset = writable_file.create_dataset('foo', (10,), dtype=dt)
+    dset = writable_file.create_dataset(make_name(), (10,), dtype=dt)
     assert dset.fillvalue == expected
 
 
@@ -605,10 +629,12 @@ class TestCreateNamedType(BaseDataset):
 
     def test_named(self):
         """ Named type object works and links the dataset to type """
-        self.f['type'] = np.dtype('f8')
-        dset = self.f.create_dataset('x', (100,), dtype=self.f['type'])
+        name = make_name("type")
+        self.f[name] = np.dtype('f8')
+        dt = self.f[name]
+        dset = self.f.create_dataset(make_name("x"), (100,), dtype=dt)
         self.assertEqual(dset.dtype, np.dtype('f8'))
-        self.assertEqual(dset.id.get_type(), self.f['type'].id)
+        self.assertEqual(dset.id.get_type(), dt.id)
         self.assertTrue(dset.id.get_type().committed())
 
 
@@ -621,20 +647,22 @@ class TestCreateGzip(BaseDataset):
 
     def test_gzip(self):
         """ Create with explicit gzip options """
-        dset = self.f.create_dataset('foo', (20, 30), compression='gzip',
+        dset = self.f.create_dataset(make_name(), (20, 30), compression='gzip',
                                      compression_opts=9)
         self.assertEqual(dset.compression, 'gzip')
         self.assertEqual(dset.compression_opts, 9)
 
     def test_gzip_implicit(self):
         """ Create with implicit gzip level (level 4) """
-        dset = self.f.create_dataset('foo', (20, 30), compression='gzip')
+        dset = self.f.create_dataset(make_name(), (20, 30), compression='gzip')
         self.assertEqual(dset.compression, 'gzip')
         self.assertEqual(dset.compression_opts, 4)
 
+    @pytest.mark.thread_unsafe(reason="monkey-patch")
     def test_gzip_number(self):
         """ Create with gzip level by specifying integer """
-        dset = self.f.create_dataset('foo', (20, 30), compression=7)
+        name = make_name()
+        dset = self.f.create_dataset(name, (20, 30), compression=7)
         self.assertEqual(dset.compression, 'gzip')
         self.assertEqual(dset.compression_opts, 7)
 
@@ -642,18 +670,19 @@ class TestCreateGzip(BaseDataset):
         try:
             h5py._hl.dataset._LEGACY_GZIP_COMPRESSION_VALS = tuple()
             with self.assertRaises(ValueError):
-                dset = self.f.create_dataset('foo', (20, 30), compression=7)
+                dset = self.f.create_dataset(name, (20, 30), compression=7)
         finally:
             h5py._hl.dataset._LEGACY_GZIP_COMPRESSION_VALS = original_compression_vals
 
     def test_gzip_exc(self):
         """ Illegal gzip level (explicit or implicit) raises ValueError """
+        name = make_name()
         with self.assertRaises((ValueError, RuntimeError)):
-            self.f.create_dataset('foo', (20, 30), compression=14)
+            self.f.create_dataset(name, (20, 30), compression=14)
         with self.assertRaises(ValueError):
-            self.f.create_dataset('foo', (20, 30), compression=-4)
+            self.f.create_dataset(name, (20, 30), compression=-4)
         with self.assertRaises(ValueError):
-            self.f.create_dataset('foo', (20, 30), compression='gzip',
+            self.f.create_dataset(name, (20, 30), compression='gzip',
                                   compression_opts=14)
 
 
@@ -663,7 +692,7 @@ class TestCreateCompressionNumber(BaseDataset):
     """
         Feature: Datasets created with a compression code
     """
-
+    @pytest.mark.thread_unsafe(reason="monkey-patch")
     def test_compression_number(self):
         """ Create with compression number of gzip (h5py.h5z.FILTER_DEFLATE) and a compression level of 7"""
         original_compression_vals = h5py._hl.dataset._LEGACY_GZIP_COMPRESSION_VALS
@@ -676,6 +705,7 @@ class TestCreateCompressionNumber(BaseDataset):
         self.assertEqual(dset.compression, 'gzip')
         self.assertEqual(dset.compression_opts, 7)
 
+    @pytest.mark.thread_unsafe(reason="monkey-patch")
     def test_compression_number_invalid(self):
         """ Create with invalid compression numbers  """
         with self.assertRaises(ValueError) as e:
@@ -704,26 +734,29 @@ class TestCreateLZF(BaseDataset):
         Feature: Datasets created with LZF compression
     """
 
-    def test_lzf(self):
-        """ Create with explicit lzf """
-        dset = self.f.create_dataset('foo', (20, 30), compression='lzf')
+    def test_lzf_sparse(self):
+        """ Create with explicit lzf (empty chunks)"""
+        dset = self.f.create_dataset(make_name(), (20, 30), compression='lzf')
         self.assertEqual(dset.compression, 'lzf')
         self.assertEqual(dset.compression_opts, None)
 
+    def test_lzf_dense(self):
+        """ Create with explicit lzf (populated)"""
+        name = make_name()
         testdata = np.arange(100)
-        dset = self.f.create_dataset('bar', data=testdata, compression='lzf')
+        dset = self.f.create_dataset(name, data=testdata, compression='lzf')
         self.assertEqual(dset.compression, 'lzf')
         self.assertEqual(dset.compression_opts, None)
 
         self.f.flush()  # Actually write to file
 
-        readdata = self.f['bar'][()]
+        readdata = self.f[name][()]
         self.assertArrayEqual(readdata, testdata)
 
     def test_lzf_exc(self):
         """ Giving lzf options raises ValueError """
         with self.assertRaises(ValueError):
-            self.f.create_dataset('foo', (20, 30), compression='lzf',
+            self.f.create_dataset(make_name(), (20, 30), compression='lzf',
                                   compression_opts=4)
 
 
@@ -736,7 +769,7 @@ class TestCreateSZIP(BaseDataset):
 
     def test_szip(self):
         """ Create with explicit szip """
-        dset = self.f.create_dataset('foo', (20, 30), compression='szip',
+        dset = self.f.create_dataset(make_name(), (20, 30), compression='szip',
                                      compression_opts=('ec', 16))
 
 
@@ -749,7 +782,7 @@ class TestCreateShuffle(BaseDataset):
 
     def test_shuffle(self):
         """ Enable shuffle filter """
-        dset = self.f.create_dataset('foo', (20, 30), shuffle=True)
+        dset = self.f.create_dataset(make_name(), (20, 30), shuffle=True)
         self.assertTrue(dset.shuffle)
 
 
@@ -761,7 +794,7 @@ class TestCreateFletcher32(BaseDataset):
 
     def test_fletcher32(self):
         """ Enable fletcher32 filter """
-        dset = self.f.create_dataset('foo', (20, 30), fletcher32=True)
+        dset = self.f.create_dataset(make_name(), (20, 30), fletcher32=True)
         self.assertTrue(dset.fletcher32)
 
 
@@ -769,25 +802,28 @@ class TestCreateFletcher32(BaseDataset):
 class TestCreateScaleOffset(BaseDataset):
     """
         Feature: Datasets can use the scale/offset filter
-    """
 
+    Note: loss of precision caused by scaleoffset only becomes visible
+    when closing and reopening the File.
+    Can't close/reopen the shared self.f in pytest-run-parallel.
+    """
     def test_float_fails_without_options(self):
         """ Ensure that a scale factor is required for scaleoffset compression of floating point data """
 
         with self.assertRaises(ValueError):
-            dset = self.f.create_dataset('foo', (20, 30), dtype=float, scaleoffset=True)
+            dset = self.f.create_dataset(make_name(), (20, 30), dtype=float, scaleoffset=True)
 
     def test_non_integer(self):
         """ Check when scaleoffset is negetive"""
 
         with self.assertRaises(ValueError):
-            dset = self.f.create_dataset('foo', (20, 30), dtype=float, scaleoffset=-0.1)
+            dset = self.f.create_dataset(make_name(), (20, 30), dtype=float, scaleoffset=-0.1)
 
     def test_unsupport_dtype(self):
         """ Check when dtype is unsupported type"""
 
         with self.assertRaises(TypeError):
-            dset = self.f.create_dataset('foo', (20, 30), dtype=bool, scaleoffset=True)
+            dset = self.f.create_dataset(make_name(), (20, 30), dtype=bool, scaleoffset=True)
 
     def test_float(self):
         """ Scaleoffset filter works for floating point data """
@@ -796,22 +832,22 @@ class TestCreateScaleOffset(BaseDataset):
         shape = (100, 300)
         range = 20 * 10 ** scalefac
         testdata = (np.random.rand(*shape) - 0.5) * range
+        fname = self.mktemp()
 
-        dset = self.f.create_dataset('foo', shape, dtype=np.float64, scaleoffset=scalefac)
+        with h5py.File(fname, 'w') as f:
+            dset = f.create_dataset(
+                'foo', shape, dtype=np.float64, scaleoffset=scalefac
+            )
+            # Dataset reports that scaleoffset is in use
+            assert dset.scaleoffset is not None
+            # Dataset round-trips
+            dset[...] = testdata
 
-        # Dataset reports that scaleoffset is in use
-        assert dset.scaleoffset is not None
-
-        # Dataset round-trips
-        dset[...] = testdata
-        filename = self.f.filename
-        self.f.close()
-        self.f = h5py.File(filename, 'r')
-        readdata = self.f['foo'][...]
+        with h5py.File(fname, 'r') as f:
+            readdata = f['foo'][...]
 
         # Test that data round-trips to requested precision
         self.assertArrayEqual(readdata, testdata, precision=10 ** (-scalefac))
-
         # Test that the filter is actually active (i.e. compression is lossy)
         assert not (readdata == testdata).all()
 
@@ -821,19 +857,19 @@ class TestCreateScaleOffset(BaseDataset):
         nbits = 12
         shape = (100, 300)
         testdata = np.random.randint(0, 2 ** nbits - 1, size=shape, dtype=np.int64)
+        fname = self.mktemp()
 
-        # Create dataset; note omission of nbits (for library-determined precision)
-        dset = self.f.create_dataset('foo', shape, dtype=np.int64, scaleoffset=True)
+        with h5py.File(fname, 'w') as f:
+            # Create dataset; note omission of nbits (for library-determined precision)
+            dset = f.create_dataset('foo', shape, dtype=np.int64, scaleoffset=True)
+            # Dataset reports scaleoffset enabled
+            assert dset.scaleoffset is not None
+            # Data round-trips correctly and identically
+            dset[...] = testdata
 
-        # Dataset reports scaleoffset enabled
-        assert dset.scaleoffset is not None
+        with h5py.File(fname, 'r') as f:
+            readdata = f['foo'][...]
 
-        # Data round-trips correctly and identically
-        dset[...] = testdata
-        filename = self.f.filename
-        self.f.close()
-        self.f = h5py.File(filename, 'r')
-        readdata = self.f['foo'][...]
         self.assertArrayEqual(readdata, testdata)
 
     def test_int_with_minbits(self):
@@ -842,18 +878,18 @@ class TestCreateScaleOffset(BaseDataset):
         nbits = 12
         shape = (100, 300)
         testdata = np.random.randint(0, 2 ** nbits, size=shape, dtype=np.int64)
+        fname = self.mktemp()
 
-        dset = self.f.create_dataset('foo', shape, dtype=np.int64, scaleoffset=nbits)
+        with h5py.File(fname, 'w') as f:
+            dset = f.create_dataset('foo', shape, dtype=np.int64, scaleoffset=nbits)
+            # Dataset reports scaleoffset enabled with correct precision
+            self.assertTrue(dset.scaleoffset == 12)
+            # Data round-trips correctly
+            dset[...] = testdata
 
-        # Dataset reports scaleoffset enabled with correct precision
-        self.assertTrue(dset.scaleoffset == 12)
+        with h5py.File(fname, 'r') as f:
+            readdata = f['foo'][...]
 
-        # Data round-trips correctly
-        dset[...] = testdata
-        filename = self.f.filename
-        self.f.close()
-        self.f = h5py.File(filename, 'r')
-        readdata = self.f['foo'][...]
         self.assertArrayEqual(readdata, testdata)
 
     def test_int_with_minbits_lossy(self):
@@ -862,18 +898,17 @@ class TestCreateScaleOffset(BaseDataset):
         nbits = 12
         shape = (100, 300)
         testdata = np.random.randint(0, 2 ** (nbits + 1) - 1, size=shape, dtype=np.int64)
+        fname = self.mktemp()
 
-        dset = self.f.create_dataset('foo', shape, dtype=np.int64, scaleoffset=nbits)
+        with h5py.File(fname, 'w') as f:
+            dset = f.create_dataset('foo', shape, dtype=np.int64, scaleoffset=nbits)
+            # Dataset reports scaleoffset enabled with correct precision
+            self.assertTrue(dset.scaleoffset == 12)
+            # Data can be written and read
+            dset[...] = testdata
 
-        # Dataset reports scaleoffset enabled with correct precision
-        self.assertTrue(dset.scaleoffset == 12)
-
-        # Data can be written and read
-        dset[...] = testdata
-        filename = self.f.filename
-        self.f.close()
-        self.f = h5py.File(filename, 'r')
-        readdata = self.f['foo'][...]
+        with h5py.File(fname, 'r') as f:
+            readdata = f['foo'][...]
 
         # Compression is lossy
         assert not (readdata == testdata).all()
@@ -893,7 +928,7 @@ class TestExternal(BaseDataset):
         ext_file = self.mktemp()
         external = [(ext_file, 0, h5f.UNLIMITED)]
         # ${ORIGIN} should be replaced by the parent dir of the HDF5 file
-        dset = self.f.create_dataset('foo', shape, dtype=testdata.dtype, external=external, efile_prefix="${ORIGIN}")
+        dset = self.f.create_dataset(make_name(), shape, dtype=testdata.dtype, external=external, efile_prefix="${ORIGIN}")
         dset[...] = testdata
 
         assert dset.external is not None
@@ -909,7 +944,7 @@ class TestExternal(BaseDataset):
 
     def test_contents_efile_prefix(self):
         """ Create and access an external dataset using an efile_prefix"""
-
+        name = make_name()
         shape = (6, 100)
         testdata = np.random.random(shape)
 
@@ -917,7 +952,7 @@ class TestExternal(BaseDataset):
         ext_file = self.mktemp()
         # set only the basename, let the efile_prefix do the rest
         external = [(os.path.basename(ext_file), 0, h5f.UNLIMITED)]
-        dset = self.f.create_dataset('foo', shape, dtype=testdata.dtype, external=external, efile_prefix=os.path.dirname(ext_file))
+        dset = self.f.create_dataset(name, shape, dtype=testdata.dtype, external=external, efile_prefix=os.path.dirname(ext_file))
         dset[...] = testdata
 
         assert dset.external is not None
@@ -932,19 +967,19 @@ class TestExternal(BaseDataset):
         parent = pathlib.Path(ext_file).parent.as_posix()
         assert efile_prefix == parent
 
-        dset2 = self.f.require_dataset('foo', shape, testdata.dtype, efile_prefix=os.path.dirname(ext_file))
+        dset2 = self.f.require_dataset(name, shape, testdata.dtype, efile_prefix=os.path.dirname(ext_file))
         assert dset2.external is not None
         dset2[()] == testdata
 
     def test_name_str(self):
         """ External argument may be a file name str only """
 
-        self.f.create_dataset('foo', (6, 100), external=self.mktemp())
+        self.f.create_dataset(make_name(), (6, 100), external=self.mktemp())
 
     def test_name_path(self):
         """ External argument may be a file name path only """
 
-        self.f.create_dataset('foo', (6, 100),
+        self.f.create_dataset(make_name(), (6, 100),
                               external=pathlib.Path(self.mktemp()))
 
     def test_iter_multi(self):
@@ -953,7 +988,7 @@ class TestExternal(BaseDataset):
         ext_file = self.mktemp()
         N = 100
         external = iter((ext_file, x * 1000, 1000) for x in range(N))
-        dset = self.f.create_dataset('poo', (6, 100), external=external)
+        dset = self.f.create_dataset(make_name(), (6, 100), external=external)
         assert len(dset.external) == N
 
     def test_invalid(self):
@@ -972,7 +1007,7 @@ class TestExternal(BaseDataset):
             (TypeError, [(ext_file, 0, "h5f.UNLIMITED")]),
         ]:
             with self.assertRaises(exc_type):
-                self.f.create_dataset('foo', shape, external=external)
+                self.f.create_dataset(make_name(), shape, external=external)
 
     def test_create_expandable(self):
         """ Create expandable external dataset """
@@ -980,7 +1015,7 @@ class TestExternal(BaseDataset):
         ext_file = self.mktemp()
         shape = (128, 64)
         maxshape = (None, 64)
-        exp_dset = self.f.create_dataset('foo', shape=shape, maxshape=maxshape,
+        exp_dset = self.f.create_dataset(make_name(), shape=shape, maxshape=maxshape,
                                          external=ext_file)
         assert exp_dset.chunks is None
         assert exp_dset.shape == shape
@@ -1001,78 +1036,95 @@ class TestAutoCreate(BaseDataset):
 
     def test_vlen_bytes(self):
         """Assigning byte strings produces a vlen string ASCII dataset """
-        self.f['x'] = b"Hello there"
-        self.assert_string_type(self.f['x'], h5py.h5t.CSET_ASCII)
+        x = make_name("x")
+        y = make_name("y")
+        z = make_name("z")
 
-        self.f['y'] = [b"a", b"bc"]
-        self.assert_string_type(self.f['y'], h5py.h5t.CSET_ASCII)
+        self.f[x] = b"Hello there"
+        self.assert_string_type(self.f[x], h5py.h5t.CSET_ASCII)
 
-        self.f['z'] = np.array([b"a", b"bc"], dtype=np.object_)
-        self.assert_string_type(self.f['z'], h5py.h5t.CSET_ASCII)
+        self.f[y] = [b"a", b"bc"]
+        self.assert_string_type(self.f[y], h5py.h5t.CSET_ASCII)
+
+        self.f[z] = np.array([b"a", b"bc"], dtype=np.object_)
+        self.assert_string_type(self.f[z], h5py.h5t.CSET_ASCII)
 
     def test_vlen_unicode(self):
         """Assigning unicode strings produces a vlen string UTF-8 dataset """
-        self.f['x'] = "Hello there" + chr(0x2034)
-        self.assert_string_type(self.f['x'], h5py.h5t.CSET_UTF8)
+        x = make_name("x")
+        y = make_name("y")
+        z = make_name("z")
 
-        self.f['y'] = ["a", "bc"]
-        self.assert_string_type(self.f['y'], h5py.h5t.CSET_UTF8)
+        self.f[x] = "Hello there" + chr(0x2034)
+        self.assert_string_type(self.f[x], h5py.h5t.CSET_UTF8)
+
+        self.f[y] = ["a", "bc"]
+        self.assert_string_type(self.f[y], h5py.h5t.CSET_UTF8)
 
         # 2D array; this only works with an array, not nested lists
-        self.f['z'] = np.array([["a", "bc"]], dtype=np.object_)
-        self.assert_string_type(self.f['z'], h5py.h5t.CSET_UTF8)
+        self.f[z] = np.array([["a", "bc"]], dtype=np.object_)
+        self.assert_string_type(self.f[z], h5py.h5t.CSET_UTF8)
 
     def test_string_fixed(self):
         """ Assignment of fixed-length byte string produces a fixed-length
         ascii dataset """
-        self.f['x'] = np.bytes_("Hello there")
-        ds = self.f['x']
+        name = make_name()
+        self.f[name] = np.bytes_("Hello there")
+        ds = self.f[name]
         self.assert_string_type(ds, h5py.h5t.CSET_ASCII, variable=False)
         self.assertEqual(ds.id.get_type().get_size(), 11)
 
 
 class TestCreateLike(BaseDataset):
     def test_no_chunks(self):
-        self.f['lol'] = np.arange(25).reshape(5, 5)
-        self.f.create_dataset_like('like_lol', self.f['lol'])
-        dslike = self.f['like_lol']
+        x = make_name("x")
+        y = make_name("y")
+
+        self.f[x] = np.arange(25).reshape(5, 5)
+        self.f.create_dataset_like(y, self.f[x])
+        dslike = self.f[y]
         self.assertEqual(dslike.shape, (5, 5))
         self.assertIs(dslike.chunks, None)
 
     def test_track_times(self):
-        orig = self.f.create_dataset('honda', data=np.arange(12),
+        x = make_name("x")
+        y = make_name("y")
+        z = make_name("z")
+        w = make_name("w")
+
+        orig = self.f.create_dataset(x, data=np.arange(12),
                                      track_times=True)
         self.assertNotEqual(0, h5py.h5g.get_objinfo(orig._id).mtime)
-        similar = self.f.create_dataset_like('hyundai', orig)
+        similar = self.f.create_dataset_like(y, orig)
         self.assertNotEqual(0, h5py.h5g.get_objinfo(similar._id).mtime)
 
-        orig = self.f.create_dataset('ibm', data=np.arange(12),
+        orig = self.f.create_dataset(z, data=np.arange(12),
                                      track_times=False)
         self.assertEqual(0, h5py.h5g.get_objinfo(orig._id).mtime)
-        similar = self.f.create_dataset_like('lenovo', orig)
+        similar = self.f.create_dataset_like(w, orig)
         self.assertEqual(0, h5py.h5g.get_objinfo(similar._id).mtime)
 
     def test_maxshape(self):
         """ Test when other.maxshape != other.shape """
 
-        other = self.f.create_dataset('other', (10,), maxshape=20)
-        similar = self.f.create_dataset_like('sim', other)
+        other = self.f.create_dataset(make_name("x"), (10,), maxshape=20)
+        similar = self.f.create_dataset_like(make_name("y"), other)
         self.assertEqual(similar.shape, (10,))
         self.assertEqual(similar.maxshape, (20,))
 
 class TestChunkIterator(BaseDataset):
     def test_no_chunks(self):
-        dset = self.f.create_dataset("foo", ())
+        dset = self.f.create_dataset(make_name(), ())
         with self.assertRaises(TypeError):
             dset.iter_chunks()
 
     def test_rank_mismatch(self):
-        dset = self.f.create_dataset("foo", shape=(100,), chunks=(32,))
+        dset = self.f.create_dataset(make_name(), shape=(100,), chunks=(32,))
         with self.assertRaises(ValueError):
             dset.iter_chunks((slice(19,67), 9))
 
     def test_1d(self):
-        dset = self.f.create_dataset("foo", (100,), chunks=(32,))
+        dset = self.f.create_dataset(make_name(), (100,), chunks=(32,))
         expected = ((slice(0,32,1),), (slice(32,64,1),), (slice(64,96,1),),
             (slice(96,100,1),))
         self.assertEqual(list(dset.iter_chunks()), list(expected))
@@ -1084,7 +1136,7 @@ class TestChunkIterator(BaseDataset):
         self.assertEqual(list(dset.iter_chunks(np.s_[96])), list(expected))
 
     def test_2d(self):
-        dset = self.f.create_dataset("foo", (100,100), chunks=(32,64))
+        dset = self.f.create_dataset(make_name(), (100,100), chunks=(32,64))
         expected = (
             (slice(0, 32, 1), slice(0, 64, 1)),
             (slice(0, 32, 1), slice(64, 100, 1)),
@@ -1112,7 +1164,7 @@ class TestChunkIterator(BaseDataset):
         self.assertEqual(list(dset.iter_chunks(np.s_[96,19:67])), list(expected))
 
     def test_2d_partial_slice(self):
-        dset = self.f.create_dataset("foo", (5,5), chunks=(2,2))
+        dset = self.f.create_dataset(make_name(), (5,5), chunks=(2,2))
         expected = ((slice(3, 4, 1), slice(3, 4, 1)),
                    (slice(3, 4, 1), slice(4, 5, 1)),
                    (slice(4, 5, 1), slice(3, 4, 1)),
@@ -1130,22 +1182,24 @@ class TestResize(BaseDataset):
 
     def test_create(self):
         """ Create dataset with "maxshape" """
-        dset = self.f.create_dataset('foo', (20, 30), maxshape=(20, 60))
+        dset = self.f.create_dataset(make_name(), (20, 30), maxshape=(20, 60))
         self.assertIsNot(dset.chunks, None)
         self.assertEqual(dset.maxshape, (20, 60))
 
-    def test_create_1D(self):
-        """ Create dataset with "maxshape" using integer maxshape"""
-        dset = self.f.create_dataset('foo', (20,), maxshape=20)
+    def test_create_1D_integer_maxshape_tuple(self):
+        """ Create dataset with "maxshape" using tuple shape and integer maxshape"""
+        dset = self.f.create_dataset(make_name(), (20,), maxshape=20)
         self.assertIsNot(dset.chunks, None)
         self.assertEqual(dset.maxshape, (20,))
 
-        dset = self.f.create_dataset('bar', 20, maxshape=20)
+    def test_create_1D_integer_maxshape_integer(self):
+        """ Create dataset with "maxshape" using integer shape and integer maxshape"""
+        dset = self.f.create_dataset(make_name(), 20, maxshape=20)
         self.assertEqual(dset.maxshape, (20,))
 
     def test_resize(self):
         """ Datasets may be resized up to maxshape """
-        dset = self.f.create_dataset('foo', (20, 30), maxshape=(20, 60))
+        dset = self.f.create_dataset(make_name(), (20, 30), maxshape=(20, 60))
         self.assertEqual(dset.shape, (20, 30))
         dset.resize((20, 50))
         self.assertEqual(dset.shape, (20, 50))
@@ -1154,38 +1208,38 @@ class TestResize(BaseDataset):
 
     def test_resize_1D(self):
         """ Datasets may be resized up to maxshape using integer maxshape"""
-        dset = self.f.create_dataset('foo', 20, maxshape=40)
+        dset = self.f.create_dataset(make_name(), 20, maxshape=40)
         self.assertEqual(dset.shape, (20,))
         dset.resize((30,))
         self.assertEqual(dset.shape, (30,))
 
     def test_resize_over(self):
         """ Resizing past maxshape triggers an exception """
-        dset = self.f.create_dataset('foo', (20, 30), maxshape=(20, 60))
+        dset = self.f.create_dataset(make_name(), (20, 30), maxshape=(20, 60))
         with self.assertRaises(Exception):
             dset.resize((20, 70))
 
     def test_resize_nonchunked(self):
         """ Resizing non-chunked dataset raises TypeError """
-        dset = self.f.create_dataset("foo", (20, 30))
+        dset = self.f.create_dataset(make_name(), (20, 30))
         with self.assertRaises(TypeError):
             dset.resize((20, 60))
 
     def test_resize_axis(self):
         """ Resize specified axis """
-        dset = self.f.create_dataset('foo', (20, 30), maxshape=(20, 60))
+        dset = self.f.create_dataset(make_name(), (20, 30), maxshape=(20, 60))
         dset.resize(50, axis=1)
         self.assertEqual(dset.shape, (20, 50))
 
     def test_axis_exc(self):
         """ Illegal axis raises ValueError """
-        dset = self.f.create_dataset('foo', (20, 30), maxshape=(20, 60))
+        dset = self.f.create_dataset(make_name(), (20, 30), maxshape=(20, 60))
         with self.assertRaises(ValueError):
             dset.resize(50, axis=2)
 
     def test_zero_dim(self):
         """ Allow zero-length initial dims for unlimited axes (issue 111) """
-        dset = self.f.create_dataset('foo', (15, 0), maxshape=(15, None))
+        dset = self.f.create_dataset(make_name(), (15, 0), maxshape=(15, None))
         self.assertEqual(dset.shape, (15, 0))
         self.assertEqual(dset.maxshape, (15, None))
 
@@ -1198,14 +1252,14 @@ class TestDtype(BaseDataset):
 
     def test_dtype(self):
         """ Retrieve dtype from dataset """
-        dset = self.f.create_dataset('foo', (5,), '|S10')
+        dset = self.f.create_dataset(make_name(), (5,), '|S10')
         self.assertEqual(dset.dtype, np.dtype('|S10'))
 
     def test_dtype_complex32(self):
         """ Retrieve dtype from complex float16 dataset (gh-2156) """
         # No native support in numpy as of v1.23.3, so expect compound type.
         complex32 = np.dtype([('r', np.float16), ('i', np.float16)])
-        dset = self.f.create_dataset('foo', (5,), complex32)
+        dset = self.f.create_dataset(make_name(), (5,), complex32)
         self.assertEqual(dset.dtype, complex32)
 
 
@@ -1217,12 +1271,12 @@ class TestLen(BaseDataset):
 
     def test_len(self):
         """ Python len() (under 32 bits) """
-        dset = self.f.create_dataset('foo', (312, 15))
+        dset = self.f.create_dataset(make_name(), (312, 15))
         self.assertEqual(len(dset), 312)
 
     def test_len_big(self):
         """ Python len() vs Dataset.len() """
-        dset = self.f.create_dataset('foo', (2 ** 33, 15))
+        dset = self.f.create_dataset(make_name(), (2 ** 33, 15))
         self.assertEqual(dset.shape, (2 ** 33, 15))
         if sys.maxsize == 2 ** 31 - 1:
             with self.assertRaises(OverflowError):
@@ -1241,14 +1295,14 @@ class TestIter(BaseDataset):
     def test_iter(self):
         """ Iterating over a dataset yields rows """
         data = np.arange(30, dtype='f').reshape((10, 3))
-        dset = self.f.create_dataset('foo', data=data)
+        dset = self.f.create_dataset(make_name(), data=data)
         for x, y in zip(dset, data, strict=True):
             self.assertEqual(len(x), 3)
             self.assertArrayEqual(x, y)
 
     def test_iter_scalar(self):
         """ Iterating over scalar dataset raises TypeError """
-        dset = self.f.create_dataset('foo', shape=())
+        dset = self.f.create_dataset(make_name(), shape=())
         with self.assertRaises(TypeError):
             [x for x in dset]
 
@@ -1263,7 +1317,7 @@ class TestStrings(BaseDataset):
     def test_vlen_bytes(self):
         """ Vlen bytes dataset maps to vlen ascii in the file """
         dt = h5py.string_dtype(encoding='ascii')
-        ds = self.f.create_dataset('x', (100,), dtype=dt)
+        ds = self.f.create_dataset(make_name(), (100,), dtype=dt)
         tid = ds.id.get_type()
         self.assertEqual(type(tid), h5py.h5t.TypeStringID)
         self.assertEqual(tid.get_cset(), h5py.h5t.CSET_ASCII)
@@ -1274,15 +1328,15 @@ class TestStrings(BaseDataset):
         """ Vlen bytes dataset handles fillvalue """
         dt = h5py.string_dtype(encoding='ascii')
         fill_value = b'bar'
-        ds = self.f.create_dataset('x', (100,), dtype=dt, fillvalue=fill_value)
-        self.assertEqual(self.f['x'][0], fill_value)
-        self.assertEqual(self.f['x'].asstr()[0], fill_value.decode())
-        self.assertEqual(self.f['x'].fillvalue, fill_value)
+        ds = self.f.create_dataset(make_name(), (100,), dtype=dt, fillvalue=fill_value)
+        self.assertEqual(ds[0], fill_value)
+        self.assertEqual(ds.asstr()[0], fill_value.decode())
+        self.assertEqual(ds.fillvalue, fill_value)
 
     def test_vlen_unicode(self):
         """ Vlen unicode dataset maps to vlen utf-8 in the file """
         dt = h5py.string_dtype()
-        ds = self.f.create_dataset('x', (100,), dtype=dt)
+        ds = self.f.create_dataset(make_name(), (100,), dtype=dt)
         tid = ds.id.get_type()
         self.assertEqual(type(tid), h5py.h5t.TypeStringID)
         self.assertEqual(tid.get_cset(), h5py.h5t.CSET_UTF8)
@@ -1293,16 +1347,16 @@ class TestStrings(BaseDataset):
         """ Vlen unicode dataset handles fillvalue """
         dt = h5py.string_dtype()
         fill_value = 'bár'
-        ds = self.f.create_dataset('x', (100,), dtype=dt, fillvalue=fill_value)
-        self.assertEqual(self.f['x'][0], fill_value.encode("utf-8"))
-        self.assertEqual(self.f['x'].asstr()[0], fill_value)
-        self.assertEqual(self.f['x'].fillvalue, fill_value.encode("utf-8"))
+        ds = self.f.create_dataset(make_name(), (100,), dtype=dt, fillvalue=fill_value)
+        self.assertEqual(ds[0], fill_value.encode("utf-8"))
+        self.assertEqual(ds.asstr()[0], fill_value)
+        self.assertEqual(ds.fillvalue, fill_value.encode("utf-8"))
 
     def test_fixed_ascii(self):
         """ Fixed-length bytes dataset maps to fixed-length ascii in the file
         """
         dt = np.dtype("|S10")
-        ds = self.f.create_dataset('x', (100,), dtype=dt)
+        ds = self.f.create_dataset(make_name(), (100,), dtype=dt)
         tid = ds.id.get_type()
         self.assertEqual(type(tid), h5py.h5t.TypeStringID)
         self.assertFalse(tid.is_variable_str())
@@ -1316,14 +1370,14 @@ class TestStrings(BaseDataset):
         """ Vlen bytes dataset handles fillvalue """
         dt = h5py.string_dtype(encoding='ascii', length=10)
         fill_value = b'bar'
-        ds = self.f.create_dataset('x', (100,), dtype=dt, fillvalue=fill_value)
-        self.assertEqual(self.f['x'][0], fill_value)
-        self.assertEqual(self.f['x'].asstr()[0], fill_value.decode())
-        self.assertEqual(self.f['x'].fillvalue, fill_value)
+        ds = self.f.create_dataset(make_name(), (100,), dtype=dt, fillvalue=fill_value)
+        self.assertEqual(ds[0], fill_value)
+        self.assertEqual(ds.asstr()[0], fill_value.decode())
+        self.assertEqual(ds.fillvalue, fill_value)
 
     def test_fixed_utf8(self):
         dt = h5py.string_dtype(encoding='utf-8', length=5)
-        ds = self.f.create_dataset('x', (100,), dtype=dt)
+        ds = self.f.create_dataset(make_name(), (100,), dtype=dt)
         tid = ds.id.get_type()
         self.assertEqual(tid.get_cset(), h5py.h5t.CSET_UTF8)
         s = 'cù'
@@ -1341,22 +1395,22 @@ class TestStrings(BaseDataset):
         """ Vlen unicode dataset handles fillvalue """
         dt = h5py.string_dtype(encoding='utf-8', length=10)
         fill_value = 'bár'.encode("utf-8")
-        ds = self.f.create_dataset('x', (100,), dtype=dt, fillvalue=fill_value)
-        self.assertEqual(self.f['x'][0], fill_value)
-        self.assertEqual(self.f['x'].asstr()[0], fill_value.decode("utf-8"))
-        self.assertEqual(self.f['x'].fillvalue, fill_value)
+        ds = self.f.create_dataset(make_name(), (100,), dtype=dt, fillvalue=fill_value)
+        self.assertEqual(ds[0], fill_value)
+        self.assertEqual(ds.asstr()[0], fill_value.decode("utf-8"))
+        self.assertEqual(ds.fillvalue, fill_value)
 
     def test_fixed_unicode(self):
         """ Fixed-length unicode datasets are unsupported (raise TypeError) """
         dt = np.dtype("|U10")
         with self.assertRaises(TypeError):
-            ds = self.f.create_dataset('x', (100,), dtype=dt)
+            ds = self.f.create_dataset(make_name(), (100,), dtype=dt)
 
     def test_roundtrip_vlen_bytes(self):
         """ writing and reading to vlen bytes dataset preserves type and content
         """
         dt = h5py.string_dtype(encoding='ascii')
-        ds = self.f.create_dataset('x', (100,), dtype=dt)
+        ds = self.f.create_dataset(make_name(), (100,), dtype=dt)
         data = b"Hello\xef"
         ds[0] = data
         out = ds[0]
@@ -1367,7 +1421,7 @@ class TestStrings(BaseDataset):
         """ Writing to and reading from fixed-length bytes dataset preserves
         type and content """
         dt = np.dtype("|S10")
-        ds = self.f.create_dataset('x', (100,), dtype=dt)
+        ds = self.f.create_dataset(make_name(), (100,), dtype=dt)
         data = b"Hello\xef"
         ds[0] = data
         out = ds[0]
@@ -1376,7 +1430,7 @@ class TestStrings(BaseDataset):
 
     def test_retrieve_vlen_unicode(self):
         dt = h5py.string_dtype()
-        ds = self.f.create_dataset('x', (10,), dtype=dt)
+        ds = self.f.create_dataset(make_name(), (10,), dtype=dt)
         data = "fàilte"
         ds[0] = data
         self.assertIsInstance(ds[0], bytes)
@@ -1385,7 +1439,7 @@ class TestStrings(BaseDataset):
         self.assertEqual(out, data)
 
     def test_asstr(self):
-        ds = self.f.create_dataset('x', (10,), dtype=h5py.string_dtype())
+        ds = self.f.create_dataset(make_name(), (10,), dtype=h5py.string_dtype())
         data = "fàilte"
         ds[0] = data
 
@@ -1413,7 +1467,7 @@ class TestStrings(BaseDataset):
 
     def test_asstr_fixed(self):
         dt = h5py.string_dtype(length=5)
-        ds = self.f.create_dataset('x', (10,), dtype=dt)
+        ds = self.f.create_dataset(make_name(), (10,), dtype=dt)
         data = 'cù'
         ds[0] = np.array(data.encode('utf-8'), dtype=dt)
 
@@ -1436,7 +1490,7 @@ class TestStrings(BaseDataset):
     def test_unicode_write_error(self):
         """Encoding error when writing a non-ASCII string to an ASCII vlen dataset"""
         dt = h5py.string_dtype('ascii')
-        ds = self.f.create_dataset('x', (100,), dtype=dt)
+        ds = self.f.create_dataset(make_name(), (100,), dtype=dt)
         data = "fàilte"
         with self.assertRaises(UnicodeEncodeError):
             ds[0] = data
@@ -1445,7 +1499,7 @@ class TestStrings(BaseDataset):
         """ Writing valid utf-8 byte strings to a unicode vlen dataset is OK
         """
         dt = h5py.string_dtype()
-        ds = self.f.create_dataset('x', (100,), dtype=dt)
+        ds = self.f.create_dataset(make_name(), (100,), dtype=dt)
         data = (u"Hello there" + chr(0x2034)).encode('utf8')
         ds[0] = data
         out = ds[0]
@@ -1456,7 +1510,7 @@ class TestStrings(BaseDataset):
         """ Writing an ascii str to ascii vlen dataset is OK
         """
         dt = h5py.string_dtype('ascii')
-        ds = self.f.create_dataset('x', (100,), dtype=dt)
+        ds = self.f.create_dataset(make_name(), (100,), dtype=dt)
         data = "ASCII string"
         ds[0] = data
         out = ds[0]
@@ -1485,8 +1539,9 @@ class TestCompound(BaseDataset):
         for key in dt.fields:
             testdata[key] = np.random.random((16,)) * 100
 
-        self.f['test'] = testdata
-        outdata = self.f['test'][...]
+        name = make_name()
+        self.f[name] = testdata
+        outdata = self.f[name][...]
         self.assertTrue(np.all(outdata == testdata))
         self.assertEqual(outdata.dtype, testdata.dtype)
 
@@ -1498,11 +1553,12 @@ class TestCompound(BaseDataset):
         for key in dt.fields:
             testdata[key] = np.random.random(size=testdata[key].shape) * 100
 
-        ds = self.f.create_dataset('test', (16,), dtype=dt)
+        name = make_name()
+        ds = self.f.create_dataset(name, (16,), dtype=dt)
         for key in dt.fields:
             ds[key] = testdata[key]
 
-        outdata = self.f['test'][...]
+        outdata = self.f[name][...]
 
         self.assertTrue(np.all(outdata == testdata))
         self.assertEqual(outdata.dtype, testdata.dtype)
@@ -1518,29 +1574,31 @@ class TestCompound(BaseDataset):
         for key in dt.fields:
             testdata[key] = np.random.random((16,)) * 100
 
-        self.f['test'] = testdata
+        name = make_name()
+        self.f[name] = testdata
+        ds = self.f[name]
 
         # Extract multiple fields
         np.testing.assert_array_equal(
-            self.f['test'].fields(['x', 'y'])[:], testdata[['x', 'y']]
+            ds.fields(['x', 'y'])[:], testdata[['x', 'y']]
         )
         # Extract single field
         np.testing.assert_array_equal(
-            self.f['test'].fields('x')[:], testdata['x']
+            ds.fields('x')[:], testdata['x']
         )
         # Check __array__() method of fields wrapper
         np.testing.assert_array_equal(
-            np.asarray(self.f['test'].fields(['x', 'y'])), testdata[['x', 'y']]
+            np.asarray(ds.fields(['x', 'y'])), testdata[['x', 'y']]
         )
         # Check type conversion of __array__() method
         dt_int = np.dtype([('x', np.int32)])
         np.testing.assert_array_equal(
-            np.asarray(self.f['test'].fields(['x']), dtype=dt_int),
+            np.asarray(ds.fields(['x']), dtype=dt_int),
             testdata[['x']].astype(dt_int)
         )
 
         # Check len() on fields wrapper
-        assert len(self.f['test'].fields('x')) == 16
+        assert len(ds.fields('x')) == 16
 
     def test_nested_compound_vlen(self):
         dt_inner = np.dtype([('a', h5py.vlen_dtype(np.int32)),
@@ -1559,8 +1617,9 @@ class TestCompound(BaseDataset):
                         (np.array([inner1], dtype=dt_inner), 3)],
                         dtype=dt)
 
-        self.f["ds"] = data
-        out = self.f["ds"]
+        name = make_name()
+        self.f[name] = data
+        out = self.f[name]
 
         # Specifying check_alignment=False because vlen fields have 8 bytes of padding
         # because the vlen datatype in hdf5 occupies 16 bytes
@@ -1569,7 +1628,7 @@ class TestCompound(BaseDataset):
 
 class TestSubarray(BaseDataset):
     def test_write_list(self):
-        ds = self.f.create_dataset("a", (1,), dtype="3int8")
+        ds = self.f.create_dataset(make_name(), (1,), dtype="3int8")
         ds[0] = [1, 2, 3]
         np.testing.assert_array_equal(ds[:], [[1, 2, 3]])
 
@@ -1577,7 +1636,7 @@ class TestSubarray(BaseDataset):
         np.testing.assert_array_equal(ds[:], [[4, 5, 6]])
 
     def test_write_array(self):
-        ds = self.f.create_dataset("a", (1,), dtype="3int8")
+        ds = self.f.create_dataset(make_name(), (1,), dtype="3int8")
         ds[0] = np.array([1, 2, 3])
         np.testing.assert_array_equal(ds[:], [[1, 2, 3]])
 
@@ -1596,7 +1655,7 @@ class TestEnum(BaseDataset):
     def test_create(self):
         """ Enum datasets can be created and type correctly round-trips """
         dt = h5py.enum_dtype(self.EDICT, basetype='i')
-        ds = self.f.create_dataset('x', (100, 100), dtype=dt)
+        ds = self.f.create_dataset(make_name(), (100, 100), dtype=dt)
         dt2 = ds.dtype
         dict2 = h5py.check_enum_dtype(dt2)
         self.assertEqual(dict2, self.EDICT)
@@ -1604,7 +1663,7 @@ class TestEnum(BaseDataset):
     def test_readwrite(self):
         """ Enum datasets can be read/written as integers """
         dt = h5py.enum_dtype(self.EDICT, basetype='i4')
-        ds = self.f.create_dataset('x', (100, 100), dtype=dt)
+        ds = self.f.create_dataset(make_name(), (100, 100), dtype=dt)
         ds[35, 37] = 42
         ds[1, :] = 1
         self.assertEqual(ds[35, 37], 42)
@@ -1618,7 +1677,7 @@ class TestFloats(BaseDataset):
     """
 
     def _exectest(self, dt):
-        dset = self.f.create_dataset('x', (100,), dtype=dt)
+        dset = self.f.create_dataset(make_name(), (100,), dtype=dt)
         self.assertEqual(dset.dtype, dt)
         data = np.ones((100,), dtype=dt)
         dset[...] = data
@@ -1646,14 +1705,14 @@ class TestTrackTimes(BaseDataset):
 
     def test_disable_track_times(self):
         """ check that when track_times=False, the time stamp=0 (Jan 1, 1970) """
-        ds = self.f.create_dataset('foo', (4,), track_times=False)
+        ds = self.f.create_dataset(make_name(), (4,), track_times=False)
         ds_mtime = h5py.h5g.get_objinfo(ds._id).mtime
         self.assertEqual(0, ds_mtime)
 
     def test_invalid_track_times(self):
         """ check that when give track_times an invalid value """
         with self.assertRaises(TypeError):
-            self.f.create_dataset('foo', (4,), track_times='null')
+            self.f.create_dataset(make_name(), (4,), track_times='null')
 
 
 class TestZeroShape(BaseDataset):
@@ -1664,19 +1723,19 @@ class TestZeroShape(BaseDataset):
 
     def test_array_conversion(self):
         """ Empty datasets can be converted to NumPy arrays """
-        ds = self.f.create_dataset('x', 0, maxshape=None)
+        ds = self.f.create_dataset(make_name("x"), 0, maxshape=None)
         self.assertEqual(ds.shape, np.array(ds).shape)
 
-        ds = self.f.create_dataset('y', (0,), maxshape=(None,))
+        ds = self.f.create_dataset(make_name("y"), (0,), maxshape=(None,))
         self.assertEqual(ds.shape, np.array(ds).shape)
 
-        ds = self.f.create_dataset('z', (0, 0), maxshape=(None, None))
+        ds = self.f.create_dataset(make_name("z"), (0, 0), maxshape=(None, None))
         self.assertEqual(ds.shape, np.array(ds).shape)
 
     def test_reading(self):
         """ Slicing into empty datasets works correctly """
         dt = [('a', 'f'), ('b', 'i')]
-        ds = self.f.create_dataset('x', (0,), dtype=dt, maxshape=(None,))
+        ds = self.f.create_dataset(make_name(), (0,), dtype=dt, maxshape=(None,))
         arr = np.empty((0,), dtype=dt)
 
         self.assertEqual(ds[...].shape, arr.shape)
@@ -1710,7 +1769,7 @@ class TestRegionRefs(BaseDataset):
         # Ideally we should preserve shape (0, 100), but it seems this is lost.
 
     def test_scalar_dataset(self):
-        ds = self.f.create_dataset("scalar", data=1.0, dtype='f4')
+        ds = self.f.create_dataset(make_name(), data=1.0, dtype='f4')
         sid = h5py.h5s.create(h5py.h5s.SCALAR)
 
         # Deselected
@@ -1735,19 +1794,19 @@ class TestAstype(BaseDataset):
     """.astype() wrapper & context manager
     """
     def test_astype_wrapper(self):
-        dset = self.f.create_dataset('x', (100,), dtype='i2')
+        dset = self.f.create_dataset(make_name(), (100,), dtype='i2')
         dset[...] = np.arange(100)
         arr = dset.astype('f4')[:]
         self.assertArrayEqual(arr, np.arange(100, dtype='f4'))
 
 
     def test_astype_wrapper_len(self):
-        dset = self.f.create_dataset('x', (100,), dtype='i2')
+        dset = self.f.create_dataset(make_name(), (100,), dtype='i2')
         dset[...] = np.arange(100)
         self.assertEqual(100, len(dset.astype('f4')))
 
     def test_astype_wrapper_asarray(self):
-        dset = self.f.create_dataset('x', (100,), dtype='i2')
+        dset = self.f.create_dataset(make_name(), (100,), dtype='i2')
         dset[...] = np.arange(100)
         arr = np.asarray(dset.astype('f4'), dtype='i2')
         self.assertArrayEqual(arr, np.arange(100, dtype='i2'))
@@ -1763,14 +1822,14 @@ class TestScalarCompound(BaseDataset):
     def test_scalar_compound(self):
 
         dt = np.dtype([('a', 'i')])
-        dset = self.f.create_dataset('x', (), dtype=dt)
+        dset = self.f.create_dataset(make_name(), (), dtype=dt)
         self.assertEqual(dset['a'].dtype, np.dtype('i'))
 
 
 class TestVlen(BaseDataset):
     def test_int(self):
         dt = h5py.vlen_dtype(int)
-        ds = self.f.create_dataset('vlen', (4,), dtype=dt)
+        ds = self.f.create_dataset(make_name(), (4,), dtype=dt)
         ds[0] = np.arange(3)
         ds[1] = np.arange(0)
         ds[2] = [1, 2, 3]
@@ -1788,20 +1847,22 @@ class TestVlen(BaseDataset):
 
     def test_reuse_from_other(self):
         dt = h5py.vlen_dtype(int)
-        ds = self.f.create_dataset('vlen', (1,), dtype=dt)
-        self.f.create_dataset('vlen2', (1,), ds[()].dtype)
+        ds = self.f.create_dataset(make_name("x"), (1,), dtype=dt)
+        self.f.create_dataset(make_name("y"), (1,), ds[()].dtype)
 
     def test_reuse_struct_from_other(self):
         dt = [('a', int), ('b', h5py.vlen_dtype(int))]
-        ds = self.f.create_dataset('vlen', (1,), dtype=dt)
-        fname = self.f.filename
-        self.f.close()
-        self.f = h5py.File(fname, 'a')
-        self.f.create_dataset('vlen2', (1,), self.f['vlen']['b'][()].dtype)
+
+        fname = self.mktemp()
+        with h5py.File(fname, 'w') as f:
+            f.create_dataset("x", (1,), dtype=dt)
+
+        with h5py.File(fname, 'a') as f:
+            f.create_dataset("y", (1,), f["x"]['b'][()].dtype)
 
     def test_convert(self):
         dt = h5py.vlen_dtype(int)
-        ds = self.f.create_dataset('vlen', (3,), dtype=dt)
+        ds = self.f.create_dataset(make_name(), (3,), dtype=dt)
         ds[0] = np.array([1.4, 1.2])
         ds[1] = np.array([1.2])
         ds[2] = [1.2, 2, 3]
@@ -1818,21 +1879,20 @@ class TestVlen(BaseDataset):
 
     def test_multidim(self):
         dt = h5py.vlen_dtype(int)
-        ds = self.f.create_dataset('vlen', (2, 2), dtype=dt)
+        ds = self.f.create_dataset(make_name(), (2, 2), dtype=dt)
         ds[0, 0] = np.arange(1)
         ds[:, :] = np.array([[np.arange(3), np.arange(2)],
                             [np.arange(1), np.arange(2)]], dtype=object)
         ds[:, :] = np.array([[np.arange(2), np.arange(2)],
                              [np.arange(2), np.arange(2)]])
 
-    def _help_float_testing(self, np_dt, dataset_name='vlen'):
+    def _help_float_testing(self, np_dt):
         """
         Helper for testing various vlen numpy data types.
         :param np_dt: Numpy datatype to test
-        :param dataset_name: String name of the dataset to create for testing.
         """
         dt = h5py.vlen_dtype(np_dt)
-        ds = self.f.create_dataset(dataset_name, (5,), dtype=dt)
+        ds = self.f.create_dataset(make_name(), (5,), dtype=dt)
 
         # Create some arrays, and assign them to the dataset
         array_0 = np.array([1., 2., 30.], dtype=np_dt)
@@ -1871,7 +1931,8 @@ class TestVlen(BaseDataset):
 
         # Make sure we can close the file.
         self.f.flush()
-        self.f.close()
+        if is_main_thread():
+            self.f.close()
 
     def test_numpy_float16(self):
         np_dt = np.dtype('float16')
@@ -1889,24 +1950,29 @@ class TestVlen(BaseDataset):
         np_dt = np.float64
         self._help_float_testing(np_dt)
 
-    def test_non_contiguous_arrays(self):
+    def test_non_contiguous_arrays_bool(self):
         """Test that non-contiguous arrays are stored correctly"""
-        self.f.create_dataset('nc', (10,), dtype=h5py.vlen_dtype('bool'))
+        name = make_name()
+        self.f.create_dataset(name, (10,), dtype=h5py.vlen_dtype('bool'))
+        ds = self.f[name]
         x = np.array([True, False, True, True, False, False, False])
-        self.f['nc'][0] = x[::2]
+        ds[0] = x[::2]
 
-        assert all(self.f['nc'][0] == x[::2]), f"{self.f['nc'][0]} != {x[::2]}"
+        assert all(ds[0] == x[::2]), f"{ds[0]} != {x[::2]}"
 
-        self.f.create_dataset('nc2', (10,), dtype=h5py.vlen_dtype('int8'))
+    def test_non_contiguous_arrays_int(self):
+        name = make_name()
+        self.f.create_dataset(name, (10,), dtype=h5py.vlen_dtype('int8'))
+        ds = self.f[name]
         y = np.array([2, 4, 1, 5, -1, 3, 7])
-        self.f['nc2'][0] = y[::2]
+        ds[0] = y[::2]
 
-        assert all(self.f['nc2'][0] == y[::2]), f"{self.f['nc2'][0]} != {y[::2]}"
+        assert all(ds[0] == y[::2]), f"{ds[0]} != {y[::2]}"
 
     def test_asstr_array_dtype(self):
         dt = h5py.string_dtype(encoding='ascii')
         fill_value = b'bar'
-        ds = self.f.create_dataset('x', (100,), dtype=dt, fillvalue=fill_value)
+        ds = self.f.create_dataset(make_name(), (100,), dtype=dt, fillvalue=fill_value)
         with pytest.raises(ValueError):
             np.array(ds.asstr(), dtype=int)
 
@@ -1915,28 +1981,30 @@ class TestLowOpen(BaseDataset):
 
     def test_get_access_list(self):
         """ Test H5Dget_access_plist """
-        ds = self.f.create_dataset('foo', (4,))
+        ds = self.f.create_dataset(make_name(), (4,))
         p_list = ds.id.get_access_plist()
 
     def test_dapl(self):
         """ Test the dapl keyword to h5d.open """
+        name = make_name()
         dapl = h5py.h5p.create(h5py.h5p.DATASET_ACCESS)
-        dset = self.f.create_dataset('x', (100,))
+        dset = self.f.create_dataset(name, (100,))
         del dset
-        dsid = h5py.h5d.open(self.f.id, b'x', dapl)
+        dsid = h5py.h5d.open(self.f.id, name.encode('utf-8'), dapl)
         self.assertIsInstance(dsid, h5py.h5d.DatasetID)
 
 
 def test_get_chunk_details():
     from io import BytesIO
     buf = BytesIO()
+    name = make_name()
     with h5py.File(buf, 'w') as fout:
-        fout.create_dataset('test', shape=(100, 100), chunks=(10, 10), dtype='i4')
-        fout['test'][:] = 1
+        fout.create_dataset(name, shape=(100, 100), chunks=(10, 10), dtype='i4')
+        fout[name][:] = 1
 
     buf.seek(0)
     with h5py.File(buf, 'r') as fin:
-        ds = fin['test'].id
+        ds = fin[name].id
 
         assert ds.get_num_chunks() == 100
         for j in range(100):
@@ -1962,13 +2030,14 @@ def test_chunk_iter():
     """H5Dchunk_iter() for chunk information"""
     from io import BytesIO
     buf = BytesIO()
+    name = make_name()
     with h5py.File(buf, 'w') as f:
-        f.create_dataset('test', shape=(100, 100), chunks=(10, 10), dtype='i4')
-        f['test'][:] = 1
+        f.create_dataset(name, shape=(100, 100), chunks=(10, 10), dtype='i4')
+        f[name][:] = 1
 
     buf.seek(0)
     with h5py.File(buf, 'r') as f:
-        dsid = f['test'].id
+        dsid = f[name].id
 
         num_chunks = dsid.get_num_chunks()
         assert num_chunks == 100
@@ -1988,7 +2057,7 @@ def test_chunk_iter():
 
 
 def test_empty_shape(writable_file):
-    ds = writable_file.create_dataset('empty', dtype='int32')
+    ds = writable_file.create_dataset(make_name(), dtype='int32')
     assert ds.shape is None
     assert ds.maxshape is None
 
@@ -2012,7 +2081,7 @@ def test_python_int_uint64(writable_file):
     data = [np.iinfo(np.int64).max, np.iinfo(np.int64).max + 1]
 
     # Check creating a new dataset
-    ds = writable_file.create_dataset('x', data=data, dtype=np.uint64)
+    ds = writable_file.create_dataset(make_name(), data=data, dtype=np.uint64)
     assert ds.dtype == np.dtype(np.uint64)
     np.testing.assert_array_equal(ds[:], np.array(data, dtype=np.uint64))
 
@@ -2023,7 +2092,7 @@ def test_python_int_uint64(writable_file):
 
 def test_setitem_fancy_indexing(writable_file):
     # https://github.com/h5py/h5py/issues/1593
-    arr = writable_file.create_dataset('data', (5, 1000, 2), dtype=np.uint8)
+    arr = writable_file.create_dataset(make_name(), (5, 1000, 2), dtype=np.uint8)
     block = np.random.randint(255, size=(5, 3, 2))
     arr[:, [0, 2, 4], ...] = block
 
@@ -2042,7 +2111,7 @@ def test_allow_unknown_filter(writable_file):
     # apparently 256-511 are reserved for testing purposes
     fake_filter_id = 256
     ds = writable_file.create_dataset(
-        'data', shape=(10, 10), dtype=np.uint8, compression=fake_filter_id,
+        make_name(), shape=(10, 10), dtype=np.uint8, compression=fake_filter_id,
         allow_unknown_filter=True
     )
     assert str(fake_filter_id) in ds._filters
@@ -2052,9 +2121,11 @@ def test_dset_chunk_cache():
     """Chunk cache configuration for individual datasets."""
     from io import BytesIO
     buf = BytesIO()
+    name = make_name()
+
     with h5py.File(buf, 'w') as fout:
         ds = fout.create_dataset(
-            'x', shape=(10, 20), chunks=(5, 4), dtype='i4',
+            name, shape=(10, 20), chunks=(5, 4), dtype='i4',
             rdcc_nbytes=2 * 1024 * 1024, rdcc_w0=0.2, rdcc_nslots=997)
         ds_chunk_cache = ds.id.get_access_plist().get_chunk_cache()
         assert fout.id.get_access_plist().get_cache()[1:] != ds_chunk_cache
@@ -2063,7 +2134,7 @@ def test_dset_chunk_cache():
     buf.seek(0)
     with h5py.File(buf, 'r') as fin:
         ds = fin.require_dataset(
-            'x', shape=(10, 20), dtype='i4',
+            name, shape=(10, 20), dtype='i4',
             rdcc_nbytes=3 * 1024 * 1024, rdcc_w0=0.67, rdcc_nslots=709)
         ds_chunk_cache = ds.id.get_access_plist().get_chunk_cache()
         assert fin.id.get_access_plist().get_cache()[1:] != ds_chunk_cache
@@ -2081,7 +2152,7 @@ class TestCommutative(BaseDataset):
         Check that it returns symmetric response to == and !=
         """
         shape = (100,1)
-        dset = self.f.create_dataset("test", shape, dtype=float,
+        dset = self.f.create_dataset(make_name(), shape, dtype=float,
                                      data=np.random.rand(*shape))
 
         # grab a value from the elements, ie dset[0, 0]
@@ -2106,7 +2177,7 @@ class TestCommutative(BaseDataset):
         not meaningful.
         """
         shape = (100,1)
-        dset = self.f.create_dataset("test", shape, dtype=float,
+        dset = self.f.create_dataset(make_name(), shape, dtype=float,
                                      data=np.random.rand(*shape))
 
         # generate float type, sample float(0.)
@@ -2122,7 +2193,7 @@ class TestVirtualPrefix(BaseDataset):
     def test_virtual_prefix_create(self):
         shape = (100,1)
         virtual_prefix = "/path/to/virtual"
-        dset = self.f.create_dataset("test", shape, dtype=float,
+        dset = self.f.create_dataset(make_name(), shape, dtype=float,
                                      data=np.random.rand(*shape),
                                      virtual_prefix = virtual_prefix)
 
@@ -2131,7 +2202,7 @@ class TestVirtualPrefix(BaseDataset):
 
     def test_virtual_prefix_require(self):
         virtual_prefix = "/path/to/virtual"
-        dset = self.f.require_dataset('foo', (10, 3), 'f', virtual_prefix = virtual_prefix)
+        dset = self.f.require_dataset(make_name(), (10, 3), 'f', virtual_prefix = virtual_prefix)
         virtual_prefix_readback = pathlib.Path(dset.id.get_access_plist().get_virtual_prefix().decode()).as_posix()
         self.assertEqual(virtual_prefix, virtual_prefix_readback)
         self.assertIsInstance(dset, Dataset)
@@ -2141,7 +2212,7 @@ class TestVirtualPrefix(BaseDataset):
 def ds_str(file, shape=(10, )):
     dt = h5py.string_dtype(encoding='ascii')
     fill_value = b'fill'
-    return file.create_dataset('x', shape, dtype=dt, fillvalue=fill_value)
+    return file.create_dataset(make_name(), shape, dtype=dt, fillvalue=fill_value)
 
 
 def ds_fields(file, shape=(10, )):
@@ -2150,8 +2221,9 @@ def ds_fields(file, shape=(10, )):
         ('bar', np.float64),
     ])
     fill_value = np.asarray(('fill', 0.0), dtype=dt)
-    file['x'] = np.broadcast_to(fill_value, shape)
-    return file['x']
+    name = make_name()
+    file[name] = np.broadcast_to(fill_value, shape)
+    return file[name]
 
 
 view_getters = pytest.mark.parametrize(
@@ -2221,6 +2293,7 @@ def test_view_properties(view_getter, make_ds, writable_file):
     assert len(view) == 5
 
 
+@pytest.mark.thread_unsafe(reason="spawns thread pool itself")
 def test_concurrent_dataset_creation(writable_file):
     N_THREADS = 25
     N_DATASETS_PER_THREAD = 5

--- a/h5py/tests/test_dataset_getitem.py
+++ b/h5py/tests/test_dataset_getitem.py
@@ -47,7 +47,7 @@ import numpy as np
 import pytest
 
 import h5py
-from .common import ut, TestCase
+from .common import ut, TestCase, make_name
 
 
 class TestEmpty(TestCase):
@@ -595,7 +595,11 @@ def test_read_no_fill_value(writable_file):
     dcpl.set_chunk((1,))
     dcpl.set_fill_time(h5py.h5d.FILL_TIME_NEVER)
     ds = h5py.Dataset(h5py.h5d.create(
-        writable_file.id, b'a', h5py.h5t.IEEE_F64LE, h5py.h5s.create_simple((5,)), dcpl
+        writable_file.id,
+        make_name().encode("utf-8"),
+        h5py.h5t.IEEE_F64LE,
+        h5py.h5s.create_simple((5,)),
+        dcpl,
     ))
     np.testing.assert_array_equal(ds[:3], np.zeros(3, np.float64))
 
@@ -620,6 +624,6 @@ class TestBoolIndex(TestCase):
 
 
 def test_error_newaxis(writable_file):
-    ds = writable_file.create_dataset('a', data=np.arange(5))
+    ds = writable_file.create_dataset(make_name(), data=np.arange(5))
     with pytest.raises(TypeError, match="newaxis"):
         ds[np.newaxis, :]

--- a/h5py/tests/test_dataset_swmr.py
+++ b/h5py/tests/test_dataset_swmr.py
@@ -1,4 +1,6 @@
 import numpy as np
+import pytest
+
 import h5py
 
 from .common import TestCase
@@ -44,6 +46,8 @@ class TestDatasetSwmrRead(TestCase):
             self.f.swmr_mode = False
         self.assertTrue(self.f.swmr_mode)
 
+
+@pytest.mark.thread_unsafe(reason="Can't enable global SWMR flag twice")
 class TestDatasetSwmrWrite(TestCase):
     """ Testing SWMR functions when reading a dataset.
     Skip this test if the HDF5 library does not have the SWMR features.

--- a/h5py/tests/test_datatype.py
+++ b/h5py/tests/test_datatype.py
@@ -15,7 +15,7 @@
 
 import numpy as np
 
-from .common import TestCase
+from .common import TestCase, is_main_thread, make_name
 
 from h5py import Datatype
 
@@ -27,12 +27,13 @@ class TestCreation(TestCase):
 
     def test_repr(self):
         """ repr() on datatype objects """
-        self.f['foo'] = np.dtype('S10')
-        dt = self.f['foo']
+        name = make_name()
+        self.f[name] = np.dtype('S10')
+        dt = self.f[name]
         self.assertIsInstance(repr(dt), str)
-        self.f.close()
-        self.assertIsInstance(repr(dt), str)
-
+        if is_main_thread():
+            self.f.close()
+            self.assertIsInstance(repr(dt), str)
 
     def test_appropriate_low_level_id(self):
         " Binding a group to a non-TypeID identifier fails with ValueError "

--- a/h5py/tests/test_dims_dimensionproxy.py
+++ b/h5py/tests/test_dims_dimensionproxy.py
@@ -12,11 +12,11 @@
 """
 
 
-from .common import TestCase
+from .common import TestCase, make_name
 
 class TestItems(TestCase):
 
     def test_empty(self):
         """ no dimension scales -> empty list """
-        dset = self.f.create_dataset('x', (10,))
+        dset = self.f.create_dataset(make_name(), (10,))
         self.assertEqual(dset.dims[0].items(), [])

--- a/h5py/tests/test_errors.py
+++ b/h5py/tests/test_errors.py
@@ -12,7 +12,11 @@
 """
 
 import threading
+
+import pytest
+
 import h5py
+from .common import make_name
 
 
 def _access_not_existing_object(filename):
@@ -24,6 +28,7 @@ def _access_not_existing_object(filename):
             pass
 
 
+@pytest.mark.thread_unsafe(reason="Changes global state")
 def test_unsilence_errors(tmp_path, capfd):
     """Check that HDF5 errors can be muted/unmuted from h5py"""
     filename = tmp_path / 'test.h5'
@@ -53,7 +58,7 @@ def test_thread_hdf5_silence_error_membership(tmp_path, capfd):
     No console messages should be shown from membership tests
     """
     th = threading.Thread(target=_access_not_existing_object,
-                          args=(tmp_path / 'test.h5',))
+                          args=(tmp_path / make_name("{}.h5"),))
     th.start()
     th.join()
 
@@ -68,7 +73,7 @@ def test_thread_hdf5_silence_error_attr(tmp_path, capfd):
     No console messages should be shown for non-existing attributes
     """
     def test():
-        with h5py.File(tmp_path/'test.h5', 'w') as newfile:
+        with h5py.File(tmp_path/make_name("{}.h5"), 'w') as newfile:
             newfile['newdata'] = [1, 2, 3]
             try:
                 nonexistent_attr = newfile['newdata'].attrs['nonexistent_attr']

--- a/h5py/tests/test_file_alignment.py
+++ b/h5py/tests/test_file_alignment.py
@@ -1,3 +1,5 @@
+import pytest
+
 import h5py
 from .common import TestCase
 
@@ -43,6 +45,7 @@ class TestFileAlignment(TestCase):
             else:
                 raise RuntimeError("Data was all found to be aligned to 4096")
 
+    @pytest.mark.parallel_threads(2)  # Quite slow otherwise
     def test_alignment_set_above_threshold(self):
         # 2022/01/19 hmaarrfk
         # UnitTest (TestCase) doesn't play well with pytest parametrization.

--- a/h5py/tests/test_h5d_direct_chunk.py
+++ b/h5py/tests/test_h5d_direct_chunk.py
@@ -3,7 +3,7 @@ import numpy
 import numpy.testing
 import pytest
 
-from .common import ut, TestCase
+from .common import ut, TestCase, make_name
 
 
 class TestWriteDirectChunk(TestCase):
@@ -119,7 +119,7 @@ class TestReadDirectChunkToOut:
     def test_uncompressed_data(self, writable_file):
         ref_data = numpy.arange(16).reshape(4, 4)
         dataset = writable_file.create_dataset(
-            "uncompressed", data=ref_data, chunks=ref_data.shape)
+            make_name(), data=ref_data, chunks=ref_data.shape)
 
         out = bytearray(ref_data.nbytes)
         filter_mask, chunk = dataset.id.read_direct_chunk((0, 0), out=out)
@@ -138,7 +138,7 @@ class TestReadDirectChunkToOut:
     def test_compressed_data(self, writable_file):
         ref_data = numpy.arange(16).reshape(4, 4)
         dataset = writable_file.create_dataset(
-            "gzip",
+            make_name(),
             data=ref_data,
             chunks=ref_data.shape,
             compression="gzip",
@@ -158,7 +158,7 @@ class TestReadDirectChunkToOut:
     def test_fail_buffer_too_small(self, writable_file):
         ref_data = numpy.arange(16).reshape(4, 4)
         dataset = writable_file.create_dataset(
-            "uncompressed", data=ref_data, chunks=ref_data.shape)
+            make_name(), data=ref_data, chunks=ref_data.shape)
 
         out = bytearray(ref_data.nbytes // 2)
         with pytest.raises(ValueError):
@@ -167,7 +167,7 @@ class TestReadDirectChunkToOut:
     def test_fail_buffer_readonly(self, writable_file):
         ref_data = numpy.arange(16).reshape(4, 4)
         dataset = writable_file.create_dataset(
-            "uncompressed", data=ref_data, chunks=ref_data.shape)
+            make_name(), data=ref_data, chunks=ref_data.shape)
 
         out = bytes(ref_data.nbytes)
         with pytest.raises(BufferError):
@@ -176,7 +176,7 @@ class TestReadDirectChunkToOut:
     def test_fail_buffer_not_contiguous(self, writable_file):
         ref_data = numpy.arange(16).reshape(4, 4)
         dataset = writable_file.create_dataset(
-            "uncompressed", data=ref_data, chunks=ref_data.shape)
+            make_name(), data=ref_data, chunks=ref_data.shape)
 
         array = numpy.empty(ref_data.shape + (2,), dtype=ref_data.dtype)
         out = array[:, :, ::2]  # Array is not contiguous

--- a/h5py/tests/test_h5f.py
+++ b/h5py/tests/test_h5f.py
@@ -19,7 +19,7 @@ from .common import ut, TestCase
 
 class TestFileID(TestCase):
     def test_descriptor_core(self):
-        with File('TestFileID.test_descriptor_core', driver='core',
+        with File(self.mktemp(), driver='core',
                   backing_store=False, mode='x') as f:
             assert isinstance(f.id.get_vfd_handle(), int)
 

--- a/h5py/tests/test_h5o.py
+++ b/h5py/tests/test_h5o.py
@@ -1,6 +1,6 @@
 import pytest
 
-from .common import TestCase
+from .common import TestCase, make_name
 from h5py import File
 
 
@@ -15,7 +15,7 @@ class TestVisit(TestCase):
     def test_visit(self):
         fname = self.mktemp()
         fid = File(fname, 'w')
-        fid.create_dataset('foo', (100,), dtype='uint8')
+        fid.create_dataset(make_name(), (100,), dtype='uint8')
         with pytest.raises(SampleException, match='throwing exception'):
             fid.visititems(throwing)
         fid.close()

--- a/h5py/tests/test_h5z.py
+++ b/h5py/tests/test_h5z.py
@@ -44,6 +44,7 @@ class H5ZClass2T(Structure):
     ]
 
 
+@pytest.mark.thread_unsafe(reason="fixed filter_id")
 def test_register_filter():
     filter_id = 256  # Test ID
 

--- a/h5py/tests/test_objects.py
+++ b/h5py/tests/test_objects.py
@@ -8,9 +8,10 @@
 #           and contributor agreement.
 import os
 import threading
+import time
 from unittest import SkipTest
 
-import time
+import pytest
 
 from h5py import _objects as o
 from .common import TestCase
@@ -40,6 +41,7 @@ class TestObjects(TestCase):
         with self.assertRaises(TypeError):
             hash(oid)
 
+    @pytest.mark.thread_unsafe(reason="fork() from a thread may deadlock")
     def test_phil_fork_with_threads(self):
         # Test that handling of the phil Lock after fork is correct.
         # We simulate a deadlock in the forked process by explicitly

--- a/h5py/tests/test_selections.py
+++ b/h5py/tests/test_selections.py
@@ -16,7 +16,7 @@ import h5py
 import h5py._hl.selections as sel
 import h5py._hl.selections2 as sel2
 
-from .common import TestCase
+from .common import TestCase, make_name
 
 class BaseSelection(TestCase):
     def setUp(self):
@@ -88,7 +88,7 @@ class TestScalarSliceRules(BaseSelection):
         with self.assertRaises(ValueError):
             shape, selection = sel2.read_selections_scalar(self.dsid, (1,))
 
-        dsid = self.f.create_dataset('y', (1,)).id
+        dsid = self.f.create_dataset(make_name(), (1,)).id
         with self.assertRaises(RuntimeError):
             shape, selection = sel2.read_selections_scalar(dsid, (1,))
 
@@ -98,7 +98,7 @@ class TestSelection(BaseSelection):
     """
 
     def test_selection(self):
-        dset = self.f.create_dataset('dset', (100,100))
+        dset = self.f.create_dataset(make_name(), (100,100))
         regref = dset.regionref[0:100, 0:100]
 
         # args is list, return a FancySelection

--- a/h5py/tests/test_vds/test_lowlevel_vds.py
+++ b/h5py/tests/test_vds/test_lowlevel_vds.py
@@ -9,7 +9,7 @@ import tempfile
 import numpy as np
 
 import h5py as h5
-from ..common import ut
+from ..common import ut, make_name
 
 
 class TestEigerLowLevel(ut.TestCase):
@@ -29,7 +29,7 @@ class TestEigerLowLevel(ut.TestCase):
         self.fname = [osp.join(self.working_dir.name, ix) for ix in self.fname]
 
     def test_eiger_low_level(self):
-        outfile = osp.join(self.working_dir.name, 'eiger.h5')
+        outfile = osp.join(self.working_dir.name, make_name('eiger{}.h5'))
         with h5.File(outfile, 'w', libver='latest') as f:
             vdset_shape = (78, 200, 200)
             vdset_max_shape = vdset_shape
@@ -134,7 +134,7 @@ class TestExcaliburLowLevel(ut.TestCase):
     def test_excalibur_low_level(self):
 
         excalibur_data = self.edata
-        outfile = osp.join(self.working_dir.name, 'excalibur.h5')
+        outfile = osp.join(self.working_dir.name, make_name('excalibur{}.h5'))
         vdset_stripe_shape = (1,) + excalibur_data.fem_stripe_dimensions
         vdset_stripe_max_shape = (5, ) + excalibur_data.fem_stripe_dimensions
         vdset_shape = (5,
@@ -217,7 +217,7 @@ class TestPercivalLowLevel(ut.TestCase):
         self.fname = [osp.join(self.working_dir.name, ix) for ix in self.fname]
 
     def test_percival_low_level(self):
-        outfile = osp.join(self.working_dir.name, 'percival.h5')
+        outfile = osp.join(self.working_dir.name, make_name('percival{}.h5'))
 
         with h5.File(outfile, 'w', libver='latest') as f:
             vdset_shape = (1,200,200)
@@ -268,8 +268,8 @@ class TestPercivalLowLevel(ut.TestCase):
 
 
 def test_virtual_prefix(tmp_path):
-    a = tmp_path / 'a'
-    b = tmp_path / 'b'
+    a = tmp_path / make_name('a')
+    b = tmp_path / make_name('b')
     a.mkdir()
     b.mkdir()
     src_file = h5.File(a / 'src.h5', 'w')

--- a/h5py/tests/test_vds/test_virtual_source.py
+++ b/h5py/tests/test_vds/test_virtual_source.py
@@ -1,4 +1,4 @@
-from ..common import ut
+from ..common import ut, make_name
 import h5py as h5
 import numpy as np
 
@@ -141,7 +141,7 @@ class TestVirtualSource(ut.TestCase):
         self.assertEqual(dataset.maxshape, (30,))
 
     def test_extra_args(self):
-        with h5.File(name='f1', driver='core',
+        with h5.File(make_name("f1{}.h5"), driver='core',
                      backing_store=False, mode='w') as ftest:
             ftest['a'] = [1, 2, 3]
             a = ftest['a']

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,10 @@
 markers =
     network: Tests requiring network access, skipped with --no-network
     slow: Slow tests
+    # These definitions suppress pytest warnings when
+    # pytest-run-parallel is not installed
+    parallel_threads: Number of threads to use in pytest-run-parallel
+    thread_unsafe: Tests that must run on a single thread in pytest-run-parallel
 filterwarnings =
     error
 required_plugins = pytest-mpi


### PR DESCRIPTION
Supersedes #2588

pytest-run-parallel operates as follows:
1. run setUp / setup_method, once
2. spawn many threads
3. run a single test in parallel. All variables created by setUp (`self.XXX`) are shared.
4. join threads
5. run tearDown / teardown_method, once

In the vast majority of h5py tests, `setUp` is used to open a `h5py.File` (and sometimes populate it with test data).

In preparation to running the whole test suite with pytest-run-parallel, preempt name collisions when two threads operate on the same file; this is done by randomizing dataset/group/attribute names.
As per @takluyver's request (#2588), on regular serial pytest runs these names will instead be deterministic to simplify debugging.

Read https://github.com/h5py/h5py/issues/2475#issuecomment-3197457594 for more context and follow-up work.