### PR TITLE
CLN: cleanup unused import statement

### DIFF
--- a/h5py/_hl/attrs.py
+++ b/h5py/_hl/attrs.py
@@ -15,7 +15,6 @@
 """
 
 import numpy
-import uuid
 
 from .. import h5, h5s, h5t, h5a, h5p
 from . import base


### PR DESCRIPTION
follow up to #2660. This is the only unused import left outside an `__init__` module