### PR TITLE
ENH: add a `filepath` attribute to `File` and `ExternalLink` instances

### DIFF
--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -14,6 +14,7 @@
 import inspect
 import os
 import sys
+from pathlib import Path
 from warnings import warn
 
 from .compat import filename_decode, filename_encode
@@ -293,9 +294,15 @@ class File(Group):
 
     @property
     @with_phil
-    def filename(self):
+    def filename(self) -> str:
         """File name on disk"""
         return filename_decode(h5f.get_name(self.id))
+
+    @property
+    @with_phil
+    def filepath(self) -> Path:
+        """File path on disk"""
+        return Path(self.filename).resolve()
 
     @property
     @with_phil

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -12,6 +12,7 @@
 """
 
 from contextlib import contextmanager
+from pathlib import Path
 import posixpath as pp
 import numpy
 
@@ -793,16 +794,21 @@ class ExternalLink:
     """
 
     @property
-    def path(self):
+    def path(self) -> str:
         """ Soft link path, i.e. the part inside the HDF5 file. """
         return self._path
 
     @property
-    def filename(self):
-        """ Path to the external HDF5 file in the filesystem. """
+    def filename(self) -> str:
+        """ Path to the external HDF5 file in the filesystem (as a str)"""
         return self._filename
 
-    def __init__(self, filename, path):
+    @property
+    def filepath(self) -> Path:
+        """ Path to the external HDF5 file in the filesystem. """
+        return Path(self._path, self._filename).resolve()
+
+    def __init__(self, filename: str, path: str) -> None:
         self._filename = filename_decode(filename_encode(filename))
         self._path = path
 

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -902,8 +902,8 @@ class TestExternal(BaseDataset):
             contents = fid.read()
         assert contents == testdata.tobytes()
 
-        efile_prefix = pathlib.Path(dset.id.get_access_plist().get_efile_prefix().decode()).as_posix()
-        parent = pathlib.Path(self.f.filename).parent.as_posix()
+        efile_prefix = pathlib.Path(dset.id.get_access_plist().get_efile_prefix().decode()).resolve().as_posix()
+        parent = self.f.filepath.parent.as_posix()
         assert efile_prefix == parent
 
     def test_contents_efile_prefix(self):

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -667,6 +667,7 @@ class TestUnicode(TestCase):
         try:
             self.assertEqual(fid.filename, fname)
             self.assertIsInstance(fid.filename, str)
+            self.assertIsInstance(fid.filepath, pathlib.Path)
         finally:
             fid.close()
 
@@ -800,6 +801,7 @@ class TestFilename(TestCase):
         try:
             self.assertEqual(fid.filename, fname)
             self.assertIsInstance(fid.filename, str)
+            self.assertIsInstance(fid.filepath, pathlib.Path)
         finally:
             fid.close()
 
@@ -866,9 +868,12 @@ class TestPathlibSupport(TestCase):
             path = pathlib.Path(f)
             with File(path, 'w') as h5f1:
                 pathlib_name = h5f1.filename
+                pathlib_path = h5f1.filepath
             with File(f, 'w') as h5f2:
                 normal_name = h5f2.filename
+                normal_path = h5f2.filepath
             self.assertEqual(pathlib_name, normal_name)
+            self.assertEqual(pathlib_path, normal_path)
 
 
 class TestPickle(TestCase):

--- a/h5py/tests/test_group.py
+++ b/h5py/tests/test_group.py
@@ -19,7 +19,7 @@
 
 import numpy as np
 import os
-import os.path
+from pathlib import Path
 from tempfile import mkdtemp
 
 from collections.abc import MutableMapping
@@ -882,6 +882,7 @@ class TestExternalLinks(TestCase):
         el = ExternalLink('foo.hdf5', '/foo')
         self.assertEqual(el.filename, 'foo.hdf5')
         self.assertEqual(el.path, '/foo')
+        self.assertEqual(el.filepath, Path(el.path, el.filename).resolve())
 
     def test_erepr(self):
         """ External link repr """

--- a/news/pathlib-support.rst
+++ b/news/pathlib-support.rst
@@ -1,0 +1,5 @@
+New features
+------------
+
+* ``h5py.File`` and ``h5py.ExternalLink`` gained a ``filepath`` attribute,
+  representing the on-disk location of the object as a ``pathlib.Path``.


### PR DESCRIPTION
Seems to complete the API quite nicely