### PR TITLE
BUG: fix an unreleased bug where the `track_times` argument to `File` was ignored

### DIFF
--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -556,9 +556,9 @@ class File(Group):
                                  alignment_interval=alignment_interval,
                                  meta_block_size=meta_block_size,
                                  **kwds)
-                fcpl = make_fcpl(track_order=track_order, fs_strategy=fs_strategy,
-                                 fs_persist=fs_persist, fs_threshold=fs_threshold,
-                                 fs_page_size=fs_page_size)
+                fcpl = make_fcpl(track_order=track_order, track_times=track_times,
+                                 fs_strategy=fs_strategy, fs_persist=fs_persist,
+                                 fs_threshold=fs_threshold, fs_page_size=fs_page_size)
                 fid = make_fid(name, mode, userblock_size, fapl, fcpl, swmr=swmr)
 
             if isinstance(libver, tuple):


### PR DESCRIPTION
This looks like an oversight from #2611

We could easily catch such mistakes before merge in the future by enabling a linter. Specifically I'm thinking of https://docs.astral.sh/ruff/rules/#flake8-unused-arguments-arg
Any objections ?

Furthermore, this should have been caught by the test suite, but it wasn't, which is a strong hint that we're missing a test case. I don't know the details enough to do that myself quite yet, and I actually caught this while working on something else. Suggestions welcome. Otherwise, I'll circle back to it eventually.
