### PR TITLE
RFC: use direct `os` import statements and reduce complexity in `filename_(en|de)code` helper functions

### DIFF
--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -25,13 +25,13 @@ import numpy as np
 # lock acquisition.
 from .._objects import phil, with_phil
 from .. import h5d, h5i, h5r, h5p, h5f, h5t, h5s
-from .compat import fspath, filename_encode
+from .compat import filename_encode
 
 
 def is_hdf5(fname):
     """ Determine if a file is valid HDF5 (False if it doesn't exist). """
     with phil:
-        fname = os.path.abspath(fspath(fname))
+        fname = os.path.abspath(os.fspath(fname))
 
         if os.path.isfile(fname):
             return h5f.is_hdf5(filename_encode(fname))

--- a/h5py/_hl/compat.py
+++ b/h5py/_hl/compat.py
@@ -1,8 +1,8 @@
 """
 Compatibility module for high-level h5py
 """
+import os
 import sys
-from os import fspath, fsencode, fsdecode
 from ..version import hdf5_built_version_tuple
 
 # HDF5 supported passing paths as UTF-8 for Windows from 1.10.6, but this
@@ -22,12 +22,11 @@ def filename_encode(filename):
     called on any filenames passed to the HDF5 library. See the documentation on
     filenames in h5py for more information.
     """
-    filename = fspath(filename)
-    if sys.platform == "win32":
-        if isinstance(filename, str):
-            return filename.encode(WINDOWS_ENCODING, "strict")
-        return filename
-    return fsencode(filename)
+    filename = os.fspath(filename)
+    if sys.platform == "win32" and isinstance(filename, str):
+        return filename.encode(WINDOWS_ENCODING, "strict")
+    else:
+        return os.fsencode(filename)
 
 
 def filename_decode(filename):
@@ -38,11 +37,10 @@ def filename_decode(filename):
     called on any filenames passed from the HDF5 library. See the documentation
     on filenames in h5py for more information.
     """
-    if sys.platform == "win32":
-        if isinstance(filename, bytes):
-            return filename.decode(WINDOWS_ENCODING, "strict")
-        elif isinstance(filename, str):
-            return filename
-        else:
-            raise TypeError("expect bytes or str, not %s" % type(filename).__name__)
-    return fsdecode(filename)
+    if not isinstance(filename, (str, bytes)):
+        raise TypeError(f"expect bytes or str, not {type(filename).__name__}")
+
+    if sys.platform == "win32" and isinstance(filename, bytes):
+        return filename.decode(WINDOWS_ENCODING, "strict")
+    else:
+        return os.fsdecode(filename)


### PR DESCRIPTION
A small quality upgrade, inspired by #2664