### PR TITLE
DOC: fix a couple quirks in `h5py.File`'s docstring

### DIFF
--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -400,7 +400,8 @@ class File(Group):
             recommended), 'core', 'sec2', 'direct', 'stdio', 'mpio', 'ros3'.
         libver
             Library version bounds.  Supported values: 'earliest', 'v108',
-            'v110', 'v112', 'v114' and 'latest'.
+            'v110', 'v112', 'v114', 'v200' and 'latest' depending on the
+            version of libhdf5 h5py is built against.
         userblock_size
             Desired size of user block.  Only allowed when creating a new
             file (mode w, w- or x).


### PR DESCRIPTION
- `'v114'` was missing from `libver`'s list of valid values
- `rdcc_nslot`'s position in the docstring didn't match the one it occupies in the signature
