### PR TITLE
allow for system endianness in dataset repr tests

### DIFF
--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -46,10 +46,11 @@ class TestRepr(BaseDataset):
     """
         Feature: repr(Dataset) behaves sensibly
     """
+    endian_mark = '>' if sys.byteorder=='big' else '<'
 
     def test_repr_basic(self):
         ds = self.f.create_dataset('foo', (4,), dtype='int32')
-        assert repr(ds) == '<HDF5 dataset "foo": shape (4,), type "<i4">'
+        assert repr(ds) == f'<HDF5 dataset "foo": shape (4,), type "{self.endian_mark}i4">'
 
     def test_repr_closed(self):
         """ repr() works on live and dead datasets """
@@ -59,7 +60,7 @@ class TestRepr(BaseDataset):
 
     def test_repr_anonymous(self):
         ds = self.f.create_dataset(None, (4,), dtype='int32')
-        assert repr(ds) == '<HDF5 dataset (anonymous): shape (4,), type "<i4">'
+        assert repr(ds) == f'<HDF5 dataset (anonymous): shape (4,), type "{self.endian_mark}i4">'
 
 
 class TestCreateShape(BaseDataset):


### PR DESCRIPTION
repr tests in test_dataset.py included a little-endian marker type "<i4", which was causing the tests to fail on bigendian systems like [s390x](https://buildd.debian.org/status/fetch.php?pkg=h5py&arch=s390x&ver=3.14.0-1&stamp=1756309533&raw=0).

This patch checks `sys.byteorder` and uses `>` instead of `<` on bigendian systems.

Closes: #2669
