### PR TITLE
RFC: set explicit strict arguments in `zip` calls

### DIFF
--- a/examples/threading_example.py
+++ b/examples/threading_example.py
@@ -202,7 +202,7 @@ class ComputeWidget:
 
         for entry, val in zip((self.nxfield, self.nyfield, self.escapefield,
                 self.startxfield, self.startyfield, self.extentxfield,
-                self.extentyfield), suggestions[self.suggest]):
+                self.extentyfield), suggestions[self.suggest], strict=True):
             entry.delete(0, 999)
             entry.insert(0, repr(val))
 

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -66,6 +66,9 @@ def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
     # Validate chunk shape
     if isinstance(chunks, int) and not isinstance(chunks, bool):
         chunks = (chunks,)
+    # Logically, the following `zip`` could be strict, but it's happening
+    # before we've done checks elsewhere that raise more descriptive errors
+    # (like "chunks" must have same rank as dataset shape).
     if isinstance(chunks, tuple) and any(
         chunk > dim for dim, chunk in zip(tmp_shape, chunks, strict=False) if dim is not None
     ):

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -67,7 +67,7 @@ def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
     if isinstance(chunks, int) and not isinstance(chunks, bool):
         chunks = (chunks,)
     if isinstance(chunks, tuple) and any(
-        chunk > dim for dim, chunk in zip(tmp_shape, chunks) if dim is not None
+        chunk > dim for dim, chunk in zip(tmp_shape, chunks, strict=False) if dim is not None
     ):
         errmsg = "Chunk shape must not be greater than data shape in any dimension. "\
                  "{} is not compatible with {}".format(chunks, shape)

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -66,9 +66,8 @@ def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
     # Validate chunk shape
     if isinstance(chunks, int) and not isinstance(chunks, bool):
         chunks = (chunks,)
-    # Logically, the following `zip`` could be strict, but it's happening
+    # Logically, the following `zip` could be strict, but it's happening
     # before we've done checks elsewhere that raise more descriptive errors
-    # (like "chunks" must have same rank as dataset shape).
     if isinstance(chunks, tuple) and any(
         chunk > dim for dim, chunk in zip(tmp_shape, chunks, strict=False) if dim is not None
     ):

--- a/h5py/_hl/selections.py
+++ b/h5py/_hl/selections.py
@@ -222,7 +222,7 @@ class SimpleSelection(Selection):
     @property
     def array_shape(self):
         scalar = self._sel[3]
-        return tuple(x for x, s in zip(self.mshape, scalar) if not s)
+        return tuple(x for x, s in zip(self.mshape, scalar, strict=True) if not s)
 
     def __init__(self, shape, spaceid=None, hyperslab=None):
         super().__init__(shape, spaceid)
@@ -294,7 +294,7 @@ class SimpleSelection(Selection):
         if any(d == 0 for d in count):
             return
 
-        chunks = tuple(x//y for x, y in zip(count, tshape))
+        chunks = tuple(x//y for x, y in zip(count, tshape, strict=True))
         nchunks = product(chunks)
 
         if nchunks == 1:
@@ -303,7 +303,7 @@ class SimpleSelection(Selection):
             sid = self._id.copy()
             sid.select_hyperslab((0,)*rank, tshape, step)
             for idx in range(nchunks):
-                offset = tuple(x*y*z + s for x, y, z, s in zip(np.unravel_index(idx, chunks), tshape, step, start))
+                offset = tuple(x*y*z + s for x, y, z, s in zip(np.unravel_index(idx, chunks), tshape, step, start, strict=True))
                 sid.offset_simple(offset)
                 yield sid
 

--- a/h5py/tests/common.py
+++ b/h5py/tests/common.py
@@ -141,7 +141,7 @@ class TestCase(ut.TestCase):
             assert np.all(np.abs(dset[...] - arr[...]) < precision), \
                 "Arrays differ by more than %.3f%s" % (precision, message)
         elif arr.dtype.kind == 'O':
-            for v1, v2 in zip(dset.flat, arr.flat):
+            for v1, v2 in zip(dset.flat, arr.flat, strict=True):
                 self.assertArrayEqual(v1, v2, message=message, precision=precision, check_alignment=check_alignment)
         else:
             assert np.all(dset[...] == arr[...]), \

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1242,7 +1242,7 @@ class TestIter(BaseDataset):
         """ Iterating over a dataset yields rows """
         data = np.arange(30, dtype='f').reshape((10, 3))
         dset = self.f.create_dataset('foo', data=data)
-        for x, y in zip(dset, data):
+        for x, y in zip(dset, data, strict=True):
             self.assertEqual(len(x), 3)
             self.assertArrayEqual(x, y)
 

--- a/h5py/tests/test_group.py
+++ b/h5py/tests/test_group.py
@@ -715,7 +715,7 @@ class TestVisitLinks(TestCase):
         self.links = [
             'linkto_grp1', 'grp1/linkto_grp11', 'grp1/linkto_grp12', 'linkto_grp2', 'grp2/linkto_grp21', 'grp2/grp21/linkto_grp211'
         ]
-        for g, l in zip(self.groups, self.links):
+        for g, l in zip(self.groups, self.links, strict=True):
             self.f.create_group(g)
             self.f[l] = SoftLink(f'/{g}')
 

--- a/h5py/tests/test_h5t.py
+++ b/h5py/tests/test_h5t.py
@@ -44,7 +44,7 @@ class TestCompound(ut.TestCase):
 
         tid = h5t.create(h5t.COMPOUND, size)
         for name, offset, dt in zip(
-                type_dict["names"], type_dict["offsets"], type_dict["formats"]
+                type_dict["names"], type_dict["offsets"], type_dict["formats"], strict=True
         ):
             tid.insert(
                 name.encode("utf8") if isinstance(name, str) else name,


### PR DESCRIPTION
This is a pet peeve of mine; now that we dropped Python 3.9, we have access to the `strict` kwarg in `zip`, which, in a better world, would default to `strict=True`, but doesn't for backward compat reasons. I want to stress test against CI and see if *any* of these actually need the implicit `strict=False` behavior.

for reference, I ensured my search was thorough by seeding the patch with
```
ruff check --select B905 --fix
```
but then changed `strict=False` to `strict=True`