### PR TITLE
RFC: set explicit exception chains in raise-in-except-blocks

### DIFF
--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -751,7 +751,7 @@ class Dataset(HLObject):
                 try:
                     newlen = int(size)
                 except TypeError:
-                    raise TypeError("Argument must be a single int if axis is specified")
+                    raise TypeError("Argument must be a single int if axis is specified") from None
                 size = list(self.shape)
                 size[axis] = newlen
 

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -170,8 +170,8 @@ def make_fapl(
 
     try:
         set_fapl = _drivers[driver]
-    except KeyError:
-        raise ValueError('Unknown driver type "%s"' % driver)
+    except KeyError as exc:
+        raise ValueError(f'Unknown driver type {driver!r}') from exc
     else:
         if driver == 'ros3':
             token = kwds.pop('session_token', None)
@@ -229,7 +229,7 @@ def make_fid(name, mode, userblock_size, fapl, fcpl=None, swmr=False):
         try:
             userblock_size = int(userblock_size)
         except (TypeError, ValueError):
-            raise ValueError("User block size must be an integer")
+            raise ValueError("User block size must be an integer") from None
         if fcpl is None:
             fcpl = h5p.create(h5p.FILE_CREATE)
         fcpl.set_userblock(userblock_size)

--- a/h5py/_hl/filters.py
+++ b/h5py/_hl/filters.py
@@ -173,10 +173,10 @@ def fill_dcpl(plist, shape, dtype, chunks, compression, compression_opts,
             return
         try:
             tpl = tuple(tpl)
-        except TypeError:
-            raise TypeError('"%s" argument must be None or a sequence object' % name)
+        except TypeError as exc:
+            raise TypeError(f'{name!r} argument must be None or a sequence object') from exc
         if len(tpl) != len(shape):
-            raise ValueError('"%s" must have same rank as dataset shape' % name)
+            raise ValueError(f'{name!r} must have same rank as dataset shape')
 
     rq_tuple(chunks, 'chunks')
     rq_tuple(maxshape, 'maxshape')
@@ -208,8 +208,8 @@ def fill_dcpl(plist, shape, dtype, chunks, compression, compression_opts,
             err = "SZIP options must be a 2-tuple ('ec'|'nn', even integer 0-32)"
             try:
                 szmethod, szpix = compression_opts
-            except TypeError:
-                raise TypeError(err)
+            except TypeError as exc:
+                raise TypeError(err) from exc
             if szmethod not in ('ec', 'nn'):
                 raise ValueError(err)
             if not (0<szpix<=32 and szpix%2 == 0):

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -290,9 +290,9 @@ class Group(HLObject, MutableMappingHDF5):
             try:
                 dsid = dataset.open_dset(self, self._e(name), **kwds)
                 dset = dataset.Dataset(dsid)
-            except KeyError:
+            except KeyError as exc:
                 dset = self[name]
-                raise TypeError("Incompatible object (%s) already exists" % dset.__class__.__name__)
+                raise TypeError(f"Incompatible object ({dset.__class__.__name__}) already exists") from exc
 
             if shape != dset.shape:
                 if "maxshape" not in kwds:
@@ -421,8 +421,8 @@ class Group(HLObject, MutableMappingHDF5):
                     return {h5o.TYPE_GROUP: Group,
                             h5o.TYPE_DATASET: dataset.Dataset,
                             h5o.TYPE_NAMED_DATATYPE: datatype.Datatype}[typecode]
-                except KeyError:
-                    raise TypeError("Unknown object type")
+                except KeyError as exc:
+                    raise TypeError("Unknown object type") from exc
 
             elif getlink:
                 typecode = self.id.links.get_info(self._e(name), lapl=self._lapl).type

--- a/h5py/tests/test_file2.py
+++ b/h5py/tests/test_file2.py
@@ -105,7 +105,7 @@ class TestDriverRegistration(TestCase):
             fname = self.mktemp()
             h5py.File(fname, driver='new-driver', mode='w')
 
-        self.assertEqual(str(e.exception), 'Unknown driver type "new-driver"')
+        self.assertEqual(str(e.exception), "Unknown driver type 'new-driver'")
 
 
 class TestCache(TestCase):


### PR DESCRIPTION
A small quality of life improvement that I found while setting up a linter.
These were detected with
```
ruff check --select B904
```

