### PR TITLE
CLN: cleanup unused import statements and variables

### DIFF
--- a/ci/get_hdf5_win.py
+++ b/ci/get_hdf5_win.py
@@ -10,7 +10,7 @@ CI environment which thrown away each time
 from os import environ, makedirs, walk, getcwd, chdir
 from os.path import join as pjoin, exists, basename, dirname, abspath
 from tempfile import TemporaryFile, TemporaryDirectory
-from sys import exit, stderr
+from sys import stderr
 from shutil import copy
 from glob import glob
 from subprocess import run

--- a/ci/upload_coverage.py
+++ b/ci/upload_coverage.py
@@ -79,9 +79,9 @@ def get_pr_azure_ci():
 def send_coverage(*, workdir, coverage_files, codecov_token):
     chdir(workdir)
     run_with_python(['coverage', 'combine'] + coverage_files)
-    msg(f"Combined coverage")
+    msg("Combined coverage")
     run_with_python(['coverage', 'xml', '--ignore-errors'])
-    msg(f"Created coverage xml")
+    msg("Created coverage xml")
 
     # Upload coverage.xml to codecov
     codecov_args = []

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,8 +12,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
-import os
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/h5py/tests/test_h5f.py
+++ b/h5py/tests/test_h5f.py
@@ -15,7 +15,6 @@ from h5py import File, special_dtype
 from h5py._hl.files import direct_vfd
 
 from .common import ut, TestCase
-from .common import ut, TestCase
 
 
 class TestFileID(TestCase):


### PR DESCRIPTION
This is obtained with
```
ruff check --select F --fix
```
(excluding any autofixes marked as unsafe for now)