### PR TITLE
REL: automate sdist creation alongside wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -37,6 +37,25 @@ permissions:
   contents: write
 
 jobs:
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+      with:
+        python-version: 3.13
+    - name: Build sdist
+      run: |
+        pipx run build --sdist
+        pipx run twine check --strict dist/*
+    - name: Upload sdist
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: sdist
+        path: dist/*.tar.gz
+
   build_wheels:
     name: 'Wheels: ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.python }}'
     runs-on: ${{ matrix.os }}
@@ -109,15 +128,24 @@ jobs:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
-  upload_wheels:
-    name: Upload wheels
-    needs: build_wheels
+  upload_artifacts:
+    name: Upload build artifacts
+    needs:
+      - build_sdist
+      - build_wheels
     runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash -el {0}
     steps:
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+      - name: Download sdist
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: sdist
+          path: dist
+        if: github.repository_owner == 'h5py' && github.event_name == 'push' && github.ref_type == 'tag'
+      - name: Download wheels
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           pattern: cibw-wheels-*
           merge-multiple: true

--- a/docs/release_guide.rst
+++ b/docs/release_guide.rst
@@ -33,20 +33,15 @@ Steps to make an h5py release:
    other maintainers to check it as well.
 6. When everything looks good, merge the PR.
 7. Checkout the master branch, pull, make and push the tag, which will cause
-   CI to build wheels & make a GitHub release::
+   CI to build sdist, wheels & make a GitHub release::
 
     git switch master
     git pull
     git tag 3.14.0  # <-- change this
     git push --tags
 
-8. Prepare the sdist::
-
-    git clean -xfdi
-    python -m build --sdist
-
-9. Download the wheels: ``gh release download 3.14.0 -D dist/``
-10. Upload to PyPI: ``twine upload dist/h5py-3.14.0*`` - this requires a token
+8. Download the artifacts: ``gh release download 3.14.0 -D dist/``
+9. Upload to PyPI: ``twine upload dist/h5py-3.14.0*`` - this requires a token
     from PyPI, which must be `supplied to twine <https://twine.readthedocs.io/en/stable/#configuration>`_.
-11. Close the GitHub milestone for this release and open one for the next
+10. Close the GitHub milestone for this release and open one for the next
     version.


### PR DESCRIPTION
A quick follow up to https://github.com/h5py/h5py/pull/2592, simplifying the release process a bit

I can also set up auto-publication as proposed there, but I'll reserve this for a later PR
update: this is #2685
