### PR TITLE
MNT: simplify cibuildwheel setup

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -93,12 +93,6 @@ jobs:
 
       # Now actually build the wheels
       - uses: pypa/cibuildwheel@c923d83ad9c1bc00211c5041d0c3f73294ff88f6 # v3.1.4
-        env:
-          CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_BUILD: ${{ env.CIBW_BUILD }}
-          CIBW_BEFORE_BUILD: ${{ env.CIBW_BEFORE_BUILD }}
-          CIBW_BUILD_FRONTEND: ${{ env.CIBW_BUILD_FRONTEND }}
-          CIBW_ENABLE: ${{ env.CIBW_ENABLE }}
 
       - run: python ./ci/bundle_hdf5_whl.py wheelhouse
         if: runner.os == 'Windows'

--- a/ci/triage_build.sh
+++ b/ci/triage_build.sh
@@ -20,7 +20,7 @@ KIND="$RUNNER_OS $ARCH"
 
 # If it's a scheduled build or [pip-pre] in commit message, use pip-pre
 if [[ "$GITHUB_EVENT_NAME" == "schedule" ]] || [[ "$MSG" = *'[pip-pre]'* ]]; then
-    echo "Using NumPy pip-pre wheel and, setting CIBW_BEFORE_BUILD, CIBW_BUILD_FRONTEND and CIBW_ENABLE"
+    echo "Using NumPy pip-pre wheel and, setting CIBW_BEFORE_BUILD and CIBW_BUILD_FRONTEND"
     echo "CIBW_BEFORE_BUILD=pip install --pre --only-binary numpy --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \"numpy>=2.0.0.dev0\" \"Cython>=0.29.31,<4\" pkgconfig \"setuptools>=77\"" | tee -a $GITHUB_ENV
     echo "CIBW_BUILD_FRONTEND=pip; args: --no-build-isolation" | tee -a $GITHUB_ENV
 fi
@@ -31,4 +31,3 @@ PYTHON="${PYTHON%-dev*}"
 # replace dots in PYTHON with nothing, e.g., 3.8->38
 CIBW_BUILD="cp${PYTHON//./}-*_$ARCH"
 echo "CIBW_BUILD=$CIBW_BUILD" | tee -a $GITHUB_ENV
-echo "CIBW_ENABLE=$CIBW_ENABLE" | tee -a $GITHUB_ENV


### PR DESCRIPTION
Explanation: unconditionally setting `CIBW_*` env variables is redundant and a footgun.

- redundant, because all variable we *want* to set dynamically via, e.g., `ci/triage_build.sh`, are already exported to `$GITHUB_ENV`
- a footgun, because if there's nothing to pass, we still define env vars as empty strings, which will take precedent over any corresponding option defined in the `[tool.cibuildwheel]` static table. This costed me longer than I care to admit to realise, so I'd like to simplify the setup before I forget and become subject to the same costly mistake again.