### PR TITLE
BLD: cleanup setuptools subclassing, drop unused and deprecated build dependencies on distutils and wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "Cython >=3.0.0,<4",
     "numpy >=2.0.0, <3",
     "pkgconfig",
-    "setuptools >=77",
+    "setuptools >=77.0.1",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ if setup_configure.mpi_enabled():
 if os.environ.get('H5PY_SETUP_REQUIRES', '1') == '0':
     SETUP_REQUIRES = []
 
-# --- Custom Distutils commands -----------------------------------------------
+# --- Custom setuptools commands -----------------------------------------------
 
 CMDCLASS = {'build_ext': setup_build.h5py_build_ext}
 

--- a/setup_build.py
+++ b/setup_build.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-    Implements a custom Distutils build_ext replacement, which handles the
+    Implements a custom build_ext replacement, which handles the
     full extension module build process, from api_gen to C compilation and
     linking.
 """
@@ -15,7 +15,7 @@ from pathlib import Path
 
 from Cython import Tempita as tempita
 from setuptools import Extension
-from distutils.command.build_ext import build_ext
+from setuptools.command.build_ext import build_ext
 
 import api_gen
 from setup_configure import BuildConfig
@@ -76,7 +76,7 @@ if sys.platform.startswith('win'):
 class h5py_build_ext(build_ext):
 
     """
-        Custom distutils command which encapsulates api_gen pre-building,
+        Custom setuptools command which encapsulates api_gen pre-building,
         Cython building, and C compilation.
 
         Also handles making the Extension modules, since we can't rely on
@@ -199,12 +199,16 @@ class h5py_build_ext(build_ext):
         }
         # Run Cython
         print("Executing cythonize()")
-        self.extensions = cythonize(self._make_extensions(config, templ_config),
-                                    force=config.changed() or self.force,
-                                    language_level=3)
+        self.extensions = self.distribution.ext_modules = cythonize(
+            self._make_extensions(config, templ_config),
+            force=config.changed() or self.force,
+            language_level=3
+        )
 
         # Perform the build
-        build_ext.run(self)
+        self.swig_opts = None # workaround https://github.com/pypa/setuptools/pull/5083
+        self.finalize_options()
+        super().run()
 
         # Record the configuration we built
         config.record_built()

--- a/setup_build.py
+++ b/setup_build.py
@@ -5,11 +5,6 @@
     linking.
 """
 
-try:
-    from setuptools import Extension
-except ImportError:
-    from distutils.extension import Extension
-from distutils.command.build_ext import build_ext
 import copy
 import sys
 import sysconfig
@@ -17,7 +12,11 @@ import os
 import os.path as op
 import platform
 from pathlib import Path
+
 from Cython import Tempita as tempita
+from setuptools import Extension
+from distutils.command.build_ext import build_ext
+
 import api_gen
 from setup_configure import BuildConfig
 

--- a/setup_configure.py
+++ b/setup_configure.py
@@ -1,6 +1,6 @@
 
 """
-    Implements a new custom Distutils command for handling library
+    Implements a new custom setuptools command for handling library
     configuration.
 
     The "configure" command exists to provide a set of attributes that are


### PR DESCRIPTION
This contains a handful of small improvements I found while working on #2589 that can be merged independently.

Most importantly: moving `cythonize` call from `bdist_ext.run` to `bdist_ext.finalize_options` is crucial to avoid hacky patches in #2589, because `finalize_options` is called first, and is responsible for setting the `py_limited_api` attribute on `self.extensions` (which need to be already set at this point).

Furthermore, doing the rounds there allowed me to rid the code of both `wheel` and `distutils` as direct build dependencies, as they are both vendored by setuptools already *and* deprecated as APIs.