### PR TITLE
MNT: cleanup obsolete workaround for tox issue 2442

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -54,8 +54,6 @@ basepython = python3.10
 
 [testenv:docs]
 skip_install=True
-# Work around https://github.com/tox-dev/tox/issues/2442
-package_env = DUMMY NON-EXISTENT ENV NAME
 changedir=docs
 deps=
     -r docs/requirements-rtd.txt
@@ -71,8 +69,6 @@ commands=
 
 [testenv:checkreadme]
 skip_install=True
-# Work around https://github.com/tox-dev/tox/issues/2442
-package_env = DUMMY NON-EXISTENT ENV NAME
 dependency_groups =
     check-readme
 commands=
@@ -81,8 +77,6 @@ commands=
 
 [testenv:checkmanifest]
 skip_install=True
-# Work around https://github.com/tox-dev/tox/issues/2442
-package_env = DUMMY NON-EXISTENT ENV NAME
 dependency_groups=
     check-manifest
 commands=
@@ -90,8 +84,6 @@ commands=
 
 [testenv:pre-commit]
 skip_install=True
-# Work around https://github.com/tox-dev/tox/issues/2442
-package_env = DUMMY NON-EXISTENT ENV NAME
 dependency_groups =
     lint
 passenv =


### PR DESCRIPTION
we already require tox 4.22, released less than a year ago, while the issue has been resolved for 3 years

xref: https://github.com/tox-dev/tox/pull/2800
