### PR TITLE
TST/MNT: skip caching HDF5 on Linux CI

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -71,6 +71,7 @@ jobs:
         with:
           key: ${{ matrix.os }}-${{ matrix.arch }}-6
           path: cache/hdf5
+        if: runner.os != 'Linux'
 
       # Windows HDF5
       - uses: nuget/setup-nuget@323ab0502cd38fdc493335025a96c8fdb0edc71f # v2.0.1


### PR DESCRIPTION
As noted by @takluyver in #2646, we don't actually install HDF5 on Linux CI because it's already present in our custum manylinux/musllinux images, so we can also skip caching.