### PR TITLE
SEC: fix security issues with GHA detected with zizmor

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -43,6 +43,8 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        persist-credentials: false
     - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       with:
         python-version: 3.13
@@ -79,6 +81,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0  # get the non-merge commit for PRs
+          persist-credentials: false
 
       # Get HDF5 outside of cibuildwheel so that we can set env vars via GITHUB_ENV
       # inside the HDF5-getting scripts and have them be in effect for the
@@ -90,6 +93,7 @@ jobs:
         with:
           key: ${{ matrix.os }}-${{ matrix.arch }}-6
           path: cache/hdf5
+          lookup-only: true
         if: runner.os != 'Linux'
 
       # Windows HDF5
@@ -142,6 +146,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0  # get the non-merge commit for PRs
+          persist-credentials: false
 
       # Triage build
       - run: bash ./ci/triage_build.sh "${{ matrix.arch }}" "${{ github.event.pull_request.head.sha || github.sha }}"
@@ -194,7 +199,7 @@ jobs:
         id: vars
         run: |
           set -eo pipefail
-          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             RELEASE_NAME=""  # will use the tag name, which we always set to the release name
             GENERATE=false
           else

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -34,7 +34,6 @@ on:
 
 permissions:
   actions: read
-  contents: write
 
 jobs:
   build_sdist:

--- a/.github/workflows/lowlevel-api-docs.yml
+++ b/.github/workflows/lowlevel-api-docs.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   api-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       HDF5_VERSION: 1.14.6
       HDF5_DIR: ${{ github.workspace }}/cache/hdf5

--- a/.github/workflows/lowlevel-api-docs.yml
+++ b/.github/workflows/lowlevel-api-docs.yml
@@ -18,6 +18,8 @@ jobs:
       TOXENV: apidocs
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Cache HDF5
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,5 +7,10 @@ repos:
     -   id: trailing-whitespace
         exclude: .+\.patch
 
+- repo: https://github.com/zizmorcore/zizmor-pre-commit
+  rev: v1.13.0
+  hooks:
+    - id: zizmor
+
 ci:
     autoupdate_schedule: monthly


### PR DESCRIPTION
In #2685, @takluyver suggested that we should be even more cautious on security if we're going to automate most of the release process with GHA using PyPI'ss trusted publishing. Here I'm setting up `zizmor` as a pre-commit hook for continuous auditing and using it to resolve existing issues in this area, including but not limited to, excessively permissive permission settings.