### PR TITLE
CI: give the upload artifacts job more power

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -161,6 +161,8 @@ jobs:
 
   upload_artifacts:
     name: Upload build artifacts
+    permissions:
+      actions: write
     needs:
       - build_sdist
       - build_wheels


### PR DESCRIPTION
Fixes a bug introduced in #2696 which over-restricted permission causing failures: 
https://github.com/h5py/h5py/actions/runs/17894803441/job/50880501354