### PR TITLE
CI: fix permission settings for wheel upload again

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -162,7 +162,7 @@ jobs:
   upload_artifacts:
     name: Upload build artifacts
     permissions:
-      actions: write
+      contents: write
     needs:
       - build_sdist
       - build_wheels


### PR DESCRIPTION
Follow up to #2696 and #2697
I hope this time we got it right
doc: https://github.com/softprops/action-gh-release#permissions

