### PR TITLE
MNT: add PEP 723 inline script metadata

### DIFF
--- a/ci/get_hdf5_win.py
+++ b/ci/get_hdf5_win.py
@@ -1,4 +1,10 @@
-# -*- coding: utf-8 -*-
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "requests>=2.30.0",
+# ]
+# ///
+
 """
 Script for downloading and building HDF5 on Windows
 This does not support MPI, nor non-Windows OSes


### PR DESCRIPTION
A quick quality of life improvement. This makes installing `requests` explicitly unnecessary if you're running the script via `uv` or `pipx` (and any other PEP 723-compliant script runners).

(note that this is the only such script I found with any third party dependency)