### PR TITLE
MNT: replace unused Travis CI status badge with a GHA one

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-.. image:: https://travis-ci.org/h5py/h5py.png
-   :target: https://travis-ci.org/h5py/h5py
+.. image:: https://github.com/h5py/h5py/actions/workflows/build_wheels.yml/badge.svg?branch=master
+   :target: https://github.com/h5py/h5py/actions/workflows/build_wheels.yml
 .. image:: https://ci.appveyor.com/api/projects/status/h3iajp4d1myotprc/branch/master?svg=true
    :target: https://ci.appveyor.com/project/h5py/h5py/branch/master
 .. image:: https://dev.azure.com/h5pyappveyor/h5py/_apis/build/status/h5py.h5py?branchName=master


### PR DESCRIPTION
<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py312-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->
