### PR TITLE
Fix `PropLAID.get_elink_prefix`

### DIFF
--- a/h5py/h5p.templ.pyx
+++ b/h5py/h5p.templ.pyx
@@ -1628,19 +1628,20 @@ cdef class PropLAID(PropInstanceID):
 
         Get the external link prefix
         """
-        cdef char* buf = NULL
+        cdef char* cprefix = NULL
         cdef ssize_t size
 
         size = H5Pget_elink_prefix(self.id, NULL, 0)
-        buf = <char*>emalloc(size+1)
-        buf[0] = 0
+        cprefix = <char*>emalloc(size+1)
+        cprefix[0] = 0
         try:
-            H5Pget_elink_prefix(self.id, buf, size+1)
-            pstr = buf
+            # TODO check return size
+            H5Pget_elink_prefix(self.id, cprefix, size+1)
+            prefix = bytes(cprefix)
         finally:
-            efree(buf)
+            efree(cprefix)
 
-        return pstr
+        return prefix
 
 
     @with_phil

--- a/h5py/tests/test_h5p.py
+++ b/h5py/tests/test_h5p.py
@@ -208,7 +208,7 @@ class TestPL(TestCase):
         self.assertEqual((0,0), cid.get_attr_phase_change())
 
 
-def test_PropLAID():
+def test_proplaid():
     """Test Link Access Property List"""
     lapl = h5p.create(h5p.LINK_ACCESS)
 

--- a/news/fix-lapl-get_elink_prefix.rst
+++ b/news/fix-lapl-get_elink_prefix.rst
@@ -1,0 +1,4 @@
+Bug fixes
+---------
+
+* Fixed ``h5py.h5p.PropLAID.get_elink_prefix`` method


### PR DESCRIPTION
<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py312-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->

This PR fixes `PropLAID.get_elink_prefix` which was returning random values.
It now uses the same implementation as [PropDAID.get_efile_prefix](https://github.com/h5py/h5py/blob/38ed02c1c6ac9bfb7b482a520ce81699083b9553/h5py/h5p.templ.pyx#L1839) and [PropDAID.get_virtual_prefix](https://github.com/h5py/h5py/blob/38ed02c1c6ac9bfb7b482a520ce81699083b9553/h5py/h5p.templ.pyx#L1942-L1961).

It also adds a test of PropLAID setter/getters.