### PR TITLE
WHL: match runner images macosx versions in MACOSX_DEPLOYMENT_TARGET

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -72,9 +72,9 @@ jobs:
             arch: AMD64
           - os: windows-11-arm
             arch: ARM64
-          - os: macos-14
+          - os: macos-14 # keep in sync with cibuildwheel.overrides
             arch: arm64
-          - os: macos-15-intel
+          - os: macos-15-intel # keep in sync with cibuildwheel.overrides
             arch: x86_64
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,16 @@ delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel} \
 H5PY_ROS3 = "0"
 H5PY_DIRECT_VFD = "0"
 
+[[tool.cibuildwheel.overrides]]
+select = "cp3*-macosx_arm64"
+inherit.environment = "append"
+environment = {"MACOSX_DEPLOYMENT_TARGET" = "14.0"}
+
+[[tool.cibuildwheel.overrides]]
+select = "cp3*-macosx_x86_64"
+inherit.environment = "append"
+environment = {"MACOSX_DEPLOYMENT_TARGET" = "15.0"}
+
 [tool.uv]
 # never build numpy from source
 no-build-package = ["numpy"]


### PR DESCRIPTION
This isn't ideal; and I'd like to spend more time studying if it can be reverted for future releases, but this should unblock h5py 3.15