### PR TITLE
Include HDF5 build scripts in key for HDF5 cache

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -86,18 +86,15 @@ jobs:
       # inside the HDF5-getting scripts and have them be in effect for the
       # cibuildwheel step.
 
-      # Cache HDF5
-      - name: Cache built HDF5
+      # Windows HDF5
+      - name: Cache built HDF5 (Windows)
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.4  # zizmor: ignore[cache-poisoning] cache not used when uploading wheels
         with:
-          key: ${{ matrix.os }}-${{ matrix.arch }}-6
+          key: ${{ matrix.os }}-${{ matrix.arch }}-0-${{ hashFiles('ci/cibw_before_all_windows.sh', 'ci/get_hdf5_win.py') }}
           path: cache/hdf5
         # When preparing to upload a release, always build HDF5 to avoid potential
-        # cache-poisoning attacks. We also ignore the cache on Linux, because
-        # HDF5 is built separately in the hdf5-manylinux container image.
-        if: ${{ github.ref_type != 'tag' && github.event_name != 'schedule' && runner.os != 'Linux' }}
-
-      # Windows HDF5
+        # cache-poisoning attacks.
+        if: ${{ runner.os == 'Windows' && github.ref_type != 'tag' && github.event_name != 'schedule' }}
       - uses: nuget/setup-nuget@323ab0502cd38fdc493335025a96c8fdb0edc71f # v2.0.1
         if: runner.os == 'Windows'
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
@@ -110,6 +107,14 @@ jobs:
         if: runner.os == 'Windows'
 
       # macOS HDF5
+      - name: Cache built HDF5 (Mac)
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.4  # zizmor: ignore[cache-poisoning] cache not used when uploading wheels
+        with:
+          key: ${{ matrix.os }}-${{ matrix.arch }}-0-${{ hashFiles('ci/cibw_before_all_macos.sh', 'ci/get_hdf5_if_needed.sh') }}
+          path: cache/hdf5
+        # When preparing to upload a release, always build HDF5 to avoid potential
+        # cache-poisoning attacks.
+        if: ${{ runner.os == 'macOS' && github.ref_type != 'tag' && github.event_name != 'schedule' }}
       - run: bash ./ci/cibw_before_all_macos.sh "${{ github.workspace }}"
         if: runner.os == 'macOS'
 


### PR DESCRIPTION
This should improve cache invalidation for HDF5 builds.

I've split up the cache step between Windows & Mac, as there are different scripts involved in the build for each platform.