### PR TITLE
WHL: build HDF5 with backward compatible system APIs on macOS

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -72,9 +72,9 @@ jobs:
             arch: AMD64
           - os: windows-11-arm
             arch: ARM64
-          - os: macos-14 # keep in sync with cibuildwheel.overrides
+          - os: macos-14
             arch: arm64
-          - os: macos-15-intel # keep in sync with cibuildwheel.overrides
+          - os: macos-15-intel
             arch: x86_64
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/ci/get_hdf5_if_needed.sh
+++ b/ci/get_hdf5_if_needed.sh
@@ -51,6 +51,15 @@ else
             ARCH=$(uname -m)
             ZLIB_VERSION="1.3.1"
 
+            # When compiling HDF5, we should use the minimum across all
+            # Python versions for a given arch.
+            # See cibuildwheel.pypa.io/en/stable/platforms#macos-version-compatibility
+            if [[ "$ARCH" == "arm64" ]]; then
+                export MACOSX_DEPLOYMENT_TARGET="11.0"
+            else
+                export MACOSX_DEPLOYMENT_TARGET="10.9"
+            fi
+
             pushd /tmp
             curl -sLO https://zlib.net/fossils/zlib-$ZLIB_VERSION.tar.gz
             tar xzf zlib-$ZLIB_VERSION.tar.gz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,16 +157,6 @@ delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel} \
 H5PY_ROS3 = "0"
 H5PY_DIRECT_VFD = "0"
 
-[[tool.cibuildwheel.overrides]]
-select = "cp3*-macosx_arm64"
-inherit.environment = "append"
-environment = {"MACOSX_DEPLOYMENT_TARGET" = "14.0"}
-
-[[tool.cibuildwheel.overrides]]
-select = "cp3*-macosx_x86_64"
-inherit.environment = "append"
-environment = {"MACOSX_DEPLOYMENT_TARGET" = "15.0"}
-
 [tool.uv]
 # never build numpy from source
 no-build-package = ["numpy"]


### PR DESCRIPTION
Close #2720

revert #2719 and part of #2715, which I now understand is when I created the problem in the first place. Will need to carefully look at logs before undrafting this (I need to check that cibw isn't affected by `MACOSX_DEPLOYMENT_TARGET` set for `HDF5`).