### PR TITLE
Generated GitHub release does not need to be draft

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -210,7 +210,7 @@ jobs:
         uses: softprops/action-gh-release@62c96d0c4e8a889135c1f3a25910db8dbe0e85f7 # v2.3.4
         # https://github.com/softprops/action-gh-release?tab=readme-ov-file#inputs
         with:
-          # Note that draft releases are not public
+          draft: false
           generate_release_notes: false
           files: |
             dist/*


### PR DESCRIPTION
I had assumed that a non-draft release was the default, but apparently not. We could add a step to the release instructions to publish the release, but for now I'm happy enough to have it published automatically.