### PR TITLE
RFC: avoid direct mutations to ndarray.shape attributes

### DIFF
--- a/h5py/_hl/selections.py
+++ b/h5py/_hl/selections.py
@@ -174,9 +174,7 @@ class PointSelection(Selection):
 
     def _perform_selection(self, points, op):
         """ Internal method which actually performs the selection """
-        points = np.asarray(points, order='C', dtype='u8')
-        if len(points.shape) == 1:
-            points.shape = (1,points.shape[0])
+        points = np.atleast_2d(np.asarray(points, order='C', dtype='u8'))
 
         if self._id.get_select_type() != h5s.SEL_POINTS:
             op = h5s.SELECT_SET


### PR DESCRIPTION
xref: https://github.com/numpy/numpy/pull/29536

this is the only block in the whole code base using this soon-to-be deprecated pattern