### PR TITLE
Add specific error message when slicing dataset with None/newaxis

### DIFF
--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -835,6 +835,9 @@ class Dataset(HLObject):
         """
         args = args if isinstance(args, tuple) else (args,)
 
+        if any(a is None for a in args):  # 'None in args' would fail on arrays
+            raise TypeError("Indexing with None (or np.newaxis) is not supported")
+
         if self._fast_read_ok and (new_dtype is None):
             try:
                 return self._fast_reader.read(args)

--- a/h5py/tests/test_dataset_getitem.py
+++ b/h5py/tests/test_dataset_getitem.py
@@ -44,8 +44,9 @@
 import sys
 
 import numpy as np
-import h5py
+import pytest
 
+import h5py
 from .common import ut, TestCase
 
 
@@ -616,3 +617,9 @@ class TestBoolIndex(TestCase):
         sel = np.s_[[False, True, False, False],:]
         with self.assertRaises(TypeError):
             self.dset[sel]
+
+
+def test_error_newaxis(writable_file):
+    ds = writable_file.create_dataset('a', data=np.arange(5))
+    with pytest.raises(TypeError, match="newaxis"):
+        ds[np.newaxis, :]


### PR DESCRIPTION
`np.newaxis` is an alias for None, but that might not be obvious (I wasn't sure), so it could be helpful to explicitly mention it in an error message.

Closes #2409