### PR TITLE
TST/DEP: upgrade pytest to version 9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,8 @@ tables = [
     "tables>=3.7.0",
 ]
 test = [
-    "pytest>=8.2.2",
+    "coverage>=7.10.0",
+    "pytest>=9.0.1",
     "pytest-cov>=5.0.0",
     "pytest-mpi>=0.6",
 ]
@@ -121,6 +122,16 @@ wheels = [
     "coverage>=7.9.1",
     "tox>=4.26.0",
     "tox-uv>=1.27.0",
+]
+
+[tool.pytest]
+minversion = "9.0"
+strict = true
+addopts = ["-ra"]
+filterwarnings = ["error"]
+markers = [
+    "network: Tests requiring network access, skipped with --no-network",
+    "slow: Slow tests",
 ]
 
 [tool.cibuildwheel]
@@ -160,3 +171,7 @@ H5PY_DIRECT_VFD = "0"
 [tool.uv]
 # never build numpy from source
 no-build-package = ["numpy"]
+constraint-dependencies = [
+    # via check-manifest
+    "setuptools>=61.0",
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,0 @@
-[pytest]
-markers =
-    network: Tests requiring network access, skipped with --no-network
-    slow: Slow tests
-filterwarnings =
-    error
-required_plugins = pytest-mpi

--- a/tox.ini
+++ b/tox.ini
@@ -47,8 +47,7 @@ setenv =
     pre: UV_INDEX=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
     pre: UV_INDEX_STRATEGY=unsafe-best-match  # match pip's behavior
 uv_resolution =
-    mindeps: lowest-direct
-    !mindeps: highest
+    mindeps: lowest
 pip_pre =
     pre: True
 


### PR DESCRIPTION
This is arguably a *very* aggressive upgrade; pytest 9.0.0 was just released yesterday.
However, I wanted to give it a spin for demonstration, if nothing else. Most importantly, this version is the first one that has proper lower bounds on its own dependencies, which enables switching uv resolution from `lowest-direct` to `lowest` the difference being that, with `lowest`, transitive deps are *also* resolved to oldest, which is much more consistent and reproducible than just pinning *direct* ones.

While I'm at it, I also took advantage of new features:
- native toml support (`[tool.pytest]`)
- `strict` mode, which makes things like typos in markers raise exceptions instead of mere warnings