### PR TITLE
TST/RFC: replace unittest.skipIf markers with pytest.mark.skipif

### DIFF
--- a/h5py/tests/test_base.py
+++ b/h5py/tests/test_base.py
@@ -15,11 +15,13 @@
 
 from h5py import File
 from h5py._hl.base import is_hdf5, Empty
-from .common import ut, TestCase, UNICODE_FILENAMES
+from .common import TestCase, UNICODE_FILENAMES
 
 import numpy as np
 import os
 import tempfile
+import pytest
+
 
 class BaseTest(TestCase):
 
@@ -125,7 +127,10 @@ class TestRepr(BaseTest):
         self.assertNotEqual(Empty(dtype='i'), data)
         self._check_type(data)
 
-    @ut.skipIf(not UNICODE_FILENAMES, "Filesystem unicode support required")
+    @pytest.mark.skipif(
+        not UNICODE_FILENAMES,
+        reason="Filesystem unicode support required",
+    )
     def test_file(self):
         """ File object repr() with unicode """
         fname = tempfile.mktemp(self.USTRING+'.hdf5')

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -25,7 +25,7 @@ import pytest
 import threading
 from concurrent.futures import ThreadPoolExecutor
 
-from .common import ut, TestCase
+from .common import TestCase
 from .data_files import get_data_file_path
 from h5py import File, Dataset
 from h5py._hl.base import is_empty_dataspace, product
@@ -119,7 +119,10 @@ class TestCreateShape(BaseDataset):
             pytest.xfail("Storage of long double deactivated on %s" % platform.machine())
         self.assertEqual(dset.dtype, np.longdouble)
 
-    @ut.skipIf(not hasattr(np, "complex256"), "No support for complex256")
+    @pytest.mark.skipif(
+        not hasattr(np, "complex256"),
+        reason="No support for complex256",
+    )
     def test_complex256(self):
         """ Confirm that the default dtype is float """
         dset = self.f.create_dataset('foo', (63,),
@@ -508,7 +511,10 @@ class TestFillTime(BaseDataset):
         self.assertEqual(dset[0], 4.0)
         self.assertEqual(dset[7], 4.0)
 
-    @ut.skipIf('gzip' not in h5py.filters.encode, "DEFLATE is not installed")
+    @pytest.mark.skipif(
+        'gzip' not in h5py.filters.encode,
+        reason="DEFLATE is not installed",
+    )
     def test_compressed_default(self):
         """ Fill time is IFSET for compressed dataset (chunked) """
         dset = self.f.create_dataset('foo', (10,), compression='gzip',
@@ -612,7 +618,10 @@ class TestCreateNamedType(BaseDataset):
         self.assertTrue(dset.id.get_type().committed())
 
 
-@ut.skipIf('gzip' not in h5py.filters.encode, "DEFLATE is not installed")
+@pytest.mark.skipif(
+    'gzip' not in h5py.filters.encode,
+    reason="DEFLATE is not installed",
+)
 class TestCreateGzip(BaseDataset):
 
     """
@@ -657,7 +666,10 @@ class TestCreateGzip(BaseDataset):
                                   compression_opts=14)
 
 
-@ut.skipIf('gzip' not in h5py.filters.encode, "DEFLATE is not installed")
+@pytest.mark.skipif(
+    'gzip' not in h5py.filters.encode,
+    reason="DEFLATE is not installed",
+)
 class TestCreateCompressionNumber(BaseDataset):
 
     """
@@ -697,7 +709,10 @@ class TestCreateCompressionNumber(BaseDataset):
             h5py._hl.dataset._LEGACY_GZIP_COMPRESSION_VALS = original_compression_vals
 
 
-@ut.skipIf('lzf' not in h5py.filters.encode, "LZF is not installed")
+@pytest.mark.skipif(
+    'lzf' not in h5py.filters.encode,
+    reason="LZF is not installed",
+)
 class TestCreateLZF(BaseDataset):
 
     """
@@ -727,7 +742,10 @@ class TestCreateLZF(BaseDataset):
                                   compression_opts=4)
 
 
-@ut.skipIf('szip' not in h5py.filters.encode, "SZIP is not installed")
+@pytest.mark.skipif(
+    'szip' not in h5py.filters.encode,
+    reason="SZIP is not installed",
+)
 class TestCreateSZIP(BaseDataset):
 
     """
@@ -740,7 +758,10 @@ class TestCreateSZIP(BaseDataset):
                                      compression_opts=('ec', 16))
 
 
-@ut.skipIf('shuffle' not in h5py.filters.encode, "SHUFFLE is not installed")
+@pytest.mark.skipif(
+    'shuffle' not in h5py.filters.encode,
+    reason="SHUFFLE is not installed",
+)
 class TestCreateShuffle(BaseDataset):
 
     """
@@ -753,7 +774,10 @@ class TestCreateShuffle(BaseDataset):
         self.assertTrue(dset.shuffle)
 
 
-@ut.skipIf('fletcher32' not in h5py.filters.encode, "FLETCHER32 is not installed")
+@pytest.mark.skipif(
+    'fletcher32' not in h5py.filters.encode,
+    reason="FLETCHER32 is not installed",
+)
 class TestCreateFletcher32(BaseDataset):
     """
         Feature: Datasets can use the fletcher32 filter
@@ -765,7 +789,10 @@ class TestCreateFletcher32(BaseDataset):
         self.assertTrue(dset.fletcher32)
 
 
-@ut.skipIf('scaleoffset' not in h5py.filters.encode, "SCALEOFFSET is not installed")
+@pytest.mark.skipif(
+    'scaleoffset' not in h5py.filters.encode,
+    reason="SCALEOFFSET is not installed",
+)
 class TestCreateScaleOffset(BaseDataset):
     """
         Feature: Datasets can use the scale/offset filter
@@ -1624,7 +1651,10 @@ class TestFloats(BaseDataset):
         dset[...] = data
         self.assertArrayEqual(dset[...], data)
 
-    @ut.skipUnless(hasattr(np, 'float16'), "NumPy float16 support required")
+    @pytest.mark.skipif(
+        not hasattr(np, 'float16'),
+        reason="NumPy float16 support required",
+    )
     def test_mini(self):
         """ Mini-floats round trip """
         self._exectest(np.dtype('float16'))
@@ -1955,9 +1985,11 @@ def test_get_chunk_details():
         assert si.size > 0
 
 
-@ut.skipUnless(h5py.version.hdf5_version_tuple >= (1, 12, 3) or
-               (h5py.version.hdf5_version_tuple >= (1, 10, 10) and h5py.version.hdf5_version_tuple < (1, 10, 99)),
-               "chunk iteration requires  HDF5 1.10.10 and later 1.10, or 1.12.3 and later")
+@pytest.mark.skipif(
+    h5py.version.hdf5_version_tuple < (1, 12, 3) and
+    (h5py.version.hdf5_version_tuple < (1, 10, 10) or h5py.version.hdf5_version_tuple >= (1, 10, 99)),
+    reason="chunk iteration requires HDF5 1.10.10 and later 1.10, or 1.12.3 and later",
+)
 def test_chunk_iter():
     """H5Dchunk_iter() for chunk information"""
     from io import BytesIO

--- a/h5py/tests/test_dataset_getitem.py
+++ b/h5py/tests/test_dataset_getitem.py
@@ -45,9 +45,10 @@ import sys
 
 import numpy as np
 import pytest
+import h5py
 
 import h5py
-from .common import ut, TestCase
+from .common import TestCase
 
 
 class TestEmpty(TestCase):
@@ -582,7 +583,10 @@ class TestVeryLargeArray(TestCase):
         TestCase.setUp(self)
         self.dset = self.f.create_dataset('x', shape=(2**15, 2**16))
 
-    @ut.skipIf(sys.maxsize < 2**31, 'Maximum integer size >= 2**31 required')
+    @pytest.mark.skipif(
+        sys.maxsize < 2**31,
+        reason='Maximum integer size >= 2**31 required',
+    )
     def test_size(self):
         self.assertEqual(self.dset.size, 2**31)
 

--- a/h5py/tests/test_dtype.py
+++ b/h5py/tests/test_dtype.py
@@ -5,13 +5,14 @@
 from itertools import count
 import platform
 import numpy as np
+import pytest
 import h5py
 try:
     import tables
 except ImportError:
     tables = None
 
-from .common import ut, TestCase
+from .common import TestCase
 
 UNSUPPORTED_LONG_DOUBLE = ('i386', 'i486', 'i586', 'i686', 'ppc64le')
 UNSUPPORTED_LONG_DOUBLE_TYPES = ('float96', 'float128', 'complex192',
@@ -403,7 +404,7 @@ class TestDateTime(TestCase):
                     self.assertArrayEqual(arr, dset)
                     self.assertEqual(arr.dtype, dset.dtype)
 
-@ut.skipUnless(tables is not None, 'tables is required')
+@pytest.mark.skipif(not tables is not None, reason='tables is required')
 class TestBitfield(TestCase):
 
     """

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -24,7 +24,7 @@ from hashlib import sha256
 
 import pytest
 
-from .common import ut, TestCase, UNICODE_FILENAMES, closed_tempfile
+from .common import TestCase, UNICODE_FILENAMES, closed_tempfile
 from h5py._hl.files import direct_vfd
 from h5py import File
 import h5py
@@ -323,7 +323,10 @@ class TestDrivers(TestCase):
         include MPI drivers (see bottom).
     """
 
-    @ut.skipUnless(os.name == 'posix', "Stdio driver is supported on posix")
+    @pytest.mark.skipif(
+        os.name != 'posix',
+        reason="Stdio driver is supported on posix",
+    )
     def test_stdio(self):
         """ Stdio driver is supported on posix """
         fid = File(self.mktemp(), 'w', driver='stdio')
@@ -337,9 +340,13 @@ class TestDrivers(TestCase):
         self.assertEqual(fid.driver, 'stdio')
         fid.close()
 
-    @ut.skipUnless(direct_vfd,
-                   "DIRECT driver is supported on Linux if hdf5 is "
-                   "built with the appriorate flags.")
+    @pytest.mark.skipif(
+        not direct_vfd,
+        reason=(
+            "DIRECT driver is supported on Linux if hdf5 is "
+            "built with the appriorate flags."
+        ),
+    )
     def test_direct(self):
         """ DIRECT driver is supported on Linux"""
         fid = File(self.mktemp(), 'w', driver='direct')
@@ -387,7 +394,7 @@ class TestDrivers(TestCase):
                 assert actual_block_size == block_size
                 assert actual_cbuf_size == actual_cbuf_size
 
-    @ut.skipUnless(os.name == 'posix', "Sec2 driver is supported on posix")
+    @pytest.mark.skipif(os.name != 'posix', reason="Sec2 driver is supported on posix")
     def test_sec2(self):
         """ Sec2 driver is supported on posix """
         fid = File(self.mktemp(), 'w', driver='sec2')
@@ -524,24 +531,30 @@ class TestNewLibver(TestCase):
         self.assertEqual(f.libver, ('v110', self.latest))
         f.close()
 
-    @ut.skipIf(h5py.version.hdf5_version_tuple < (1, 11, 4),
-               'Requires HDF5 1.11.4 or later')
+    @pytest.mark.skipif(
+        h5py.version.hdf5_version_tuple < (1, 11, 4),
+        reason='Requires HDF5 1.11.4 or later',
+    )
     def test_single_v112(self):
         """ Opening with "v112" libver arg """
         f = File(self.mktemp(), 'w', libver='v112')
         self.assertEqual(f.libver, ('v112', self.latest))
         f.close()
 
-    @ut.skipIf(h5py.version.hdf5_version_tuple < (1, 14, 0),
-               'Requires HDF5 1.14 or later')
+    @pytest.mark.skipif(
+        h5py.version.hdf5_version_tuple < (1, 14, 0),
+        reason='Requires HDF5 1.14 or later',
+    )
     def test_single_v114(self):
         """ Opening with "v114" libver arg """
         f = File(self.mktemp(), 'w', libver='v114')
         self.assertEqual(f.libver, ('v114', self.latest))
         f.close()
 
-    @ut.skipIf(h5py.version.hdf5_version_tuple < (2, 0, 0),
-               'Requires HDF5 2.0 or later')
+    @pytest.mark.skipif(
+        h5py.version.hdf5_version_tuple < (2, 0, 0),
+        reason='Requires HDF5 2.0 or later',
+    )
     def test_single_v200(self):
         """ Opening with "v200" libver arg """
         f = File(self.mktemp(), 'w', libver='v200')
@@ -670,7 +683,7 @@ class TestContextManager(TestCase):
         self.assertTrue(not fid)
 
 
-@ut.skipIf(not UNICODE_FILENAMES, "Filesystem unicode support required")
+@pytest.mark.skipif(not UNICODE_FILENAMES, reason="Filesystem unicode support required")
 class TestUnicode(TestCase):
 
     """

--- a/h5py/tests/test_filters.py
+++ b/h5py/tests/test_filters.py
@@ -14,8 +14,9 @@
 import os
 import numpy as np
 import h5py
+import pytest
 
-from .common import ut, TestCase
+from .common import TestCase
 
 
 class TestFilters(TestCase):
@@ -25,7 +26,10 @@ class TestFilters(TestCase):
         self.path = self.mktemp()
         self.f = h5py.File(self.path, 'w')
 
-    @ut.skipUnless(h5py.h5z.filter_avail(h5py.h5z.FILTER_SZIP), 'szip filter required')
+    @pytest.mark.skipif(
+        not h5py.h5z.filter_avail(h5py.h5z.FILTER_SZIP),
+        reason='szip filter required',
+    )
     def test_wr_szip_fletcher32_64bit(self):
         """ test combination of szip, fletcher32, and 64bit arrays
 
@@ -61,7 +65,10 @@ class TestFilters(TestCase):
                                   )
 
 
-@ut.skipIf('gzip' not in h5py.filters.encode, "DEFLATE is not installed")
+@pytest.mark.skipif(
+    'gzip' not in h5py.filters.encode,
+    reason="DEFLATE is not installed",
+)
 def test_filter_ref_obj(writable_file):
     gzip8 = h5py.filters.Gzip(level=8)
     # **kwargs unpacking (compatible with earlier h5py versions)
@@ -85,7 +92,10 @@ def test_filter_ref_obj_eq():
     assert gzip8 != h5py.filters.Gzip(level=7)
 
 
-@ut.skipIf(not os.getenv('H5PY_TEST_CHECK_FILTERS'),  "H5PY_TEST_CHECK_FILTERS not set")
+@pytest.mark.skipif(
+    'H5PY_TEST_CHECK_FILTERS' not in os.environ,
+    reason="H5PY_TEST_CHECK_FILTERS not set",
+)
 def test_filters_available():
     assert 'gzip' in h5py.filters.decode
     assert 'gzip' in h5py.filters.encode

--- a/h5py/tests/test_group.py
+++ b/h5py/tests/test_group.py
@@ -21,10 +21,11 @@ import numpy as np
 import os
 import os.path
 from tempfile import mkdtemp
+import pytest
 
 from collections.abc import MutableMapping
 
-from .common import ut, TestCase
+from .common import TestCase
 import h5py
 from h5py import File, Group, SoftLink, HardLink, ExternalLink
 from h5py import Dataset, Datatype
@@ -921,7 +922,7 @@ class TestExternalLinks(TestCase):
         f2.close()
         self.assertFalse(f2)
 
-    @ut.skipIf(NO_FS_UNICODE, "No unicode filename support")
+    @pytest.mark.skipif(NO_FS_UNICODE, reason="No unicode filename support")
     def test_unicode_encode(self):
         """
         Check that external links encode unicode filenames properly
@@ -932,7 +933,7 @@ class TestExternalLinks(TestCase):
             ext_file.create_group('external')
         self.f['ext'] = ExternalLink(ext_filename, '/external')
 
-    @ut.skipIf(NO_FS_UNICODE, "No unicode filename support")
+    @pytest.mark.skipif(NO_FS_UNICODE, reason="No unicode filename support")
     def test_unicode_decode(self):
         """
         Check that external links decode unicode filenames properly

--- a/h5py/tests/test_h5d_direct_chunk.py
+++ b/h5py/tests/test_h5d_direct_chunk.py
@@ -3,7 +3,7 @@ import numpy
 import numpy.testing
 import pytest
 
-from .common import ut, TestCase
+from .common import TestCase
 
 
 class TestWriteDirectChunk(TestCase):
@@ -32,7 +32,10 @@ class TestWriteDirectChunk(TestCase):
                 numpy.testing.assert_array_equal(array[i], read_data)
 
 
-@ut.skipIf('gzip' not in h5py.filters.encode, "DEFLATE is not installed")
+@pytest.mark.skipif(
+    'gzip' not in h5py.filters.encode,
+    reason="DEFLATE is not installed",
+)
 class TestReadDirectChunk(TestCase):
     def test_read_compressed_offsets(self):
 

--- a/h5py/tests/test_h5f.py
+++ b/h5py/tests/test_h5f.py
@@ -11,10 +11,11 @@ import tempfile
 import shutil
 import os
 import numpy as np
+import pytest
 from h5py import File, special_dtype
 from h5py._hl.files import direct_vfd
 
-from .common import ut, TestCase
+from .common import TestCase
 
 
 class TestFileID(TestCase):
@@ -34,9 +35,13 @@ class TestFileID(TestCase):
         finally:
             shutil.rmtree(dn_tmp)
 
-    @ut.skipUnless(direct_vfd,
-                   "DIRECT driver is supported on Linux if hdf5 is "
-                   "built with the appriorate flags.")
+    @pytest.mark.skipif(
+        not direct_vfd,
+        reason=(
+            "DIRECT driver is supported on Linux if hdf5 is "
+            "built with the appriorate flags."
+        ),
+    )
     def test_descriptor_direct(self):
         dn_tmp = tempfile.mkdtemp('h5py.lowtest.test_h5f.TestFileID.test_descriptor_direct')
         fn_h5 = os.path.join(dn_tmp, 'test.h5')

--- a/h5py/tests/test_h5p.py
+++ b/h5py/tests/test_h5p.py
@@ -7,7 +7,7 @@
 # License:  Standard 3-clause BSD; see "license.txt" for full license terms
 #           and contributor agreement.
 
-import unittest as ut
+import pytest
 
 from h5py import h5p, h5f, version
 
@@ -41,8 +41,10 @@ class TestLibver(TestCase):
         self.assertEqual((h5f.LIBVER_V18, h5f.LIBVER_V110),
                          plist.get_libver_bounds())
 
-    @ut.skipIf(version.hdf5_version_tuple < (1, 11, 4),
-               'Requires HDF5 1.11.4 or later')
+    @pytest.mark.skipif(
+        version.hdf5_version_tuple < (1, 11, 4),
+        reason='Requires HDF5 1.11.4 or later',
+    )
     def test_libver_v112(self):
         """ Test libver bounds set/get for H5F_LIBVER_V112"""
         plist = h5p.create(h5p.FILE_ACCESS)
@@ -50,8 +52,10 @@ class TestLibver(TestCase):
         self.assertEqual((h5f.LIBVER_V18, h5f.LIBVER_V112),
                          plist.get_libver_bounds())
 
-    @ut.skipIf(version.hdf5_version_tuple < (1, 14, 0),
-               'Requires HDF5 1.14 or later')
+    @pytest.mark.skipif(
+        version.hdf5_version_tuple < (1, 14, 0),
+        reason='Requires HDF5 1.14 or later',
+    )
     def test_libver_v114(self):
         """ Test libver bounds set/get for H5F_LIBVER_V114"""
         plist = h5p.create(h5p.FILE_ACCESS)
@@ -59,8 +63,10 @@ class TestLibver(TestCase):
         self.assertEqual((h5f.LIBVER_V18, h5f.LIBVER_V114),
                          plist.get_libver_bounds())
 
-    @ut.skipIf(version.hdf5_version_tuple < (2, 0, 0),
-               'Requires HDF5 2.0 or later')
+    @pytest.mark.skipif(
+        version.hdf5_version_tuple < (2, 0, 0),
+        reason='Requires HDF5 2.0 or later',
+    )
     def test_libver_v200(self):
         """ Test libver bounds set/get for H5F_LIBVER_V200"""
         plist = h5p.create(h5p.FILE_ACCESS)

--- a/h5py/tests/test_vds/test_highlevel_vds.py
+++ b/h5py/tests/test_vds/test_highlevel_vds.py
@@ -8,14 +8,17 @@ import os
 import os.path as osp
 import shutil
 import tempfile
+import pytest
 
 import h5py as h5
 from ..common import ut
 from ..._hl.vds import vds_support
 
 
-@ut.skipUnless(vds_support,
-               'VDS requires HDF5 >= 1.9.233')
+@pytest.mark.skipif(
+    not vds_support,
+    reason='VDS requires HDF5 >= 1.9.233',
+)
 class TestEigerHighLevel(ut.TestCase):
     def setUp(self):
         self.working_dir = tempfile.mkdtemp()
@@ -94,8 +97,10 @@ class ExcaliburData:
         return dset
 
 
-@ut.skipUnless(vds_support,
-               'VDS requires HDF5 >= 1.9.233')
+@pytest.mark.skipif(
+    not vds_support,
+    reason='VDS requires HDF5 >= 1.9.233',
+)
 class TestExcaliburHighLevel(ut.TestCase):
     def create_excalibur_fem_stripe_datafile(self, fname, nframes, excalibur_data,scale):
         shape = (nframes,) + excalibur_data.fem_stripe_dimensions
@@ -163,8 +168,10 @@ https://support.hdfgroup.org/HDF5/docNewFeatures/VDS/HDF5-VDS-requirements-use-c
 '''
 
 
-@ut.skipUnless(vds_support,
-               'VDS requires HDF5 >= 1.9.233')
+@pytest.mark.skipif(
+    not vds_support,
+    reason='VDS requires HDF5 >= 1.9.233',
+)
 class TestPercivalHighLevel(ut.TestCase):
 
     def setUp(self):
@@ -229,8 +236,10 @@ class TestPercivalHighLevel(ut.TestCase):
     def tearDown(self):
         shutil.rmtree(self.working_dir)
 
-@ut.skipUnless(vds_support,
-               'VDS requires HDF5 >= 1.9.233')
+@pytest.mark.skipif(
+    not vds_support,
+    reason='VDS requires HDF5 >= 1.9.233',
+)
 class SlicingTestCase(ut.TestCase):
 
     def setUp(self):
@@ -295,8 +304,10 @@ class SlicingTestCase(ut.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
 
-@ut.skipUnless(vds_support,
-               'VDS requires HDF5 >= 1.9.233')
+@pytest.mark.skipif(
+    not vds_support,
+    reason='VDS requires HDF5 >= 1.9.233'
+)
 class IndexingTestCase(ut.TestCase):
 
     def setUp(self):
@@ -347,8 +358,10 @@ class IndexingTestCase(ut.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
 
-@ut.skipUnless(vds_support,
-               'VDS requires HDF5 >= 1.9.233')
+@pytest.mark.skipif(
+    not vds_support,
+    reason='VDS requires HDF5 >= 1.9.233',
+)
 class RelativeLinkTestCase(ut.TestCase):
 
     def setUp(self):
@@ -417,8 +430,10 @@ class RelativeLinkBuildVDSTestCase(RelativeLinkTestCase):
             layout[0] = h5.VirtualSource(self.f1, 'data', shape=(10,))
             layout[1] = h5.VirtualSource(self.f2, 'data', shape=(10,))
 
-@ut.skipUnless(vds_support,
-               'VDS requires HDF5 >= 1.9.233')
+@pytest.mark.skipif(
+    not vds_support,
+    reason='VDS requires HDF5 >= 1.9.233',
+)
 class VDSUnlimitedTestCase(ut.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Extracted from #2738
This should be fully backward+forward compatible, but for some reason pytest 9.0.0 seems to choke on unittest decorators.
xref: https://github.com/pytest-dev/pytest/issues/13895

Independently of this problem, I think we should aim to use `pytest` API as much as possible, if nothing else, for the sake of consistency.