### PR TITLE
Enable freethreading_compatible flag

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,11 +90,6 @@ jobs:
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         H5PY_ENFORCE_COVERAGE: yes
 
-        # TODO it was decided to not mark the module as freethreading-compatible
-        # for the time being due to instability concerns.
-        # See https://github.com/h5py/h5py/pull/2650
-        PYTHON_GIL: 0
-
     maxParallel: 4
 
   steps:

--- a/ci/cibw_test_command.sh
+++ b/ci/cibw_test_command.sh
@@ -13,13 +13,6 @@ echo "WHEEL_PATH=$WHEEL_PATH"
 
 export PYVER=$(python -c "import sys; print(''.join(map(str, sys.version_info[:2])) + ('t' if (sys.version_info>=(3,13) and sys.implementation.name=='cpython' and not sys._is_gil_enabled()) else ''))")
 
-if [[ "$PYVER" == *t ]]; then
-    # TODO it was decided to not mark the module as freethreading-compatible
-    # for the time being due to instability concerns.
-    # See https://github.com/h5py/h5py/pull/2650
-    export PYTHON_GIL="0"
-fi
-
 ENVLIST="py$PYVER-test-mindeps"
 if [[ "$ONLY_MINDEPS_TESTS" != "1" ]] ; then
     ENVLIST="$ENVLIST,py$PYVER-test-deps,py$PYVER-test-deps-pre"

--- a/setup_build.py
+++ b/setup_build.py
@@ -201,10 +201,7 @@ class h5py_build_ext(build_ext):
         }
         compiler_directives = {}
         if Version(cython_version) >= Version("3.1.0b1"):
-            # TODO it was decided to not mark the module as freethreading-compatible
-            # for the time being due to instability concerns.
-            # See https://github.com/h5py/h5py/pull/2650
-            compiler_directives["freethreading_compatible"] = False
+            compiler_directives["freethreading_compatible"] = True
 
         # Run Cython
         print("Executing cythonize()")


### PR DESCRIPTION
- Part of #2475
- Extracted from #2702

As discussed in https://github.com/h5py/h5py/pull/2650, we should not enable this flag until the unit tests suite gives us confidence that there are no race conditions. See parent issue for checklist.