### PR TITLE
Fix test failure in conda-forge CI

### DIFF
--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -1020,7 +1020,8 @@ class TestFileLocking:
             File(fname, mode="r", locking=False) as f,
         ):
             # Opening in write mode with locking is expected to work
-            ex.submit(open_and_close, fname, mode="w", locking=True).result()
+            future = ex.submit(open_and_close, fname, mode="w", locking=True)
+            future.result(timeout=10)
 
 
 def open_and_close(*args, **kwargs):


### PR DESCRIPTION
This test fails when the test suite is triggered by the conda-forge recipe for 3.14t:
https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1386909&view=logs&jobId=aa85f627-05cc-5265-2465-79d7168d3859&j=f2822e16-0094-5d6c-29fd-a9f5a365b7fd&t=c158e018-8e8e-5c27-0ba4-2482c0a9e77e

```python
______________________ TestFileLocking.test_multiprocess _______________________

self = <h5py.tests.test_file.TestFileLocking object at 0x22f0e895650>
tmp_path = PosixPath('/tmp/pytest-of-conda/pytest-0/test_multiprocess0')

        def test_multiprocess(self, tmp_path):
            """Test file locking option from different concurrent processes"""
            fname = tmp_path / "test.h5"
    
            def open_in_subprocess(filename, mode, locking):
                """Open HDF5 file in a subprocess and return True on success"""
                h5py_import_dir = str(pathlib.Path(h5py.__file__).parent.parent)
    
                process = subprocess.run(
                    [
                        sys.executable,
                        "-c",
                        f"""
    import sys
    sys.path.insert(0, {h5py_import_dir!r})
    import h5py
    f = h5py.File({str(filename)!r}, mode={mode!r}, locking={locking})
                        """,
                    ],
                    capture_output=True)
                return process.returncode == 0 and not process.stderr
    
            # Create test file
            with h5py.File(fname, mode="w", locking=True) as f:
                f["data"] = 1
    
            with h5py.File(fname, mode="r", locking=False) as f:
                # Opening in write mode with locking is expected to work
>               assert open_in_subprocess(fname, mode="w", locking=True)
E               AssertionError: assert False
E                +  where False = <function TestFileLocking.test_multiprocess.<locals>.open_in_subprocess at 0x22f1120b4c0>(PosixPath('/tmp/pytest-of-conda/pytest-0/test_multiprocess0/test.h5'), mode='w', locking=True)
```

Unsure why, but the test uses an anti-pattern that encroaches on h5py's bespoke import design.
This PR fixes the issue, as demonstrated by https://github.com/conda-forge/h5py-feedstock/pull/160

CC @zklaus