### PR TITLE
MNT/DOC: pin Sphinx<9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ check-readme = [
     "twine>=6.1.0",
 ]
 docs = [
-    "sphinx>=7.4.7",
+    "sphinx>=7.4.7, <9",
 ]
 lint = [
     "pre-commit>=4.2.0",


### PR DESCRIPTION
This is meant as a temporary workaround to fix CI