### PR TITLE
Use phil lock on read_direct_chunk & write_direct_chunk methods

### DIFF
--- a/h5py/h5d.templ.pyx
+++ b/h5py/h5d.templ.pyx
@@ -482,6 +482,7 @@ cdef class DatasetID(ObjectID):
         """
         H5Drefresh(self.id)
 
+    @with_phil
     def write_direct_chunk(self, offsets, data, filter_mask=0x00000000, PropID dxpl=None):
         """ (offsets, data, uint32_t filter_mask=0x00000000, PropID dxpl=None)
 
@@ -530,6 +531,7 @@ cdef class DatasetID(ObjectID):
                 H5Sclose(space_id)
 
 
+    @with_phil
     @cython.boundscheck(False)
     @cython.wraparound(False)
     def read_direct_chunk(self, offsets, PropID dxpl=None, unsigned char[::1] out=None):


### PR DESCRIPTION
We hit a segfault in [some code](https://github.com/European-XFEL/EXtra-data/blob/893abd1281e0e01b461982ebda9d546ff6462ed2/extra_data/compression.py#L101-L117) that we have to load & decompress chunks in parallel. faulthandler pointed us to lines 110 (calling `get_chunk_info_by_coord`) and 113 (`read_direct_chunk`). I realised that read_direct_chunk & write_direct_chunk are not protected by the same `phil` lock as all the other methods.

Adding the decorator to `read_direct_chunk` prevented the segfault in local testing.