### PR TITLE
Warn on use of h5py.config().read_byte_strings (now a no-op)

### DIFF
--- a/h5py/h5.templ.pyx
+++ b/h5py/h5.templ.pyx
@@ -120,6 +120,11 @@ cdef class H5PYConfig:
     def read_byte_strings(self):
         """ Returns a context manager which forces all strings to be returned
         as byte strings. """
+        warn(
+            "h5py.get_config().read_byte_strings is deprecated, "
+            "and no longer has any effect.",
+            category=H5pyDeprecationWarning,
+        )
         with phil:
             return self._bytestrings
 


### PR DESCRIPTION
The `read_byte_strings` context manage is a no-op now. This adds a warning, prior to getting rid of it in h5py v4 (#2756).