### PR TITLE
CLN: drop outdated comment in automod Sphinx extension

### DIFF
--- a/docs_api/automod.py
+++ b/docs_api/automod.py
@@ -1,8 +1,3 @@
-
-"""
-    Requires patched version of autodoc.py
-    http://bugs.python.org/issue3422
-"""
 import re
 from functools import partial
 


### PR DESCRIPTION
I misread that comment while working on #2757. It's now clarified that the "patched version" has long be available as... any Sphinx release since 2008, so the comment is definitely misleading and not needed any more.