### PR TITLE
Allow 1D boolean selection on first axis as single indexing argument

### DIFF
--- a/h5py/_hl/selections.py
+++ b/h5py/_hl/selections.py
@@ -60,9 +60,12 @@ def select(shape, args, dataset=None):
             return arg
 
         elif isinstance(arg, np.ndarray) and arg.dtype.kind == 'b':
-            if arg.shape != shape:
+            if arg.shape == shape:
+                return PointSelection.from_mask(arg)
+            # Allow 1D boolean array on the 1st dim
+            elif arg.shape != shape[:1]:
                 raise TypeError("Boolean indexing array has incompatible shape")
-            return PointSelection.from_mask(arg)
+
 
         elif isinstance(arg, h5r.RegionReference):
             if dataset is None:

--- a/h5py/tests/test_dataset_getitem.py
+++ b/h5py/tests/test_dataset_getitem.py
@@ -627,3 +627,20 @@ def test_error_newaxis(writable_file):
     ds = writable_file.create_dataset(make_name(), data=np.arange(5))
     with pytest.raises(TypeError, match="newaxis"):
         ds[np.newaxis, :]
+
+
+def test_bool_selection_1d(writable_file):
+    """https://github.com/h5py/h5py/issues/2674"""
+    int_arr = np.arange(9).reshape(3, 3)
+    writable_file['integers'] = int_arr
+    str_arr = np.array([s.encode() for s in 'abcdefghi'], dtype=object).reshape(3, 3)
+    writable_file['strings'] = str_arr
+
+    sel = np.array([True, False, True])
+    int_dset = writable_file['integers']
+    np.testing.assert_array_equal(int_dset[sel], int_arr[sel])
+    np.testing.assert_array_equal(int_dset[sel, :], int_arr[sel, :])
+
+    str_dset = writable_file['strings']
+    np.testing.assert_array_equal(str_dset[sel], str_arr[sel])
+    np.testing.assert_array_equal(str_dset[sel, :], str_arr[sel, :])


### PR DESCRIPTION
We generally allow a 1D boolean array to index a single axis. However, if this was used for the first axis as the only indexing argument, and the fast read pathway isn't used (e.g. for strings), it went into the code path for an n-dimensional boolean mask, and threw an error.

This allows a fall through to the more general code for a boolean array that doesn't match the full shape of the dataset but does match the first axis.

Closes #2674