### PR TITLE
Fix passing a low-level TypeID object for dtype in g.create_dataset()

### DIFF
--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -17,6 +17,7 @@ from abc import ABC, abstractmethod
 
 import numpy
 
+import h5py.h5t
 from .. import h5, h5s, h5t, h5r, h5d, h5p, h5fd, h5ds, _selector
 from .base import (
     array_for_new_object, cached_property, Empty, find_item_type, HLObject,
@@ -79,6 +80,9 @@ def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
         # Named types are used as-is
         tid = dtype.id
         dtype = tid.dtype  # Following code needs this
+    elif isinstance(dtype, h5py.h5t.TypeID):  # Low-level HDF5 data type
+        tid = dtype
+        dtype = tid.dtype
     else:
         # Validate dtype
         if dtype is None and data is None:

--- a/h5py/tests/test_dtype.py
+++ b/h5py/tests/test_dtype.py
@@ -530,3 +530,22 @@ def test_opaque(writable_file):
     assert isinstance(ds.id.get_type(), h5py.h5t.TypeOpaqueID)
     assert ds.id.get_type().get_size() == 2
     np.testing.assert_array_equal(ds[:], arr)
+
+
+def test_create_bitfield(writable_file):
+    data = np.arange(12, dtype=np.uint16)
+    ds = writable_file.create_dataset(
+        'b1', dtype=h5py.Datatype(h5py.h5t.STD_B16LE), shape=(12,)
+    )
+    ds[:] = data
+    assert isinstance(ds.id.get_type(), h5py.h5t.TypeBitfieldID)
+    assert ds.id.get_type().get_size() == 2
+    np.testing.assert_array_equal(ds[:], data)
+
+    ds2 = writable_file.create_dataset(
+        'b2', dtype=h5py.h5t.STD_B16LE, shape=(12,)
+    )
+    ds2[:] = data
+    assert isinstance(ds2.id.get_type(), h5py.h5t.TypeBitfieldID)
+    assert ds2.id.get_type().get_size() == 2
+    np.testing.assert_array_equal(ds2[:], data)


### PR DESCRIPTION
Passing a low-level TypeID object when creating a dataset (e.g. `f.create_dataset('b', dtype=h5py.h5t.STD_B16LE, shape=(12,))`) works, but it's the same as passing e.g. `h5py.h5t.STD_B16LE.dtype`, i.e. the equivalent Numpy dtype. For most types this will just roundtrip back to the same HDF5 datatype, but not bitfields, since they translate to numpy uints.

This would also fail for non-standard int and float formats which don't have a numpy equivalent; either with an outright error, or using a different format to what was specified.

Is this a bugfix for the next 3.x release? Or is it a breaking change for 4.0? I don't think anyone would intentionally rely on this translation of TypeID objects to dtype and back, but I could imagine some code that happens to work because of this quirk. :thinking: 

Closes #2576.