### PR TITLE
Threads+fork test fails on 3.15t

### DIFF
--- a/h5py/tests/test_objects.py
+++ b/h5py/tests/test_objects.py
@@ -43,8 +43,6 @@ class TestObjects(TestCase):
     @pytest.mark.thread_unsafe(reason="fork() from a thread may deadlock")
     @pytest.mark.filterwarnings(
         # https://github.com/python/cpython/pull/100229
-        # The warning was introduced in Python 3.12 but for some reason it only starts
-        # appearing in Python 3.15
         r"ignore:.*use of fork\(\) may lead to deadlocks:DeprecationWarning"
     )
     @pytest.mark.skipif(not hasattr(os, "fork"), reason="fork() not available")
@@ -85,6 +83,7 @@ class TestObjects(TestCase):
                     os._exit(1)
             else:
                 # Parent process
+                assert not o.phil.is_locked()
                 # Wait for the child process to finish
                 _, status = os.waitpid(pid, 0)
                 assert os.WIFEXITED(status)

--- a/h5py/tests/test_objects.py
+++ b/h5py/tests/test_objects.py
@@ -7,6 +7,8 @@
 # License:  Standard 3-clause BSD; see "license.txt" for full license terms
 #           and contributor agreement.
 import os
+import sys
+import threading
 
 import pytest
 
@@ -40,21 +42,47 @@ class TestObjects(TestCase):
 
     @pytest.mark.thread_unsafe(reason="fork() from a thread may deadlock")
     @pytest.mark.skipif(not hasattr(os, "fork"), reason="os.fork() not available")
-    def test_phil_fork(self):
+    @pytest.mark.skipif(sys.version_info >= (3, 15), reason="os.fork() deadlocks")
+    def test_phil_fork_with_threads(self):
         # Test that handling of the phil Lock after fork is correct.
-        # Note that threading and fork() are mutually exclusive, so
-        # the use case of a locked phil Lock during a fork() is unsupported.
-        pid = os.fork()
-        if pid == 0:
-            # child process
-            if o.phil.acquire(blocking=False):
+        # We simulate a deadlock in the forked process by explicitly
+        # waiting for the phil Lock to be acquired in a different thread
+        # before forking.
+
+        thread_acquired_phil_event = threading.Event()
+        thread_stop_event = threading.Event()
+
+        def f():
+            o.phil.acquire()
+            try:
+                thread_acquired_phil_event.set()
+                thread_stop_event.wait()
+            finally:
                 o.phil.release()
-                os._exit(0)
+
+        thread = threading.Thread(target=f)
+        thread.start()
+        try:
+            # wait for the thread running "f" to have acquired the phil lock
+            thread_acquired_phil_event.wait()
+
+            # now fork the current (main) thread while the other thread holds the lock
+            pid = os.fork()
+            if pid == 0:
+                # child process
+                # If we handle the phil lock correctly, this should not deadlock,
+                # and we should be able to acquire the lock here.
+                if o.phil.acquire(blocking=False):
+                    o.phil.release()
+                    os._exit(0)
+                else:
+                    os._exit(1)
             else:
-                os._exit(1)
-        else:
-            # parent process
-            # wait for the child process to finish
-            _, status = os.waitpid(pid, 0)
-            assert os.WIFEXITED(status)
-            assert os.WEXITSTATUS(status) == 0
+                # parent process
+                # wait for the child process to finish
+                _, status = os.waitpid(pid, 0)
+                assert os.WIFEXITED(status)
+                assert os.WEXITSTATUS(status) == 0
+        finally:
+            thread_stop_event.set()
+            thread.join()

--- a/h5py/tests/test_objects.py
+++ b/h5py/tests/test_objects.py
@@ -7,9 +7,8 @@
 # License:  Standard 3-clause BSD; see "license.txt" for full license terms
 #           and contributor agreement.
 import os
+import sys
 import threading
-import time
-from unittest import SkipTest
 
 import pytest
 
@@ -43,9 +42,7 @@ class TestObjects(TestCase):
 
     @pytest.mark.thread_unsafe(reason="fork() from a thread may deadlock")
     @pytest.mark.skipif(not hasattr(os, "fork"), reason="os.fork() not available")
-    @pytest.mark.filterwarnings(  # https://github.com/python/cpython/pull/100229
-        "ignore:use of fork() may lead to deadlocks:DeprecationWarning"
-    )
+    @pytest.mark.skipif(sys.version_info >= (3, 15), reason="os.fork() deadlocks")
     def test_phil_fork_with_threads(self):
         # Test that handling of the phil Lock after fork is correct.
         # We simulate a deadlock in the forked process by explicitly

--- a/h5py/tests/test_objects.py
+++ b/h5py/tests/test_objects.py
@@ -65,7 +65,6 @@ class TestObjects(TestCase):
         thread = threading.Thread(target=f)
         thread.start()
         thread_acquired_phil_event.wait()
-        assert not o.phil.acquire(blocking=False)
 
         try:
             # Now fork the current (main) thread while the other thread holds the lock.

--- a/h5py/tests/test_objects.py
+++ b/h5py/tests/test_objects.py
@@ -7,9 +7,8 @@
 # License:  Standard 3-clause BSD; see "license.txt" for full license terms
 #           and contributor agreement.
 import os
-import sys
-import time
 import threading
+import time
 
 import pytest
 

--- a/h5py/tests/test_objects.py
+++ b/h5py/tests/test_objects.py
@@ -49,9 +49,9 @@ class TestObjects(TestCase):
     def test_phil_fork_with_threads(self):
         """Test that handling of the phil Lock after fork is correct.
 
-        h5py changes os.fork() to internally acquire the phil lock before forking
-        and release it afterwards, so that the global state of libhdf5 cannot be
-        cloned in a corrupted state.
+        h5py uses os.register_at_fork() to cause os.fork() to acquire the phil lock
+        before forking and release it afterwards, so that the global state of libhdf5
+        cannot be cloned in a corrupted state.
         """
         thread_acquired_phil_event = threading.Event()
 
@@ -68,13 +68,13 @@ class TestObjects(TestCase):
 
         try:
             # Now fork the current (main) thread while the other thread holds the lock.
-            # Internally, os.fork() acquires the phil.lock, so this will block until
-            # the other thread releases it.
+            # os.fork() acquires the phil lock, so this will block until the other
+            # thread releases it.
             pid = os.fork()
             if pid == 0:
                 # Child process
-                # If we handle the phil lock correctly, this should not deadlock,
-                # and we should be able to acquire the lock here.
+                # If we handle the phil lock correctly, this should not deadlock, and we
+                # should be able to acquire the lock here.
                 if o.phil.acquire(blocking=False):
                     o.phil.release()
                     os._exit(0)

--- a/h5py/tests/test_objects.py
+++ b/h5py/tests/test_objects.py
@@ -82,7 +82,8 @@ class TestObjects(TestCase):
                     os._exit(1)
             else:
                 # Parent process
-                assert not o.phil.is_locked()
+                assert o.phil.acquire(blocking=False)
+                o.phil.release()
                 # Wait for the child process to finish
                 _, status = os.waitpid(pid, 0)
                 assert os.WIFEXITED(status)


### PR DESCRIPTION
I'm observing this test failing frequently on 3.15a4t (without pytest-run-parallel) with

> E           DeprecationWarning: This process (pid=51457) is multi-threaded, use of fork() may lead to deadlocks in the child.

e.g. https://github.com/crusaderky/hdf5-pixi/actions/runs/21150734896/job/60826052716

I have not tested it on 3.14t extensively enough to figure out if this is a change in 3.15 or not. What we know is that it never happens on 3.14 with GIL, according to the h5py CI.

The warning is from 2022: https://github.com/python/cpython/pull/100229
Reading the code suggests that the warning should be deterministic in this test (assuming that fork takes less than 1 second to complete, which should hold almost always true even on the slow CI boxes). I can't figure out why it only happens occasionally, and why only on free-threading builds.