### PR TITLE
Make `write_direct_chunk` thread-safe

### DIFF
--- a/h5py/h5d.templ.pyx
+++ b/h5py/h5d.templ.pyx
@@ -534,6 +534,7 @@ cdef class DatasetID(ObjectID):
     @with_phil
     @cython.boundscheck(False)
     @cython.wraparound(False)
+    @with_phil
     def read_direct_chunk(self, offsets, PropID dxpl=None, unsigned char[::1] out=None):
         """ (offsets, PropID dxpl=None, out=None)
 


### PR DESCRIPTION
This race condition was detected by `pytest-run-parallel` segfaulting on  `test_write_direct_chunk`.