### PR TITLE
MNT: customize RTD build process to utilize uv

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,16 +1,22 @@
 version: 2  # Required
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "3.10"
+    python: '3'
+  jobs:
+   pre_create_environment:
+     - asdf plugin add uv
+     - asdf install uv latest
+     - asdf global uv latest
+   create_environment:
+     - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
+   install:
+     # note that uv sync should be run as `--frozen`, but this requires uv.lock to be committed to the repo
+     - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --only-group docs
 
 sphinx:
    configuration: docs/conf.py
    fail_on_warning: true
-
-python:
-   install:
-   - requirements: docs/requirements-rtd.txt
 
 formats: all

--- a/docs/requirements-rtd.txt
+++ b/docs/requirements-rtd.txt
@@ -1,2 +1,0 @@
-sphinx==7.2.6
-sphinx_rtd_theme==1.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,8 @@ check-readme = [
     "twine>=6.1.0",
 ]
 docs = [
-    "sphinx>=7.4.7, <9",
+    "sphinx>=7.4.7,<9",
+    "sphinx-rtd-theme>=1.3.0",
 ]
 lint = [
     "pre-commit>=4.2.0",


### PR DESCRIPTION
Rationale: I'm seeing traces of an attempt to pin doc dependencies to exact versions on RTD (`docs/requirements-std.txt`). However, this approach only includes *direct* dependencies, leaving out any transitive ones, which means we can still get stealth upgrades there, and are generally at risk of builds suddenly breaking.
The general solution is to use a lock file, and we could pretty easily do that with uv (which we already use in CI via tox-uv), so I'm proposing, as a first step towards this goal, to configure RTD to use uv instead of pip. This configuration is directly taken from [RTD docs](https://docs.readthedocs.com/platform/stable/build-customization.html#install-dependencies-with-uv)