### PR TITLE
Buffer overflow in scaleoffset filter

### DIFF
--- a/h5py/h5p.templ.pyx
+++ b/h5py/h5p.templ.pyx
@@ -713,8 +713,9 @@ cdef class PropDCID(PropOCID):
 
         filter_code = <int>H5Pget_filter(self.id, filter_idx, &flags,
                                          &nelements, cd_values, 256, name, NULL)
-        name[256] = c'\0'  # in case it's > 256 chars
+        assert nelements <= 16, f"H5Pget_filter returned {nelements=}"
 
+        name[256] = c'\0'  # in case it's > 256 chars
         vlist = []
         for i in range(nelements):
             vlist.append(cd_values[i])
@@ -763,9 +764,9 @@ cdef class PropDCID(PropOCID):
             # Avoid library segfault
             return None
 
-        retval = H5Pget_filter_by_id(self.id, <H5Z_filter_t>filter_code,
-                                     &flags, &nelements, cd_values, 256, name, NULL)
-        assert nelements <= 16
+        H5Pget_filter_by_id(self.id, <H5Z_filter_t>filter_code,
+                            &flags, &nelements, cd_values, 256, name, NULL)
+        assert nelements <= 16, f"H5Pget_filter_by_id returned {nelements=}"
 
         name[256] = c'\0'  # In case HDF5 doesn't terminate it properly
 

--- a/h5py/h5p.templ.pyx
+++ b/h5py/h5p.templ.pyx
@@ -696,24 +696,24 @@ cdef class PropDCID(PropOCID):
 
         0. INT filter code (h5z.FILTER*)
         1. UINT flags (h5z.FLAG*)
-        2. TUPLE of UINT values; filter aux data (16 values max)
+        2. TUPLE of UINT values; filter aux data (256 values max)
         3. STRING name of filter (256 chars max)
         """
         cdef list vlist
         cdef int filter_code
         cdef unsigned int flags
         cdef size_t nelements
-        cdef unsigned int cd_values[16]
+        cdef unsigned int cd_values[256]
         cdef char name[257]
         cdef int i
-        nelements = 16 # HDF5 library actually complains if this is too big.
+        nelements = 256 # HDF5 library actually complains if this is too big.
 
         if filter_idx < 0:
             raise ValueError("Filter index must be a non-negative integer")
 
         filter_code = <int>H5Pget_filter(self.id, filter_idx, &flags,
                                          &nelements, cd_values, 256, name, NULL)
-        assert nelements <= 16, f"H5Pget_filter returned {nelements=}"
+        assert nelements <= 256, f"H5Pget_filter returned {nelements=}"
 
         name[256] = c'\0'  # in case it's > 256 chars
         vlist = []
@@ -748,17 +748,17 @@ cdef class PropDCID(PropOCID):
         Tuple elements are:
 
         0. UINT flags (h5z.FLAG*)
-        1. TUPLE of UINT values; filter aux data (16 values max)
+        1. TUPLE of UINT values; filter aux data (256 values max)
         2. STRING name of filter (256 chars max)
         """
         cdef list vlist
         cdef unsigned int flags
         cdef size_t nelements
-        cdef unsigned int cd_values[16]
+        cdef unsigned int cd_values[256]
         cdef char name[257]
         cdef herr_t retval
         cdef int i
-        nelements = 16 # HDF5 library actually complains if this is too big.
+        nelements = 256 # HDF5 library actually complains if this is too big.
 
         if not self._has_filter(filter_code):
             # Avoid library segfault
@@ -766,7 +766,7 @@ cdef class PropDCID(PropOCID):
 
         H5Pget_filter_by_id(self.id, <H5Z_filter_t>filter_code,
                             &flags, &nelements, cd_values, 256, name, NULL)
-        assert nelements <= 16, f"H5Pget_filter_by_id returned {nelements=}"
+        assert nelements <= 256, f"H5Pget_filter_by_id returned {nelements=}"
 
         name[256] = c'\0'  # In case HDF5 doesn't terminate it properly
 


### PR DESCRIPTION
Closes #2780

On all versions of libhdf5 (tested 1.10.7 ~ 2.0.1 git tip), the scaleoffset filter has cd_nelmts = 20.

The documentation of [H5Z_get_filter](https://support.hdfgroup.org/documentation/hdf5/latest/group___o_c_p_l.html#ga024d200a6a07e12f008a62c4e62d0bcc) states 

> On input, cd_nelmts indicates the number of entries in the cd_values array, as allocated by the caller; on return, cd_nelmts contains the number of values defined by the filter.

Note that the above implies that output cd_nelmts can be higher than the input, as it does not reflect the number of elements that were read (e.g. like in various POSIX functions like `snprintf`).
h5py assumed that the output is always <= 16, and this caused a stack overflow.