### PR TITLE
Use PyDict_DelItem to remove objects from registry

### DIFF
--- a/h5py/_objects.templ.pyx
+++ b/h5py/_objects.templ.pyx
@@ -12,6 +12,7 @@
 """
 
 include "_locks.pxi"
+from cpython.dict cimport PyDict_DelItem
 from .defs cimport *
 
 import os
@@ -239,7 +240,7 @@ cdef class ObjectID:
                         )
                     )
             if self._pyid is not None:
-                del registry[self._pyid]
+                PyDict_DelItem(registry, self._pyid)
 
     def _close(self):
         """ Manually close this object. """


### PR DESCRIPTION
This is option 1 for fixing the memory leak describe in #2771. I don't understand exactly why it fixes it - I guess there must be a bug somewhere in Cython, or even CPython, on the generic code path for deleting an item from a collection.

I'm hoping to prepare a second option as well, in a few minutes, so hold off merging for now.

Closes #2771.