### PR TITLE
Use a WeakValueDictionary for the object registry

### DIFF
--- a/h5py/_objects.templ.pyx
+++ b/h5py/_objects.templ.pyx
@@ -113,7 +113,6 @@ if hasattr(os, "register_at_fork"):
 #
 # See also __cinit__ and __dealloc__ for class ObjectID.
 
-import gc
 import weakref
 import warnings
 


### PR DESCRIPTION
This is an alternative to #2782, fixing the same memory leak.

This one is a bigger change, using the [WeakValueDictionary](https://docs.python.org/3/library/weakref.html#weakref.WeakValueDictionary) class, which automatically discards its own entries when they're garbage collected, rather than managing a regular dict of weakref objects ourselves. That simplifies the code in h5py, albeit relying on more complexity in Python. I think this trade-off is worth it - weakrefs are fiddly to work with, and the Python developers probably have the best chance of getting it right.

Closes #2771.