### PR TITLE
Get rid of obsolete swmr_support variable

### DIFF
--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -28,8 +28,6 @@ ros3 = h5.get_config().ros3
 direct_vfd = h5.get_config().direct_vfd
 hdf5_version = version.hdf5_version_tuple[0:3]
 
-swmr_support = True
-
 
 libver_dict = {'earliest': h5f.LIBVER_EARLIEST, 'latest': h5f.LIBVER_LATEST,
                'v108': h5f.LIBVER_V18, 'v110': h5f.LIBVER_V110}
@@ -236,7 +234,7 @@ def make_fid(name, mode, userblock_size, fapl, fcpl=None, swmr=False):
 
     if mode == 'r':
         flags = h5f.ACC_RDONLY
-        if swmr and swmr_support:
+        if swmr:
             flags |= h5f.ACC_SWMR_READ
         fid = h5f.open(name, flags, fapl=fapl)
     elif mode == 'r+':
@@ -323,9 +321,7 @@ class File(Group):
     @with_phil
     def mode(self):
         """ Python mode used to open file """
-        write_intent = h5f.ACC_RDWR
-        if swmr_support:
-            write_intent |= h5f.ACC_SWMR_WRITE
+        write_intent = h5f.ACC_RDWR | h5f.ACC_SWMR_WRITE
         return 'r+' if self.id.get_intent() & write_intent else 'r'
 
     @property
@@ -368,7 +364,7 @@ class File(Group):
     @with_phil
     def swmr_mode(self):
         """ Controls single-writer multiple-reader mode """
-        return swmr_support and bool(self.id.get_intent() & (h5f.ACC_SWMR_READ | h5f.ACC_SWMR_WRITE))
+        return bool(self.id.get_intent() & (h5f.ACC_SWMR_READ | h5f.ACC_SWMR_WRITE))
 
     @swmr_mode.setter
     @with_phil


### PR DESCRIPTION
We no longer support pre-SWMR versions of HDF5, so this variable was set to True in all cases. It's not part of the public API, so we can get rid of it.