### PR TITLE
Improvements for storing reference objects

### DIFF
--- a/h5py/_conv.templ.pyx
+++ b/h5py/_conv.templ.pyx
@@ -372,6 +372,8 @@ cdef inline int conv_pyref2objref(void* ipt, void* opt, void* bkg, void* priv)  
         if not isinstance(obj, Reference):
             raise TypeError("Can't convert incompatible object to HDF5 object reference")
         ref = <Reference>(buf_obj0)
+        if ref.typecode != H5R_OBJECT:
+            raise TypeError("Can't convert dataset region reference to object reference")
         buf_ref[0] = ref.ref.obj_ref
     else:
         memset(buf_ref, c'\0', sizeof(hobj_ref_t))

--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -76,12 +76,12 @@ def guess_dtype(data):
     constructor to figure out)
     """
     with phil:
-        if isinstance(data, h5r.RegionReference):
-            return h5t.regionref_dtype
-        if isinstance(data, h5r.Reference):
-            return h5t.ref_dtype
-
         item_type = find_item_type(data)
+
+        if item_type is h5r.RegionReference:
+            return h5t.regionref_dtype
+        if item_type is h5r.Reference:
+            return h5t.ref_dtype
 
         if item_type is bytes:
             return h5t.string_dtype(encoding='ascii')

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -2339,12 +2339,26 @@ def test_filter_properties(writable_file):
 def test_store_refs(writable_file):
     ds1 = writable_file.create_dataset('foo', data=np.arange(12))
     refs_ds = writable_file.create_dataset('refs', data=[writable_file.ref, ds1.ref])
-    assert isinstance(refs_ds[0], h5py.h5r.Reference)
+    assert isinstance(refs_ds[0], h5py.Reference)
     assert writable_file[refs_ds[0]] == writable_file
-    assert isinstance(refs_ds[1], h5py.h5r.Reference)
+    assert isinstance(refs_ds[1], h5py.Reference)
     assert writable_file[refs_ds[1]] == ds1
 
     # Single reference
     ref_scalar_ds = writable_file.create_dataset('ref_scalar', data=ds1.ref)
     assert isinstance(ref_scalar_ds[()], h5py.h5r.Reference)
     assert writable_file[ref_scalar_ds[()]] == ds1
+
+
+def test_store_regionrefs(writable_file):
+    ds1 = writable_file.create_dataset('foo', data=np.arange(12))
+    regionrefs_ds = writable_file.create_dataset('regrefs', data=[
+        ds1.regionref[:-1], ds1.regionref[1:]
+    ])
+    assert isinstance(regionrefs_ds[0], h5py.RegionReference)
+    np.testing.assert_array_equal(ds1[regionrefs_ds[0]], np.arange(11))
+    np.testing.assert_array_equal(ds1[regionrefs_ds[1]], np.arange(1, 12))
+
+    refs_ds = writable_file.create_dataset('refs', shape=(1,), dtype=h5py.ref_dtype)
+    with pytest.raises(TypeError):
+        refs_ds[0] = ds1.regionref[:6]

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -2360,5 +2360,5 @@ def test_store_regionrefs(writable_file):
     np.testing.assert_array_equal(ds1[regionrefs_ds[1]], np.arange(1, 12))
 
     refs_ds = writable_file.create_dataset('refs', shape=(1,), dtype=h5py.ref_dtype)
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="convert"):
         refs_ds[0] = ds1.regionref[:6]

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -2334,3 +2334,17 @@ def test_filter_properties(writable_file):
         h5py.h5z.FILTER_SHUFFLE, h5py.h5z.FILTER_LZF, h5py.h5z.FILTER_FLETCHER32
     )
     assert ds.filter_names == ('shuffle', 'lzf', 'fletcher32')
+
+
+def test_store_refs(writable_file):
+    ds1 = writable_file.create_dataset('foo', data=np.arange(12))
+    refs_ds = writable_file.create_dataset('refs', data=[writable_file.ref, ds1.ref])
+    assert isinstance(refs_ds[0], h5py.h5r.Reference)
+    assert writable_file[refs_ds[0]] == writable_file
+    assert isinstance(refs_ds[1], h5py.h5r.Reference)
+    assert writable_file[refs_ds[1]] == ds1
+
+    # Single reference
+    ref_scalar_ds = writable_file.create_dataset('ref_scalar', data=ds1.ref)
+    assert isinstance(ref_scalar_ds[()], h5py.h5r.Reference)
+    assert writable_file[ref_scalar_ds[()]] == ds1


### PR DESCRIPTION
A couple of small fixes for old issues I came across:

- Region references could be stored in datasets with an object reference dtype, but lost information (#756). Throw a TypeError on trying to convert them instead.
- Creating a dataset with a single reference `data=ds.ref` worked, but a list `data=[ds.ref]` did not (came up in #2609).

Closes #756.