### PR TITLE
Fix some C compiler warnings

### DIFF
--- a/h5py/_conv.templ.pyx
+++ b/h5py/_conv.templ.pyx
@@ -701,12 +701,11 @@ cdef int conv_vlen2ndarray(void* ipt,
         void* back_buf = NULL
         cnp.ndarray ndarray
         PyObject* ndarray_obj
-        vlen_t in_vlen0
         size_t size, itemsize
 
     #Replaces the memcpy
-    size = in_vlen0.len = in_vlen[0].len
-    data = in_vlen0.ptr = in_vlen[0].ptr
+    size = in_vlen[0].len
+    data = in_vlen[0].ptr
 
     dims[0] = size
     itemsize = H5Tget_size(outtype.id)
@@ -754,8 +753,6 @@ cdef int conv_vlen2ndarray(void* ipt,
 
     PyArray_ENABLEFLAGS(ndarray, flags)
     ndarray_obj = <PyObject*>ndarray
-
-    in_vlen0.ptr = NULL
 
     # Write the new ndarray object to the buffer in-place and ensure it is not destroyed
     buf_obj[0] = ndarray_obj

--- a/h5py/_conv.templ.pyx
+++ b/h5py/_conv.templ.pyx
@@ -507,7 +507,7 @@ cdef int enum_int_converter_conv(hid_t src, hid_t dst, H5T_cdata_t *cdata,
     cdef:
         conv_enum_t *info
         size_t nalloc
-        int i
+        size_t i
         char* cbuf = NULL
         char* buf = <char*>buf_i
         int identical

--- a/h5py/_selector.pyx
+++ b/h5py/_selector.pyx
@@ -27,7 +27,7 @@ import_array()
 cdef object convert_bools(bint* data, hsize_t rank):
     # Convert a bint array to a Python tuple of bools.
     cdef list bools_l
-    cdef int i
+    cdef hsize_t i
     bools_l = []
 
     for i in range(rank):

--- a/h5py/h5fd.templ.pyx
+++ b/h5py/h5fd.templ.pyx
@@ -161,7 +161,7 @@ cdef herr_t H5FD_fileobj_read(H5FD_fileobj_t *f, H5FD_mem_t type, hid_t dxpl, ha
         (<object>f.fileobj).readinto(mview)
     else:
         b = (<object>f.fileobj).read(size)
-        if len(b) == size:
+        if <size_t>len(b) == size:
             memcpy(buf, <unsigned char *>b, size)
         else:
             return 1

--- a/h5py/h5g.pyx
+++ b/h5py/h5g.pyx
@@ -18,8 +18,6 @@ from ._objects cimport pdefault
 from .utils cimport emalloc, efree
 from .h5p import CRT_ORDER_TRACKED
 from .h5p cimport PropID, PropGCID, propwrap
-from . cimport _hdf5 # to implement container testing for 1.6
-from ._errors cimport set_error_handler, err_cookie
 
 # Python level imports
 from ._objects import phil, with_phil
@@ -458,13 +456,6 @@ cdef class GroupID(ObjectID):
 
         Determine if a group member of the given name is present
         """
-        cdef err_cookie old_handler
-        cdef err_cookie new_handler
-        cdef herr_t retval
-
-        new_handler.func = NULL
-        new_handler.data = NULL
-
         if not self:
             return False
 

--- a/h5py/h5p.templ.pyx
+++ b/h5py/h5p.templ.pyx
@@ -645,9 +645,8 @@ cdef class PropDCID(PropOCID):
         values
             TUPLE of UINTs giving auxiliary data for the filter
         """
-        cdef size_t nelements
+        cdef size_t nelements, i
         cdef unsigned int *cd_values
-        cdef int i
         cd_values = NULL
 
         require_tuple(values, 1, -1, b"values")
@@ -702,10 +701,9 @@ cdef class PropDCID(PropOCID):
         cdef list vlist
         cdef int filter_code
         cdef unsigned int flags
-        cdef size_t nelements
+        cdef size_t nelements, i
         cdef unsigned int cd_values[256]
         cdef char name[257]
-        cdef int i
         nelements = 256 # HDF5 library actually complains if this is too big.
 
         if filter_idx < 0:
@@ -753,11 +751,10 @@ cdef class PropDCID(PropOCID):
         """
         cdef list vlist
         cdef unsigned int flags
-        cdef size_t nelements
+        cdef size_t nelements, i
         cdef unsigned int cd_values[256]
         cdef char name[257]
         cdef herr_t retval
-        cdef int i
         nelements = 256 # HDF5 library actually complains if this is too big.
 
         if not self._has_filter(filter_code):

--- a/h5py/h5r.pyx
+++ b/h5py/h5r.pyx
@@ -171,7 +171,7 @@ cdef class Reference:
         self.typesize = sizeof(hobj_ref_t)
 
     def __bool__(self):
-        cdef int i
+        cdef size_t i
         for i in range(self.typesize):
             if (<unsigned char*>&self.ref)[i] != 0: return True
         return False

--- a/h5py/utils.pxd
+++ b/h5py/utils.pxd
@@ -16,7 +16,7 @@ cpdef int check_numpy_read(ndarray arr, hid_t space_id=*) except -1
 cpdef int check_numpy_write(ndarray arr, hid_t space_id=*) except -1
 
 cdef int convert_tuple(object tuple, hsize_t *dims, hsize_t rank) except -1
-cdef object convert_dims(hsize_t* dims, hsize_t rank)
+cdef object convert_dims(const hsize_t *dims, hsize_t rank)
 
 cdef int require_tuple(object tpl, int none_allowed, int size, char* name) except -1
 

--- a/h5py/utils.pyx
+++ b/h5py/utils.pyx
@@ -107,7 +107,7 @@ cdef int convert_tuple(object tpl, hsize_t *dims, hsize_t rank) except -1:
 
     return 0
 
-cdef object convert_dims(hsize_t* dims, hsize_t rank):
+cdef object convert_dims(const hsize_t* dims, hsize_t rank):
     # Convert an hsize_t array to a Python tuple of ints.
 
     cdef list dims_list

--- a/h5py/utils.pyx
+++ b/h5py/utils.pyx
@@ -94,9 +94,9 @@ cdef int convert_tuple(object tpl, hsize_t *dims, hsize_t rank) except -1:
     # Convert a Python tuple to an hsize_t array.  You must allocate
     # the array yourself and pass both it and the size to this function.
     # Returns 0 on success, -1 on failure and raises an exception.
-    cdef int i
+    cdef hsize_t i
 
-    if len(tpl) != rank:
+    if <hsize_t>len(tpl) != rank:
         raise ValueError("Tuple length incompatible with array")
 
     try:
@@ -111,7 +111,7 @@ cdef object convert_dims(const hsize_t* dims, hsize_t rank):
     # Convert an hsize_t array to a Python tuple of ints.
 
     cdef list dims_list
-    cdef int i
+    cdef hsize_t i
     dims_list = []
 
     for i in range(rank):


### PR DESCRIPTION
Mostly warnings about comparing signed & unsigned integers, plus some unused variables, and a missing `const` qualifier.

This doesn't get rid of all the warnings, I just cleaned up the ones that seemed simple and where I could easily convince myself that a fix is safe. I figure that fewer warnings makes it easier to see if there's something significant in the compiler output.