### PR TITLE
Better access to compression/filter information (simplified)

### DIFF
--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -703,7 +703,7 @@ Reference
         module, while filter IDs from plugins are listed in `HDF Group's registry
         <https://portal.hdfgroup.org/display/support/Registered+Filter+Plugins>`_.
 
-        .. versionadded:: 3.8
+        .. versionadded:: 3.16
 
     .. attribute:: fillvalue
 

--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -685,6 +685,21 @@ Reference
 
         Whether Fletcher32 checksumming is enabled (T/F).  See :ref:`dataset_fletcher32`.
 
+    .. attribute:: filter_ids
+                   filter_names
+
+        The numeric filter IDs and the string names (as stored in the file) of
+        the filters in use. Each attribute is a tuple.
+
+        Filters are mostly used to compress data, but can also do things like
+        checksumming (see :ref:`dataset_compression`). Other attributes listed
+        above provide convenient shortcuts to check on common filters.
+        IDs for filters built into h5py can be found in the :mod:`h5py.h5z`
+        module, while filter IDs from plugins are listed in `HDF Group's registry
+        <https://portal.hdfgroup.org/display/support/Registered+Filter+Plugins>`_.
+
+        .. versionadded:: 3.8
+
     .. attribute:: fillvalue
 
         Value used when reading uninitialized portions of the dataset, or None

--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -667,6 +667,11 @@ Reference
         String with the currently applied compression filter, or None if
         compression is not enabled for this dataset.  See :ref:`dataset_compression`.
 
+        This only recognises the built-in compression options ``'gzip'``,
+        ``'lzf'`` and ``'szip'``. Other compression mechanisms will show as
+        ``'unknown'`` from h5py 3.8. Use :attr:`filter_ids` and
+        :attr:`filter_names` to get more complete information.
+
     .. attribute:: compression_opts
 
         Options for the compression filter.  See :ref:`dataset_compression`.

--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -669,7 +669,7 @@ Reference
 
         This only recognises the built-in compression options ``'gzip'``,
         ``'lzf'`` and ``'szip'``. Other compression mechanisms will show as
-        ``'unknown'`` from h5py 3.8. Use :attr:`filter_ids` and
+        ``'unknown'`` from h5py 3.16. Use :attr:`filter_ids` and
         :attr:`filter_names` to get more complete information.
 
     .. attribute:: compression_opts

--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -701,7 +701,7 @@ Reference
         above provide convenient shortcuts to check on common filters.
         IDs for filters built into h5py can be found in the :mod:`h5py.h5z`
         module, while filter IDs from plugins are listed in `HDF Group's registry
-        <https://portal.hdfgroup.org/display/support/Registered+Filter+Plugins>`_.
+        <https://github.com/HDFGroup/hdf5_plugins/blob/master/docs/RegisteredFilterPlugins.md>`_.
 
         .. versionadded:: 3.16
 

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -635,6 +635,21 @@ class Dataset(HLObject):
 
     @property
     @with_phil
+    def filter_ids(self):
+        """Numeric IDs of HDF5 filters used for this dataset"""
+        pl = self._dcpl
+        return tuple([pl.get_filter(i)[0] for i in range(pl.get_nfilters())])
+
+    @property
+    @with_phil
+    def filter_names(self):
+        """Names, as stored in the file, of the filters used for this dataset"""
+        pl = self._dcpl
+        return tuple([pl.get_filter(i)[3].decode('utf-8', 'surrogateescape')
+                for i in range(pl.get_nfilters())])
+
+    @property
+    @with_phil
     def shuffle(self):
         """Shuffle filter present (T/F)"""
         return 'shuffle' in self._filters

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -625,6 +625,8 @@ class Dataset(HLObject):
         for x in ('gzip','lzf','szip'):
             if x in self._filters:
                 return x
+        if any(f not in filters._COMP_FILTERS for f in self._filters):
+            return 'unknown'  # Filter from a plugin
         return None
 
     @property

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -2115,6 +2115,7 @@ def test_allow_unknown_filter(writable_file):
         allow_unknown_filter=True
     )
     assert str(fake_filter_id) in ds._filters
+    assert ds.compression == 'unknown'
 
 
 def test_dset_chunk_cache():

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -2313,3 +2313,14 @@ def test_concurrent_dataset_creation(writable_file):
     [f.result() for f in futures]
     expected = set(f'concurrent_{i:02d}_{j:02d}' for i in range(N_THREADS) for j in range(N_DATASETS_PER_THREAD))
     assert set(writable_file) == expected
+
+
+def test_filter_properties(writable_file):
+    ds = writable_file.create_dataset(
+        'foo', shape=1000, dtype=np.float32,
+        fletcher32=True, shuffle=True, compression='lzf'
+    )
+    assert ds.filter_ids == (
+        h5py.h5z.FILTER_SHUFFLE, h5py.h5z.FILTER_LZF, h5py.h5z.FILTER_FLETCHER32
+    )
+    assert ds.filter_names == ('shuffle', 'lzf', 'fletcher32')


### PR DESCRIPTION
This provides `ds.filter_ids` and `ds.filter_names` properties to inspect all of the filters which a dataset uses, and makes `dset.compression` 'unknown' if h5py's 3 built-in compression options are not used, but an unknown filter is.

This is a simplified version of #2180. In that PR, I tried to improve `create_dataset_like()` to handle combining an arbitrary filter pipeline on the source dataset and h5py keyword arguments which could add/replace/remove filters. That added a bunch of complexity and API surface for something that just doesn't come up very much. You can create a dataset with exactly the same settings as another, including third-party filters, by dipping slightly into the low-level API: `src_ds.id.get_create_plist()`.

Closes #2161.