### PR TITLE
TSAN: race condition in h5p `set_alignment` / `get_alignment`

### DIFF
--- a/h5py/h5p.templ.pyx
+++ b/h5py/h5p.templ.pyx
@@ -1430,6 +1430,7 @@ cdef class PropFAID(PropInstanceID):
         """
         H5Pset_mdc_config(self.id, &config.cache_config)
 
+    @with_phil
     def get_alignment(self):
         """
         Retrieves the current settings for alignment properties from a file access property list.
@@ -1439,6 +1440,7 @@ cdef class PropFAID(PropInstanceID):
 
         return threshold, alignment
 
+    @with_phil
     def set_alignment(self, threshold, alignment):
         """
         Sets alignment properties of a file access property list.


### PR DESCRIPTION
Towards https://github.com/h5py/h5py/issues/2475

Running pytest-run-parallel (https://github.com/h5py/h5py/pull/2761) with TSAN (https://github.com/crusaderky/hdf5-pixi) detects a race condition in `test_h5p.py`.

## Reproducer
```bash
git clone https://github.com/crusaderky/hdf5-pixi.git
cd hdf5-pixi
sudo sysctl vm.mmap_rnd_bits=28  # Linux only
pixi r -e h5py-tsan-freethreading h5py-install
pixi r -e h5py-tsan-freethreading h5py-pytest --parallel-threads 4 -k test_set_alignment
```
Output:
```

SUMMARY: ThreadSanitizer: data race hdf5-pixi/hdf5/src/H5CX.c:561 in H5CX_push
==================
WARNING: ThreadSanitizer: data race (pid=188356)
  Read of size 8 at 0x7f31925fb048 by thread T32:
    #1 H5E__get_auto /home/crusaderky/github/hdf5-pixi/hdf5/src/H5Eint.c:1456 (libhdf5.so.1000+0x26c17e)
    #2 H5Eset_auto2 /home/crusaderky/github/hdf5-pixi/hdf5/src/H5E.c:789 (libhdf5.so.1000+0x2597fd)
    #3 __pyx_f_4h5py_7_errors_set_default_error_handler <null> (_errors.cpython-315t-x86_64-linux-gnu.so+0x1887b)
    #4 __pyx_f_4h5py_4defs_H5Pcreate <null> (defs.cpython-315t-x86_64-linux-gnu.so+0x42237)
    #5 __pyx_pf_4h5py_3h5p_create <null> (h5p.cpython-315t-x86_64-linux-gnu.so+0xcba84)
    #6 __pyx_pw_4h5py_3h5p_1create <null> (h5p.cpython-315t-x86_64-linux-gnu.so+0xcb911)
    #7 __Pyx_CyFunction_Vectorcall_FASTCALL_KEYWORDS <null> (h5p.cpython-315t-x86_64-linux-gnu.so+0xcb30d)
    #8 __Pyx_PyVectorcall_FastCallDict <null> (_errors.cpython-315t-x86_64-linux-gnu.so+0x123dd)
    #9 __Pyx_CyFunction_CallAsMethod <null> (_errors.cpython-315t-x86_64-linux-gnu.so+0x116b6)
    #10 __Pyx_PyObject_Call <null> (_objects.cpython-315t-x86_64-linux-gnu.so+0x1c3f3)
    #11 __pyx_pf_4h5py_8_objects_9with_phil_wrapper <null> (_objects.cpython-315t-x86_64-linux-gnu.so+0x37b87)
    #12 __pyx_pw_4h5py_8_objects_9with_phil_1wrapper <null> (_objects.cpython-315t-x86_64-linux-gnu.so+0x372bb)
    #13 __Pyx_CyFunction_CallMethod <null> (_errors.cpython-315t-x86_64-linux-gnu.so+0x125fa)

  Previous write of size 8 at 0x7f31925fb048 by thread T35:
    #0 __tsan_memcpy ../../../../libsanitizer/tsan/tsan_interceptors_memintrinsics.cpp:27 (libtsan.so.2+0x88b2a)
    #1 H5E__set_auto /home/crusaderky/github/hdf5-pixi/hdf5/src/H5Eint.c:1525 (libhdf5.so.1000+0x26c60e)
    #2 H5Eset_auto2 /home/crusaderky/github/hdf5-pixi/hdf5/src/H5E.c:804 (libhdf5.so.1000+0x2598bd)
    #3 __pyx_f_4h5py_7_errors_set_default_error_handler <null> (_errors.cpython-315t-x86_64-linux-gnu.so+0x1887b)
    #4 __pyx_f_4h5py_4defs_H5Pget_alignment <null> (defs.cpython-315t-x86_64-linux-gnu.so+0x31355)
    #5 __pyx_pf_4h5py_3h5p_8PropFAID_46get_alignment <null> (h5p.cpython-315t-x86_64-linux-gnu.so+0xb2803)
    #6 __pyx_pw_4h5py_3h5p_8PropFAID_47get_alignment <null> (h5p.cpython-315t-x86_64-linux-gnu.so+0xadb04)
    #7 __Pyx_CyFunction_Vectorcall_FASTCALL_KEYWORDS <null> (h5p.cpython-315t-x86_64-linux-gnu.so+0xcb30d)

  Location is global 'H5E_stack_g' of size 2112 at 0x7f31925fa840 (libhdf5.so.1000+0xbfb048)

SUMMARY: ThreadSanitizer: data race /home/crusaderky/github/hdf5-pixi/hdf5/src/H5Eint.c:1456 in H5E__get_auto
==================
WARNING: ThreadSanitizer: data race (pid=188356)
  Read of size 8 at 0x720c000007d0 by thread T32:
    #0 H5I__find_id /home/crusaderky/github/hdf5-pixi/hdf5/src/H5Iint.c:1683 (libhdf5.so.1000+0x460e8f)
    #1 H5I_object_verify /home/crusaderky/github/hdf5-pixi/hdf5/src/H5Iint.c:816 (libhdf5.so.1000+0x461a98)
    #2 H5Pcreate /home/crusaderky/github/hdf5-pixi/hdf5/src/H5P.c:236 (libhdf5.so.1000+0x555e62)
    #3 __pyx_f_4h5py_4defs_H5Pcreate <null> (defs.cpython-315t-x86_64-linux-gnu.so+0x42240)
    #4 __pyx_pf_4h5py_3h5p_create <null> (h5p.cpython-315t-x86_64-linux-gnu.so+0xcba84)
    #5 __pyx_pw_4h5py_3h5p_1create <null> (h5p.cpython-315t-x86_64-linux-gnu.so+0xcb911)
    #6 __Pyx_CyFunction_Vectorcall_FASTCALL_KEYWORDS <null> (h5p.cpython-315t-x86_64-linux-gnu.so+0xcb30d)
    #7 __Pyx_PyVectorcall_FastCallDict <null> (_errors.cpython-315t-x86_64-linux-gnu.so+0x123dd)
    #8 __Pyx_CyFunction_CallAsMethod <null> (_errors.cpython-315t-x86_64-linux-gnu.so+0x116b6)
    #9 __Pyx_PyObject_Call <null> (_objects.cpython-315t-x86_64-linux-gnu.so+0x1c3f3)
    #10 __pyx_pf_4h5py_8_objects_9with_phil_wrapper <null> (_objects.cpython-315t-x86_64-linux-gnu.so+0x37b87)
    #11 __pyx_pw_4h5py_8_objects_9with_phil_1wrapper <null> (_objects.cpython-315t-x86_64-linux-gnu.so+0x372bb)
    #12 __Pyx_CyFunction_CallMethod <null> (_errors.cpython-315t-x86_64-linux-gnu.so+0x125fa)

  Previous write of size 8 at 0x720c000007d0 by thread T35:
    #0 H5I__find_id /home/crusaderky/github/hdf5-pixi/hdf5/src/H5Iint.c:1689 (libhdf5.so.1000+0x461232)
    #1 H5I_object_verify /home/crusaderky/github/hdf5-pixi/hdf5/src/H5Iint.c:816 (libhdf5.so.1000+0x461a98)
    #2 H5P_isa_class /home/crusaderky/github/hdf5-pixi/hdf5/src/H5Pint.c:4139 (libhdf5.so.1000+0x5d7410)
    #3 H5P_object_verify /home/crusaderky/github/hdf5-pixi/hdf5/src/H5Pint.c:4221 (libhdf5.so.1000+0x5d7a28)
    #4 H5Pset_alignment /home/crusaderky/github/hdf5-pixi/hdf5/src/H5Pfapl.c:1092 (libhdf5.so.1000+0x59d335)
    #5 __pyx_f_4h5py_4defs_H5Pset_alignment <null> (defs.cpython-315t-x86_64-linux-gnu.so+0x32de6)
    #6 __pyx_pf_4h5py_3h5p_8PropFAID_48set_alignment <null> (h5p.cpython-315t-x86_64-linux-gnu.so+0xb2b25)
    #7 __pyx_pw_4h5py_3h5p_8PropFAID_49set_alignment <null> (h5p.cpython-315t-x86_64-linux-gnu.so+0xadfbf)
    #8 __Pyx_CyFunction_Vectorcall_FASTCALL_KEYWORDS <null> (h5p.cpython-315t-x86_64-linux-gnu.so+0xcb30d)

  Location is heap block of size 48 at 0x720c000007b0 allocated by main thread:
    #1 H5I_register_type /home/crusaderky/github/hdf5-pixi/hdf5/src/H5Iint.c:255 (libhdf5.so.1000+0x45d1ff)
    #2 H5P__init_package /home/crusaderky/github/hdf5-pixi/hdf5/src/H5Pint.c:489 (libhdf5.so.1000+0x5ca1cf)
    #3 H5P_init_phase1 /home/crusaderky/github/hdf5-pixi/hdf5/src/H5Pint.c:427 (libhdf5.so.1000+0x5ca09a)
    #4 H5_init_library /home/crusaderky/github/hdf5-pixi/hdf5/src/H5.c:271 (libhdf5.so.1000+0x852a0)
    #5 H5__init_package /home/crusaderky/github/hdf5-pixi/hdf5/src/H5.c:121 (libhdf5.so.1000+0x84de0)
    #6 H5_init_library /home/crusaderky/github/hdf5-pixi/hdf5/src/H5.c:147 (libhdf5.so.1000+0x85769)
    #7 H5open /home/crusaderky/github/hdf5-pixi/hdf5/src/H5.c:1054 (libhdf5.so.1000+0x88e90)
    #8 __pyx_pymod_exec__errors <null> (_errors.cpython-315t-x86_64-linux-gnu.so+0x6baf)
    #9 run_exec_func /usr/local/src/conda/python-3.15/Objects/moduleobject.c:697 (libpython3.15t.so.1.0+0x1e81eb)
    #10 PyModule_ExecDef /usr/local/src/conda/python-3.15/Objects/moduleobject.c:778 (libpython3.15t.so.1.0+0x1ea43f)
    #11 PyModule_Exec /usr/local/src/conda/python-3.15/Objects/moduleobject.c:755 (libpython3.15t.so.1.0+0x1ea508)
    #12 exec_builtin_or_dynamic /usr/local/src/conda/python-3.15/Python/import.c:873 (libpython3.15t.so.1.0+0x3dd251)
    #13 _imp_exec_dynamic_impl /usr/local/src/conda/python-3.15/Python/import.c:4866 (libpython3.15t.so.1.0+0x3dd251)
    #14 _imp_exec_dynamic /usr/local/src/conda/python-3.15/Python/clinic/import.c.h:516 (libpython3.15t.so.1.0+0x3dd251)
    #15 cfunction_vectorcall_O /usr/local/src/conda/python-3.15/Objects/methodobject.c:536 (libpython3.15t.so.1.0+0x1e71b4)
    #16 _PyVectorcall_Call /usr/local/src/conda/python-3.15/Objects/call.c:273 (libpython3.15t.so.1.0+0x13f458)
    #17 _PyObject_Call /usr/local/src/conda/python-3.15/Objects/call.c:348 (libpython3.15t.so.1.0+0x13f70b)
    #18 PyObject_Call /usr/local/src/conda/python-3.15/Objects/call.c:373 (libpython3.15t.so.1.0+0x13f77a)
    #19 _PyEval_EvalFrameDefault /usr/local/src/conda/python-3.15/Python/generated_cases.c.h:2582 (libpython3.15t.so.1.0+0x351a92)
    #20 _PyEval_EvalFrame /usr/local/src/conda/python-3.15/Include/internal/pycore_ceval.h:118 (libpython3.15t.so.1.0+0x36c559)
    #21 _PyEval_Vector /usr/local/src/conda/python-3.15/Python/ceval.c:2094 (libpython3.15t.so.1.0+0x36c559)
    #22 _PyFunction_Vectorcall /usr/local/src/conda/python-3.15/Objects/call.c:413 (libpython3.15t.so.1.0+0x13c551)
    #23 _PyObject_VectorcallTstate /usr/local/src/conda/python-3.15/Include/internal/pycore_call.h:136 (libpython3.15t.so.1.0+0x13ce34)
    #24 object_vacall /usr/local/src/conda/python-3.15/Objects/call.c:823 (libpython3.15t.so.1.0+0x13ce34)
    #25 PyObject_CallMethodObjArgs /usr/local/src/conda/python-3.15/Objects/call.c:890 (libpython3.15t.so.1.0+0x13d139)
    #26 import_find_and_load /usr/local/src/conda/python-3.15/Python/import.c:3807 (libpython3.15t.so.1.0+0x3e66d8)
    #27 PyImport_ImportModuleLevelObject /usr/local/src/conda/python-3.15/Python/import.c:3888 (libpython3.15t.so.1.0+0x3e66d8)
    #28 builtin___import___impl /usr/local/src/conda/python-3.15/Python/bltinmodule.c:285 (libpython3.15t.so.1.0+0x33384a)

SUMMARY: ThreadSanitizer: data race /home/crusaderky/github/hdf5-pixi/hdf5/src/H5Iint.c:1683 in H5I__find_id
==================
WARNING: ThreadSanitizer: data race (pid=188356)
  Write of size 8 at 0x7f319261ea48 by thread T32:
    #0 H5FL_reg_malloc /home/crusaderky/github/hdf5-pixi/hdf5/src/H5FL.c:359 (libhdf5.so.1000+0x36df92)
    #1 H5FL_reg_calloc /home/crusaderky/github/hdf5-pixi/hdf5/src/H5FL.c:395 (libhdf5.so.1000+0x36e5f5)
    #2 H5P__create /home/crusaderky/github/hdf5-pixi/hdf5/src/H5Pint.c:1890 (libhdf5.so.1000+0x5cb3c6)
    #3 H5P_create_id /home/crusaderky/github/hdf5-pixi/hdf5/src/H5Pint.c:2025 (libhdf5.so.1000+0x5cb3c6)
    #4 H5Pcreate /home/crusaderky/github/hdf5-pixi/hdf5/src/H5P.c:240 (libhdf5.so.1000+0x555e77)
    #5 __pyx_f_4h5py_4defs_H5Pcreate <null> (defs.cpython-315t-x86_64-linux-gnu.so+0x42240)
    #6 __pyx_pf_4h5py_3h5p_create <null> (h5p.cpython-315t-x86_64-linux-gnu.so+0xcba84)
    #7 __pyx_pw_4h5py_3h5p_1create <null> (h5p.cpython-315t-x86_64-linux-gnu.so+0xcb911)
    #8 __Pyx_CyFunction_Vectorcall_FASTCALL_KEYWORDS <null> (h5p.cpython-315t-x86_64-linux-gnu.so+0xcb30d)
    #9 __Pyx_PyVectorcall_FastCallDict <null> (_errors.cpython-315t-x86_64-linux-gnu.so+0x123dd)
    #10 __Pyx_CyFunction_CallAsMethod <null> (_errors.cpython-315t-x86_64-linux-gnu.so+0x116b6)
    #11 __Pyx_PyObject_Call <null> (_objects.cpython-315t-x86_64-linux-gnu.so+0x1c3f3)
    #12 __pyx_pf_4h5py_8_objects_9with_phil_wrapper <null> (_objects.cpython-315t-x86_64-linux-gnu.so+0x37b87)
    #13 __pyx_pw_4h5py_8_objects_9with_phil_1wrapper <null> (_objects.cpython-315t-x86_64-linux-gnu.so+0x372bb)
    #14 __Pyx_CyFunction_CallMethod <null> (_errors.cpython-315t-x86_64-linux-gnu.so+0x125fa)

  Previous write of size 8 at 0x7f319261ea48 by thread T35:
    #0 H5FL_reg_malloc /home/crusaderky/github/hdf5-pixi/hdf5/src/H5FL.c:359 (libhdf5.so.1000+0x36df92)
    #1 H5P__dup_prop /home/crusaderky/github/hdf5-pixi/hdf5/src/H5Pint.c:1189 (libhdf5.so.1000+0x5cce43)
    #2 H5P__set_pclass_cb /home/crusaderky/github/hdf5-pixi/hdf5/src/H5Pint.c:3182 (libhdf5.so.1000+0x5d3784)
    #3 H5P__do_prop /home/crusaderky/github/hdf5-pixi/hdf5/src/H5Pint.c:2852 (libhdf5.so.1000+0x5d2149)
    #4 H5P_set /home/crusaderky/github/hdf5-pixi/hdf5/src/H5Pint.c:3250 (libhdf5.so.1000+0x5d2b56)
    #5 H5Pset_alignment /home/crusaderky/github/hdf5-pixi/hdf5/src/H5Pfapl.c:1096 (libhdf5.so.1000+0x59d355)
    #6 __pyx_f_4h5py_4defs_H5Pset_alignment <null> (defs.cpython-315t-x86_64-linux-gnu.so+0x32de6)
    #7 __pyx_pf_4h5py_3h5p_8PropFAID_48set_alignment <null> (h5p.cpython-315t-x86_64-linux-gnu.so+0xb2b25)
    #8 __pyx_pw_4h5py_3h5p_8PropFAID_49set_alignment <null> (h5p.cpython-315t-x86_64-linux-gnu.so+0xadfbf)
    #9 __Pyx_CyFunction_Vectorcall_FASTCALL_KEYWORDS <null> (h5p.cpython-315t-x86_64-linux-gnu.so+0xcb30d)

  Location is global 'H5FL_reg_gc_head.0' of size 8 at 0x7f319261ea48 (libhdf5.so.1000+0xc1ea48)

SUMMARY: ThreadSanitizer: data race /home/crusaderky/github/hdf5-pixi/hdf5/src/H5FL.c:359 in H5FL_reg_malloc
==================
```