### PR TITLE
Fix lib version skip test check

### DIFF
--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -481,8 +481,9 @@ class TestDrivers(TestCase):
 
 
 @pytest.mark.skipif(
+    h5py.version.hdf5_version_tuple[0] == 1  and
     h5py.version.hdf5_version_tuple[1] % 2 != 0 ,
-    reason='Not HDF5 release version'
+    reason='Not HDF5 release version 1.x.y'
 )
 class TestNewLibver(TestCase):
 


### PR DESCRIPTION
Since HDF5 2.0.0, the version number is fully SemVer so the odd minor number does not reflect any more a dev release.

This was discovered when testing with a pre-release of HDF5 2.1.0.