### PR TITLE
Require mpi4py 4.0.0 at build time on Python <= 3.12

### DIFF
--- a/_custom_build/backend.py
+++ b/_custom_build/backend.py
@@ -21,9 +21,10 @@ def get_requires_for_build_wheel(config_settings=None):
     # these build requirements for any reason.
     if os.getenv('HDF5_MPI') == 'ON' and os.getenv('H5PY_SETUP_REQUIRES') != '0':
         requires.extend([
-            "mpi4py ==3.1.2; python_version=='3.10.*'",
-            "mpi4py ==3.1.4; python_version=='3.11.*'",
-            "mpi4py ==3.1.6; python_version=='3.12.*'",
+            # mpi4py 3.x fails to build with setuptools >= 81, so we'll use 4.0
+            # to keep things simple. If you need to build with older mpi4py, it
+            # may well work, but it's up to you to figure out.
+            "mpi4py ==4.0.0; python_version<'3.13'",
             "mpi4py ==4.0.1; python_version=='3.13.*'",
             "mpi4py ==4.1.0; python_version=='3.14.*'",
             # leave dependency unpinned for unstable Python versions

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,9 @@ RUN_REQUIRES = [
 ]
 
 if setup_configure.mpi_enabled():
-    # 3.1.2 is the first release with any wheels for Python 3.10
-    RUN_REQUIRES.append('mpi4py >=3.1.2')
+    # Older mpi4py probably still works if you need it, but 3.x versions can't
+    # build with setuptools >= 81, so for simplicity we build with 4.x.
+    RUN_REQUIRES.append('mpi4py >=4.0')
 
 # --- Custom setuptools commands -----------------------------------------------
 


### PR DESCRIPTION
I think this should be a simple solution. It possibly makes it slightly harder to build h5py with mpi4py 3.x, but I think it's common to skip build isolation for building with MPI support anyway, so this shouldn't be a big issue.

Closes #2797