### PR TITLE
Remove redundant call to nonlocal_close()

### DIFF
--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -621,7 +621,6 @@ class File(Group):
                 self.id._close_open_objects(h5f.OBJ_LOCAL | h5f.OBJ_FILE)
 
                 self.id.close()
-                _objects.nonlocal_close()
 
     def flush(self):
         """ Tell the HDF5 library to flush its buffers.


### PR DESCRIPTION
The high-level `File.close()` method calls this `nonlocal_close()` function immediately after the low-level `FileID.close()`, which calls the same function as its last step.

https://github.com/h5py/h5py/blob/217ce872fdb509cebfa3c0ce1960e9a439acddd3/h5py/h5f.templ.pyx#L332-L341

There's no particular harm in calling this twice, but the second call is redundant, it shouldn't find anything that wasn't cleaned up by the first. And if it does, there's a bug somewhere, and we should try to understand that rather than paper over it.