### PR TITLE
Disable Windows ARM builds

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -70,8 +70,9 @@ jobs:
             arch: aarch64
           - os: windows-latest
             arch: AMD64
-          - os: windows-11-arm
-            arch: ARM64
+          # See https://github.com/h5py/h5py/issues/2816
+          #- os: windows-11-arm
+          #  arch: ARM64
           - os: macos-14
             arch: arm64
           - os: macos-15-intel


### PR DESCRIPTION
These are failing - see #2816 - and we have so far not identified why. I propose that we disable them until someone can figure it out, making it easier to see when there are other CI failures which we should pay attention to, and saving a little bit of energy.