### PR TITLE
Update Ubuntu image & Python version for RTD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,9 @@
 version: 2  # Required
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "3.10"
+    python: "3.13"
 
 sphinx:
    configuration: docs/conf.py


### PR DESCRIPTION
I got a notification from RTD that the `ubuntu-20.04` image is deprecated, to be removed on 2026-06-01. This follows the recommended upgrade to 24.04, and also bumps the Python version at the same time.