### PR TITLE
MNT: forbid uv to install mixed-language packages from sources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,5 +163,18 @@ H5PY_ROS3 = "0"
 H5PY_DIRECT_VFD = "0"
 
 [tool.uv]
-# never build numpy from source
-no-build-package = ["numpy"]
+# never build the following packages from source
+no-build-package = [
+    "blosc2",
+    "cffi",
+    "charset-normalizer",
+    "cryptography",
+    "markupsafe",
+    "msgpack",
+    "ndindex",
+    "nh3",
+    "numexpr",
+    "numpy",
+    "pyyaml",
+    "tables",
+]


### PR DESCRIPTION
From a quick scan, I think this is our only other (dev only) dependency that takes significant resources to compile, so it's worth ignoring versions that don't have compatible wheels when resolving.