### PR TITLE
MNT: upgrade zizmor pre-commit hook, address new results and adjust settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       actions:
         patterns:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -207,13 +207,7 @@ jobs:
 
       # If it's a tag, create a Github release
       - name: Upload to GitHub releases
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
-        # https://github.com/softprops/action-gh-release?tab=readme-ov-file#inputs
-        with:
-          draft: false
-          generate_release_notes: false
-          files: |
-            dist/*
+        run: gh release create dist/*
         if: github.repository_owner == 'h5py' && github.event_name == 'push'
 
       # If it's a tag, publish to PyPI

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -89,7 +89,7 @@ jobs:
 
       # Windows HDF5
       - name: Cache built HDF5 (Windows)
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4  # zizmor: ignore[cache-poisoning] cache not used when uploading wheels
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           key: ${{ matrix.os }}-${{ matrix.arch }}-0-${{ hashFiles('ci/cibw_before_all_windows.sh', 'ci/get_hdf5_win.py') }}
           path: cache/hdf5
@@ -107,7 +107,7 @@ jobs:
 
       # macOS HDF5
       - name: Cache built HDF5 (Mac)
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4  # zizmor: ignore[cache-poisoning] cache not used when uploading wheels
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           key: ${{ matrix.os }}-${{ matrix.arch }}-0-${{ hashFiles('ci/cibw_before_all_macos.sh', 'ci/get_hdf5_if_needed.sh') }}
           path: cache/hdf5

--- a/.github/zizmor.yaml
+++ b/.github/zizmor.yaml
@@ -1,0 +1,6 @@
+rules:
+  cache-poisoning:
+    ignore:
+      # actions/cache is already disabled for releases
+      - build_wheels.yml:92
+      - build_wheels.yml:110

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         exclude: .+\.patch
 
 - repo: https://github.com/zizmorcore/zizmor-pre-commit
-  rev: v1.13.0
+  rev: v1.24.1
   hooks:
     - id: zizmor
 


### PR DESCRIPTION
- **MNT: move zizmor ignores to a config file to allow dependabot to update version comments**
- **MNT: replace superflous action with gh**
- **MNT: upgrade zizmor pre-commit hook**
- **MNT: add missing cooldown setting**

<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py312-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->
