### PR TITLE
Support user tags for opaque datatypes

### DIFF
--- a/docs/special.rst
+++ b/docs/special.rst
@@ -225,13 +225,41 @@ Here's an example of storing and reading a datetime array::
     >>> print(f['data'][:])
     ['2019-09-22T17:38:30']
 
-.. function:: opaque_dtype(dt)
+.. function:: opaque_dtype(dt, *, tag=None)
 
    Return a dtype like the input, tagged to be stored as HDF5 opaque type.
+
+   :param dt: Any numpy dtype whose itemsize is non-zero and which is not an
+              object, structured, or sub-array dtype.
+   :param tag: Optional HDF5 opaque tag (``str`` or ``bytes``). Strings are
+               encoded as UTF-8. When ``None`` (default), h5py auto-generates
+               a ``b"NUMPY:..."`` tag that lets the original numpy dtype be
+               restored on read.
+
+   A user-supplied tag must be non-empty, at most 255 bytes, and must not
+   contain a NUL byte. The prefix ``b"NUMPY:"`` is reserved for h5py's
+   automatic dtype round-trip, and ``b"PYTHON:OBJECT"`` is reserved for
+   h5py internals; both raise :class:`ValueError`.
+
+   Setting a custom tag disables the numpy-dtype round-trip: on read, the
+   dataset dtype is ``|V<n>`` and the tag is exposed via
+   :func:`get_opaque_tag`. Example::
+
+       >>> dt = h5py.opaque_dtype(np.dtype('V16'), tag=b'org.example.uuid')
+       >>> f.create_dataset('ids', shape=(10,), dtype=dt)
+       >>> h5py.get_opaque_tag(f['ids'].dtype)
+       b'org.example.uuid'
 
 .. function:: check_opaque_dtype(dt)
 
    Return True if the dtype given is tagged to be stored as HDF5 opaque data.
+
+.. function:: get_opaque_tag(dt)
+
+   Return the custom HDF5 opaque tag for ``dt`` as ``bytes``, or ``None`` if
+   ``dt`` is not opaque or carries h5py's automatic ``b"NUMPY:..."`` tag.
+   The tag can also be read from a committed opaque datatype via
+   :attr:`Datatype.opaque_tag <h5py.Datatype.opaque_tag>`.
 
 .. note::
 

--- a/docs/special.rst
+++ b/docs/special.rst
@@ -237,7 +237,7 @@ Here's an example of storing and reading a datetime array::
                restored on read.
 
    A user-supplied tag must be non-empty, at most 255 bytes, and must not
-   contain a NUL byte. The prefix ``b"NUMPY:"`` is reserved for h5py's
+   contain a NULL byte. The prefix ``b"NUMPY:"`` is reserved for h5py's
    automatic dtype round-trip, and ``b"PYTHON:OBJECT"`` is reserved for
    h5py internals; both raise :class:`ValueError`.
 

--- a/h5py/__init__.py
+++ b/h5py/__init__.py
@@ -76,7 +76,7 @@ from .h5t import (special_dtype, check_dtype,
     vlen_dtype, string_dtype, enum_dtype, ref_dtype, regionref_dtype,
     opaque_dtype, complex_compat_dtype,
     check_vlen_dtype, check_string_dtype, check_enum_dtype, check_ref_dtype,
-    check_opaque_dtype, check_complex_dtype,
+    check_opaque_dtype, check_complex_dtype, get_opaque_tag,
 )
 from .h5s import UNLIMITED
 

--- a/h5py/_hl/datatype.py
+++ b/h5py/_hl/datatype.py
@@ -13,7 +13,7 @@
 
 import posixpath as pp
 
-from ..h5t import TypeID
+from ..h5t import TypeID, TypeOpaqueID
 from .base import HLObject, with_phil
 
 class Datatype(HLObject):
@@ -33,6 +33,19 @@ class Datatype(HLObject):
     def dtype(self):
         """Numpy dtype equivalent for this datatype"""
         return self.id.dtype
+
+    @property
+    @with_phil
+    def opaque_tag(self):
+        """HDF5 opaque tag as ``bytes``, or ``None``.
+
+        Returns the tag stored on the underlying HDF5 opaque datatype, or
+        ``None`` if this committed datatype is not opaque or has no tag set.
+        """
+        if not isinstance(self.id, TypeOpaqueID):
+            return None
+        tag = self.id.get_tag()
+        return tag if tag else None
 
     @with_phil
     def __init__(self, bind):

--- a/h5py/_hl/datatype.py
+++ b/h5py/_hl/datatype.py
@@ -16,6 +16,7 @@ import posixpath as pp
 from ..h5t import TypeID, TypeOpaqueID
 from .base import HLObject, with_phil
 
+
 class Datatype(HLObject):
 
     """
@@ -36,7 +37,7 @@ class Datatype(HLObject):
 
     @property
     @with_phil
-    def opaque_tag(self):
+    def opaque_tag(self) -> bytes | None:
         """HDF5 opaque tag as ``bytes``, or ``None``.
 
         Returns the tag stored on the underlying HDF5 opaque datatype, or

--- a/h5py/h5t.templ.pyx
+++ b/h5py/h5t.templ.pyx
@@ -739,6 +739,15 @@ cdef class TypeOpaqueID(TypeID):
             # 6 = len("NUMPY:")
             return np.dtype(tag[6:], metadata={'h5py_opaque': True})
 
+        # A non-empty, non-reserved tag is user-supplied (set via
+        # opaque_dtype(..., tag=...) or by another tool). Surface it in the
+        # dtype metadata so copies and inspection can see it.
+        if tag and tag != b"PYTHON:OBJECT":
+            return np.dtype(
+                "|V" + str(self.get_size()),
+                metadata={'h5py_opaque': True, 'h5py_opaque_tag': tag},
+            )
+
         # Numpy translation function for opaque types
         return np.dtype("|V" + str(self.get_size()))
 
@@ -1613,11 +1622,17 @@ cdef TypeOpaqueID _c_opaque_tagged(cnp.dtype dt):
     Tagged opaque types can be read back easily in h5py, but not in other tools
     (they are *opaque*).
 
-    The default tag is generated via the code:
+    If the dtype metadata carries a user-supplied ``h5py_opaque_tag`` (set by
+    :func:`opaque_dtype` with a ``tag=`` argument), it is used as-is.
+    Otherwise the tag is generated via the code:
     ``b"NUMPY:" + dt_in.descr[0][1].encode()``.
     """
     cdef TypeOpaqueID new_type = _c_opaque(dt)
-    new_type.set_tag(b"NUMPY:" + dt.descr[0][1].encode())
+    user_tag = (dt.metadata or {}).get('h5py_opaque_tag')
+    if user_tag is not None:
+        new_type.set_tag(user_tag)
+    else:
+        new_type.set_tag(b"NUMPY:" + dt.descr[0][1].encode())
 
     return new_type
 
@@ -1918,12 +1933,29 @@ def enum_dtype(values_dict, basetype=np.uint8):
     return np.dtype(dt, metadata={'enum': values_dict})
 
 
-def opaque_dtype(np_dtype):
+def opaque_dtype(np_dtype, *, tag=None):
     """Return an equivalent dtype tagged to be stored in an HDF5 opaque type.
 
     This makes it easy to store numpy data like datetimes for which there is
     no equivalent HDF5 type, but it's not interoperable: other tools won't treat
     the opaque data as datetimes.
+
+    If *tag* is given (``str`` or ``bytes``), it is used as the HDF5 opaque
+    tag for the stored type. Strings are encoded as UTF-8. When *tag* is
+    ``None`` (the default), h5py auto-generates a ``b"NUMPY:..."`` tag that
+    lets the original numpy dtype be restored on read.
+
+    Tag restrictions (HDF5 and h5py):
+
+    - must be non-empty and at most 255 bytes after encoding,
+    - must not contain a NUL byte,
+    - must not start with ``b"NUMPY:"`` (reserved for h5py's automatic
+      dtype round-trip), and must not be ``b"PYTHON:OBJECT"`` or
+      ``b"NUMPY:STRING"`` (reserved for h5py internals).
+
+    A custom tag disables the numpy-dtype round-trip: on read, datasets are
+    returned as plain ``|V<n>`` with the tag exposed via
+    :func:`get_opaque_tag`.
     """
     dt = np.dtype(np_dtype)
     if np.issubdtype(dt, np.object_):
@@ -1935,7 +1967,39 @@ def opaque_dtype(np_dtype):
     if dt.itemsize == 0:
         raise TypeError("dtype for opaque data must have explicit size")
 
-    return np.dtype(dt, metadata={'h5py_opaque': True})
+    if tag is None:
+        return np.dtype(dt, metadata={'h5py_opaque': True})
+
+    if isinstance(tag, str):
+        tag_bytes = tag.encode('utf-8')
+    elif isinstance(tag, (bytes, bytearray)):
+        tag_bytes = bytes(tag)
+    else:
+        raise TypeError(
+            "opaque tag must be str or bytes, got %r" % type(tag).__name__
+        )
+
+    if len(tag_bytes) == 0:
+        raise ValueError("opaque tag must be non-empty")
+    if b'\x00' in tag_bytes:
+        raise ValueError("opaque tag must not contain a NUL byte")
+    if len(tag_bytes) > 255:
+        raise ValueError(
+            "opaque tag is limited to 255 bytes (got %d)" % len(tag_bytes)
+        )
+    if tag_bytes.startswith(b"NUMPY:"):
+        raise ValueError(
+            "tag prefix b'NUMPY:' is reserved for h5py's automatic numpy "
+            "dtype round-trip"
+        )
+    if tag_bytes == b"PYTHON:OBJECT":
+        raise ValueError(
+            "tag b'PYTHON:OBJECT' is reserved for h5py internals"
+        )
+
+    return np.dtype(
+        dt, metadata={'h5py_opaque': True, 'h5py_opaque_tag': tag_bytes}
+    )
 
 
 ref_dtype = np.dtype('O', metadata={'ref': Reference})
@@ -2067,6 +2131,21 @@ def check_opaque_dtype(dt):
         return dt.metadata.get('h5py_opaque', False)
     except AttributeError:
         return False
+
+
+def get_opaque_tag(dt):
+    """Return the custom HDF5 opaque tag for ``dt``, or ``None``.
+
+    If ``dt`` was produced by :func:`opaque_dtype` with a ``tag=`` argument,
+    or is the dtype of a dataset whose stored opaque tag is not an h5py
+    automatic tag, the tag is returned as ``bytes``. Otherwise ``None`` is
+    returned (including for non-opaque dtypes and for h5py's automatic
+    ``b"NUMPY:..."`` tags, which encode the numpy dtype instead).
+    """
+    try:
+        return dt.metadata.get('h5py_opaque_tag')
+    except AttributeError:
+        return None
 
 
 def check_ref_dtype(dt):

--- a/h5py/h5t.templ.pyx
+++ b/h5py/h5t.templ.pyx
@@ -1979,14 +1979,12 @@ def opaque_dtype(np_dtype, *, tag=None):
             "opaque tag must be str or bytes, got %r" % type(tag).__name__
         )
 
-    if len(tag_bytes) == 0:
+    if (tag_size := len(tag_bytes)) == 0:
         raise ValueError("opaque tag must be non-empty")
+    if tag_size > 255:
+        raise ValueError(f"opaque tag is limited to 255 bytes (got {tag_size})")
     if b'\x00' in tag_bytes:
-        raise ValueError("opaque tag must not contain a NUL byte")
-    if len(tag_bytes) > 255:
-        raise ValueError(
-            "opaque tag is limited to 255 bytes (got %d)" % len(tag_bytes)
-        )
+        raise ValueError("opaque tag must not contain a NULL byte")
     if tag_bytes.startswith(b"NUMPY:"):
         raise ValueError(
             "tag prefix b'NUMPY:' is reserved for h5py's automatic numpy "

--- a/h5py/h5t.templ.pyx
+++ b/h5py/h5t.templ.pyx
@@ -1933,7 +1933,7 @@ def enum_dtype(values_dict, basetype=np.uint8):
     return np.dtype(dt, metadata={'enum': values_dict})
 
 
-def opaque_dtype(np_dtype, *, tag=None):
+def opaque_dtype(np_dtype, *, tag: str | bytes | bytearray | None = None) -> np.dtype:
     """Return an equivalent dtype tagged to be stored in an HDF5 opaque type.
 
     This makes it easy to store numpy data like datetimes for which there is
@@ -2131,7 +2131,7 @@ def check_opaque_dtype(dt):
         return False
 
 
-def get_opaque_tag(dt):
+def get_opaque_tag(dt: np.dtype) -> bytes | None:
     """Return the custom HDF5 opaque tag for ``dt``, or ``None``.
 
     If ``dt`` was produced by :func:`opaque_dtype` with a ``tag=`` argument,

--- a/h5py/tests/test_dtype.py
+++ b/h5py/tests/test_dtype.py
@@ -5,6 +5,7 @@
 from itertools import count
 import platform
 import numpy as np
+import pytest
 import h5py
 try:
     import tables
@@ -530,6 +531,113 @@ def test_opaque(writable_file):
     assert isinstance(ds.id.get_type(), h5py.h5t.TypeOpaqueID)
     assert ds.id.get_type().get_size() == 2
     np.testing.assert_array_equal(ds[:], arr)
+
+
+def test_opaque_tag_dataset_roundtrip(writable_file):
+    tag = b'org.example.uuid'
+    dt = h5py.opaque_dtype(np.dtype('V16'), tag=tag)
+    assert h5py.get_opaque_tag(dt) == tag
+
+    ds = writable_file.create_dataset(make_name(), data=np.zeros(4, dtype=dt))
+    assert ds.id.get_type().get_tag() == tag
+    assert h5py.check_opaque_dtype(ds.dtype)
+    assert h5py.get_opaque_tag(ds.dtype) == tag
+    assert ds.dtype.itemsize == 16
+
+
+def test_opaque_tag_str_encoded_as_utf8():
+    dt = h5py.opaque_dtype(np.dtype('V4'), tag='utf8-\u00e9')
+    assert h5py.get_opaque_tag(dt) == 'utf8-\u00e9'.encode('utf-8')
+
+
+def test_opaque_tag_on_attribute(tmp_path):
+    tag = b'my-attr-tag'
+    dt = h5py.opaque_dtype(np.dtype('V3'), tag=tag)
+    path = tmp_path / 'attr_tag.h5'
+    with h5py.File(path, 'w') as f:
+        f.attrs.create('x', data=np.zeros(2, dtype=dt), dtype=dt)
+
+    with h5py.File(path, 'r') as f:
+        assert h5py.get_opaque_tag(f.attrs['x'].dtype) == tag
+
+
+def test_opaque_tag_committed_datatype(tmp_path):
+    tag = b'committed-opaque-v1'
+    dt = h5py.opaque_dtype(np.dtype('V8'), tag=tag)
+    path = tmp_path / 'committed_tag.h5'
+    with h5py.File(path, 'w') as f:
+        f['t'] = dt
+
+    with h5py.File(path, 'r') as f:
+        named = f['t']
+        assert isinstance(named, h5py.Datatype)
+        assert named.opaque_tag == tag
+        assert h5py.get_opaque_tag(named.dtype) == tag
+
+
+def test_opaque_default_no_tag_backwards_compatible(tmp_path):
+    # No-tag opaque_dtype should still produce the NUMPY:... on-disk tag
+    # and round-trip the original numpy dtype.
+    original = np.dtype('<M8[ns]')
+    dt = h5py.opaque_dtype(original)
+    assert h5py.get_opaque_tag(dt) is None
+
+    path = tmp_path / 'default_tag.h5'
+    arr = np.array([0], dtype='<i8').view(dt)
+    with h5py.File(path, 'w') as f:
+        f.create_dataset('d', data=arr, dtype=dt)
+
+    with h5py.File(path, 'r') as f:
+        ds = f['d']
+        assert ds.dtype == original
+        # NUMPY: tags do not surface as get_opaque_tag
+        assert h5py.get_opaque_tag(ds.dtype) is None
+
+
+def test_opaque_tag_astype_preserves_metadata():
+    tag = b'keep-me'
+    dt = h5py.opaque_dtype(np.dtype('V2'), tag=tag)
+    arr = np.zeros(3, dtype='V2').astype(dt)
+    assert h5py.get_opaque_tag(arr.dtype) == tag
+
+
+def test_opaque_foreign_tag_surfaces_on_read(tmp_path):
+    # A tag written via the low-level API (not h5py's NUMPY: scheme) is
+    # exposed through get_opaque_tag on read.
+    foreign_tag = b'other-tool/opaque'
+    path = tmp_path / 'foreign_tag.h5'
+    with h5py.File(path, 'w') as f:
+        tid = h5py.h5t.create(h5py.h5t.OPAQUE, 4)
+        tid.set_tag(foreign_tag)
+        space = h5py.h5s.create_simple((3,))
+        h5py.h5d.create(f.id, b'x', tid, space)
+
+    with h5py.File(path, 'r') as f:
+        ds = f['x']
+        assert h5py.check_opaque_dtype(ds.dtype)
+        assert h5py.get_opaque_tag(ds.dtype) == foreign_tag
+
+
+@pytest.mark.parametrize('bad_tag', [
+    b'',
+    b'has\x00nul',
+    b'x' * 256,
+    b'NUMPY:something',
+    b'PYTHON:OBJECT',
+])
+def test_opaque_tag_validation_value_errors(bad_tag):
+    with pytest.raises(ValueError):
+        h5py.opaque_dtype(np.dtype('V2'), tag=bad_tag)
+
+
+def test_opaque_tag_validation_type_error():
+    with pytest.raises(TypeError):
+        h5py.opaque_dtype(np.dtype('V2'), tag=123)
+
+
+def test_get_opaque_tag_on_plain_dtypes():
+    assert h5py.get_opaque_tag(np.dtype('i4')) is None
+    assert h5py.get_opaque_tag(np.dtype('V4')) is None
 
 
 def test_create_bitfield(writable_file):

--- a/h5py/tests/test_dtype.py
+++ b/h5py/tests/test_dtype.py
@@ -525,7 +525,7 @@ class TestBitfield(TestCase):
             self.assertArrayEqual(dset[:], arr1)
 
 def test_opaque(writable_file):
-    # opaque without an h5py tag corresponds to numpy void dtypes
+    """Opaque without an h5py tag corresponds to numpy void dtypes"""
     arr = np.zeros(3, dtype='V2')
     ds = writable_file.create_dataset(make_name(), data=arr)
     assert isinstance(ds.id.get_type(), h5py.h5t.TypeOpaqueID)
@@ -534,6 +534,7 @@ def test_opaque(writable_file):
 
 
 def test_opaque_tag_dataset_roundtrip(writable_file):
+    """User opaque tag"""
     tag = b'org.example.uuid'
     dt = h5py.opaque_dtype(np.dtype('V16'), tag=tag)
     assert h5py.get_opaque_tag(dt) == tag
@@ -546,14 +547,16 @@ def test_opaque_tag_dataset_roundtrip(writable_file):
 
 
 def test_opaque_tag_str_encoded_as_utf8():
+    """ User opaque tag as UTF-8 string"""
     dt = h5py.opaque_dtype(np.dtype('V4'), tag='utf8-\u00e9')
     assert h5py.get_opaque_tag(dt) == 'utf8-\u00e9'.encode('utf-8')
 
 
 def test_opaque_tag_on_attribute(tmp_path):
+    """User tag for attribute opaque dtype"""
     tag = b'my-attr-tag'
     dt = h5py.opaque_dtype(np.dtype('V3'), tag=tag)
-    path = tmp_path / 'attr_tag.h5'
+    path = tmp_path / make_name('attr_tag{}.h5')
     with h5py.File(path, 'w') as f:
         f.attrs.create('x', data=np.zeros(2, dtype=dt), dtype=dt)
 
@@ -562,11 +565,13 @@ def test_opaque_tag_on_attribute(tmp_path):
 
 
 def test_opaque_tag_committed_datatype(tmp_path):
+    """User tag on committed opaque dtype"""
     tag = b'committed-opaque-v1'
     dt = h5py.opaque_dtype(np.dtype('V8'), tag=tag)
-    path = tmp_path / 'committed_tag.h5'
+    path = tmp_path / make_name('committed_tag{}.h5')
     with h5py.File(path, 'w') as f:
         f['t'] = dt
+        f['int32'] = np.dtype('int32')
 
     with h5py.File(path, 'r') as f:
         named = f['t']
@@ -574,15 +579,19 @@ def test_opaque_tag_committed_datatype(tmp_path):
         assert named.opaque_tag == tag
         assert h5py.get_opaque_tag(named.dtype) == tag
 
+        i32 = f['int32']
+        assert isinstance(i32, h5py.Datatype)
+        assert i32.opaque_tag is None
+        assert h5py.get_opaque_tag(i32.dtype) is None
+
 
 def test_opaque_default_no_tag_backwards_compatible(tmp_path):
-    # No-tag opaque_dtype should still produce the NUMPY:... on-disk tag
-    # and round-trip the original numpy dtype.
+    """No tag opaque dtype tag round-trip"""
     original = np.dtype('<M8[ns]')
     dt = h5py.opaque_dtype(original)
     assert h5py.get_opaque_tag(dt) is None
 
-    path = tmp_path / 'default_tag.h5'
+    path = tmp_path / make_name('default_tag{}.h5')
     arr = np.array([0], dtype='<i8').view(dt)
     with h5py.File(path, 'w') as f:
         f.create_dataset('d', data=arr, dtype=dt)
@@ -595,6 +604,7 @@ def test_opaque_default_no_tag_backwards_compatible(tmp_path):
 
 
 def test_opaque_tag_astype_preserves_metadata():
+    """User opaque dtype tag carries metadata"""
     tag = b'keep-me'
     dt = h5py.opaque_dtype(np.dtype('V2'), tag=tag)
     arr = np.zeros(3, dtype='V2').astype(dt)
@@ -602,10 +612,9 @@ def test_opaque_tag_astype_preserves_metadata():
 
 
 def test_opaque_foreign_tag_surfaces_on_read(tmp_path):
-    # A tag written via the low-level API (not h5py's NUMPY: scheme) is
-    # exposed through get_opaque_tag on read.
+    """A tag written via the low-level API"""
     foreign_tag = b'other-tool/opaque'
-    path = tmp_path / 'foreign_tag.h5'
+    path = tmp_path / make_name('foreign_tag{}.h5')
     with h5py.File(path, 'w') as f:
         tid = h5py.h5t.create(h5py.h5t.OPAQUE, 4)
         tid.set_tag(foreign_tag)

--- a/news/user-tag-opaque.rst
+++ b/news/user-tag-opaque.rst
@@ -1,0 +1,10 @@
+New features
+------------
+
+* Support for user supplied tags for opaque datatypes. :func:`h5py.opaque_dtype`
+  now has a keyword ``tag`` argument to set a custom HDF5 opaque datatype
+  tag. A new :func:`h5py.get_opaque_tag` helper returns the tag from a dtype,
+  and :attr:`h5py.Datatype.opaque_tag` exposes it on committed opaque datatypes.
+  Opaque datasets written by other tools (with a non-``NUMPY:`` tag) are now
+  recognised by :func:`~h5py.check_opaque_dtype` on read, and their tag is
+  available via :func:`~h5py.get_opaque_tag`. See :ref:`opaque_dtypes`.

--- a/news/user-tag-opaque.rst
+++ b/news/user-tag-opaque.rst
@@ -8,3 +8,13 @@ New features
   Opaque datasets written by other tools (with a non-``NUMPY:`` tag) are now
   recognised by :func:`~h5py.check_opaque_dtype` on read, and their tag is
   available via :func:`~h5py.get_opaque_tag`. See :ref:`opaque_dtypes`.
+
+Development
+-----------
+
+* The opaque tag API carries type annotations: :func:`h5py.get_opaque_tag`, the
+  ``tag`` keyword of :func:`h5py.opaque_dtype`, and
+  :attr:`h5py.Datatype.opaque_tag`. They are documentation only at runtime.
+  Cython keeps them in ``__annotations__`` without deriving type checks. H5py
+  does not yet ship a ``py.typed`` marker, so type checkers will not pick them
+  up for downstream code.


### PR DESCRIPTION
The changes here add ability to set an arbitrary tag on an opaque (`H5T_OPAQUE`) datatype. Care is taken not to change the current behavior with special `NUMPY:...` and `PYTHON:...` opaque datatype tags.

```python
>>> dt = h5py.opaque_dtype(np.dtype('V16'), tag=b'org.example.uuid')
>>> f.create_dataset('ids', shape=(10,), dtype=dt)
>>> h5py.get_opaque_tag(f['ids'].dtype)
b'org.example.uuid'
```

High-level helper functions for this datatype are updated accordingly. Tests for this feature included.