### PR TITLE
WHL: add abi3 nightly wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -123,6 +123,14 @@ jobs:
       # Now actually build the wheels
       - uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
 
+      # For nightlies, also build a future-compatible abi3 wheel
+      - uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
+        if: ${{ github.event_name == 'schedule') }}
+        env:
+          H5PY_LIMITED_API: 1
+          CIBW_BUILD: cp314-*
+          # CIBW_ENABLE: cpython-prereleases # uncomment when numpy has nightly cp315 wheels
+
       - run: python ./ci/bundle_hdf5_whl.py wheelhouse
         if: runner.os == 'Windows'
 


### PR DESCRIPTION
This should allow downstream to test cp315 earlier. Will also continue to serve unreleased versions of Python at no extra cost in the future.