### PR TITLE
Decode non-UTF-8 names using surrogateescape mechanism

### DIFF
--- a/h5py/_hl/base.py
+++ b/h5py/_hl/base.py
@@ -173,57 +173,54 @@ class CommonStateObject:
         """
         return dlcpl
 
-    def _e(self, name, lcpl=None):
-        """ Encode a name according to the current file settings.
-
-        Returns name, or 2-tuple (name, lcpl) if lcpl is True
-
-        - Binary strings are always passed as-is, h5t.CSET_ASCII
-        - Unicode strings are encoded utf8, h5t.CSET_UTF8
-
-        If name is None, returns either None or (None, None) appropriately.
-        """
-        def get_lcpl(coding):
-            """ Create an appropriate link creation property list """
-            lcpl = self._lcpl.copy()
-            lcpl.set_char_encoding(coding)
-            return lcpl
-
+    @staticmethod
+    def _e(name):
+        """Encode a name to bytes"""
         if name is None:
-            return (None, None) if lcpl else None
-
-        if isinstance(name, bytes):
-            coding = h5t.CSET_ASCII
+            return None
+        elif isinstance(name, bytes):
+            return name
         elif isinstance(name, str):
-            try:
-                name = name.encode('ascii')
-                coding = h5t.CSET_ASCII
-            except UnicodeEncodeError:
-                name = name.encode('utf8')
-                coding = h5t.CSET_UTF8
+            return name.encode('utf-8', 'surrogateescape')
         else:
             raise TypeError(f"A name should be string or bytes, not {type(name)}")
 
-        if lcpl:
-            return name, get_lcpl(coding)
-        return name
+    def _e_lcpl(self, name):
+        """ Encode a name and prepare a link creation property list.
 
-    def _d(self, name):
-        """ Decode a name according to the current file settings.
+        Returns a 2-tuple (name, lcpl)
 
-        - Try to decode utf8
-        - Failing that, return the byte string
+        - str with only ASCII characters are marked as ASCII, otherwise UTF-8
+        - bytes are recorded as ASCII, regardless of their contents.
+        """
+        lcpl = default_lcpl()
+
+        if name is None:
+            return None, lcpl
+
+        coding = h5t.CSET_ASCII
+        if isinstance(name, str):
+            try:
+                name = name.encode('ascii')
+            except UnicodeEncodeError:
+                name = name.encode('utf8', 'surrogateescape')
+                coding = h5t.CSET_UTF8
+        elif not isinstance(name, bytes):
+            raise TypeError(f"A name should be string or bytes, not {type(name)}")
+
+        lcpl.set_char_encoding(coding)
+        return name, lcpl
+
+    @staticmethod
+    def _d(name):
+        """ Decode a name from (probably UTF-8) bytes.
 
         If name is None, returns None.
         """
         if name is None:
             return None
 
-        try:
-            return name.decode('utf8')
-        except UnicodeDecodeError:
-            pass
-        return name
+        return name.decode('utf8', 'surrogateescape')
 
 
 class _RegionProxy:

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -103,7 +103,7 @@ class Group(HLObject, MutableMappingHDF5):
             track_order = h5.get_config().track_order
 
         with phil:
-            name, lcpl = self._e(name, lcpl=True)
+            name, lcpl = self._e_lcpl(name)
             gcpl = h5p.create(h5p.GROUP_CREATE)
             if track_order:
                 order_flags = h5p.CRT_ORDER_TRACKED | h5p.CRT_ORDER_INDEXED
@@ -559,7 +559,7 @@ class Group(HLObject, MutableMappingHDF5):
             can't understand the resulting array dtype.
         """
         with phil:
-            name, lcpl = self._e(name, lcpl=True)
+            name, lcpl = self._e_lcpl(name)
 
             if isinstance(obj, HLObject):
                 h5o.link(obj.id, self.id, name, lcpl=lcpl, lapl=self._lapl)
@@ -605,11 +605,9 @@ class Group(HLObject, MutableMappingHDF5):
     @with_phil
     def __contains__(self, name):
         """ Test if a member name exists """
-        if hasattr(h5g, "_path_valid"):
-            if not self.id:
-                return False
-            return h5g._path_valid(self.id, self._e(name), self._lapl)
-        return self._e(name) in self.id
+        if not self.id:
+            return False
+        return h5g._path_valid(self.id, self._e(name), self._lapl)
 
     def copy(self, source, dest, name=None,
              shallow=False, expand_soft=False, expand_external=False,

--- a/h5py/h5g.pyx
+++ b/h5py/h5g.pyx
@@ -459,6 +459,9 @@ cdef class GroupID(ObjectID):
         if not self:
             return False
 
+        if isinstance(name, str):
+            name = name.encode('utf-8', 'surrogateescape')
+
         with phil:
             return _path_valid(self, name)
 
@@ -481,18 +484,13 @@ cdef class GroupID(ObjectID):
 
 
 @with_phil
-def _path_valid(GroupID grp not None, object path not None, PropID lapl=None):
+def _path_valid(GroupID grp not None, bytes path not None, PropID lapl=None):
     """ Determine if *path* points to an object in the file.
 
     If *path* represents an external or soft link, the link's validity is not
     checked.
     """
     from . import h5o
-
-    if isinstance(path, bytes):
-        path = path.decode('utf-8')
-    else:
-        path = unicode(path)
 
     # Empty names are not allowed by HDF5
     if len(path) == 0:
@@ -501,7 +499,7 @@ def _path_valid(GroupID grp not None, object path not None, PropID lapl=None):
     # Note: we cannot use pp.normpath as it resolves ".." components,
     # which don't exist in HDF5
 
-    path_parts = path.split('/')
+    path_parts = path.split(b'/')
 
     # Absolute path (started with slash)
     if path_parts[0] == '':
@@ -510,13 +508,13 @@ def _path_valid(GroupID grp not None, object path not None, PropID lapl=None):
         current_loc = grp
 
     # HDF5 ignores duplicate or trailing slashes
-    path_parts = [x for x in path_parts if x != '']
+    path_parts = [x for x in path_parts if x != b'']
 
     # Special case: path was entirely composed of slashes!
     if len(path_parts) == 0:
-        path_parts = ['.']  # i.e. the root group
+        path_parts = [b'.']  # i.e. the root group
 
-    path_parts = [x.encode('utf-8') for x in path_parts]
+    #path_parts = [x.encode('utf-8') for x in path_parts]
     nparts = len(path_parts)
 
     for idx, p in enumerate(path_parts):

--- a/h5py/tests/test_group.py
+++ b/h5py/tests/test_group.py
@@ -1477,7 +1477,13 @@ class TestMutableMapping(BaseGroup):
 
 
 def test_non_utf8(writable_file):
-    writable_file.create_group(b'caf\xe9')
-    assert set(writable_file) == {'caf\udce9'}  # Surrogate escape
-    assert 'caf\udce9' in writable_file
-    assert b'caf\xe9' in writable_file
+    name_b = make_name('café').encode('latin-1')
+    writable_file.create_group(name_b)
+
+    name_s = name_b.decode('utf8', 'surrogateescape')
+    assert set(writable_file) == {name_s}
+    assert name_s in writable_file
+    assert name_b in writable_file
+
+    assert isinstance(writable_file[name_s], h5py.Group)
+    assert isinstance(writable_file[name_b], h5py.Group)

--- a/h5py/tests/test_group.py
+++ b/h5py/tests/test_group.py
@@ -1474,3 +1474,10 @@ class TestMutableMapping(BaseGroup):
         Group.__delitem__
         Group.__iter__
         Group.__len__
+
+
+def test_non_utf8(writable_file):
+    writable_file.create_group(b'caf\xe9')
+    assert set(writable_file) == {'caf\udce9'}  # Surrogate escape
+    assert 'caf\udce9' in writable_file
+    assert b'caf\xe9' in writable_file

--- a/h5py/tests/test_group.py
+++ b/h5py/tests/test_group.py
@@ -1481,7 +1481,7 @@ def test_non_utf8(writable_file):
     writable_file.create_group(name_b)
 
     name_s = name_b.decode('utf8', 'surrogateescape')
-    assert set(writable_file) == {name_s}
+    assert name_s in set(writable_file)
     assert name_s in writable_file
     assert name_b in writable_file
 


### PR DESCRIPTION
Non-UTF-8 names are currently returned from the high-level API as bytes, which will be surprising for any code that assumes names are always str (an assumption I'm sure I could have made). This uses surrogateescape so we can consistently return str.

While doing this, I spotted that the low-level `_path_valid` method converted bytes paths to str and then back to bytes; this splits them up as bytes instead.

As discussed in #2756. This is a breaking change, intended for h5py 4.0.