### PR TITLE
Require specifying either data or dtype when creating dataset

### DIFF
--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -14,12 +14,10 @@
 import posixpath as pp
 import sys
 from abc import ABC, abstractmethod
-from warnings import warn
 
 import numpy
 
 from .. import h5, h5s, h5t, h5r, h5d, h5p, h5fd, h5ds, _selector
-from ..h5py_warnings import H5pyDeprecationWarning
 from .base import (
     array_for_new_object, cached_property, Empty, find_item_type, HLObject,
     phil, product, with_phil,
@@ -86,16 +84,14 @@ def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
         dtype = tid.dtype
     else:
         # Validate dtype
-        if dtype is None and data is None:
-            warn(
-                "Creating a dataset without passing data or dtype is deprecated. "
-                "Pass an explicit dtype. Using dtype='f4' will keep the "
-                "current default behaviour.",
-                category=H5pyDeprecationWarning, stacklevel=3,
-            )
-            dtype = numpy.dtype("=f4")
-        elif dtype is None and data is not None:
-            dtype = data.dtype
+        if dtype is None:
+            if data is not None:
+                dtype = data.dtype
+            else:
+                raise TypeError(
+                    "Either data or dtype must be specified. "
+                    "Pass dtype='f4' to use the default from h5py <4"
+                )
         else:
             dtype = numpy.dtype(dtype)
         tid = h5t.py_create(dtype, logical=1)

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -128,9 +128,8 @@ class Group(HLObject, MutableMappingHDF5):
             Dataset shape.  Use "()" for scalar datasets.  Required if "data"
             isn't provided.
         dtype
-            Numpy dtype or string.  If omitted, dtype('f') will be used.
-            Required if "data" isn't provided; otherwise, overrides data
-            array's dtype.
+            Numpy dtype or string. Required if "data" isn't provided; otherwise,
+            overrides data array's dtype.
         data
             Provide data to initialize the dataset.  If used, you can omit
             shape and dtype arguments.

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -138,11 +138,9 @@ class TestCreateShape(BaseDataset):
         self.assertEqual(dset2.shape, (2,))
 
     def test_no_dtype(self):
-        # From h5py 4.0, either dtype or data will be required
-        with pytest.warns(H5pyDeprecationWarning):
+        # From h5py 4.0, either dtype or data is required
+        with pytest.raises(TypeError):
             dset = self.f.create_dataset(make_name(), (5,))
-
-        assert dset.dtype == np.dtype('f4')
 
 class TestCreateData(BaseDataset):
 


### PR DESCRIPTION
As discussed in #2756. The warning was added in #2775, for 3.16.