### PR TITLE
docs: warn about external storage paths in untrusted files

### DIFF
--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -718,6 +718,11 @@ Reference
        of 3-tuples, like the ``external=`` parameter to
        :meth:`Group.create_dataset`. Otherwise, it is ``None``.
 
+       For untrusted HDF5 files, inspect this before reading or writing dataset
+       data.  External storage entries can name files outside the HDF5 file, so
+       HDF5 may read from or write to those paths when dataset data is
+       accessed.
+
     .. attribute:: is_virtual
 
        True if this dataset is a :doc:`virtual dataset </vds>`, otherwise False.

--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -278,6 +278,10 @@ dynamically loaded by the underlying HDF5 library. This is done by passing a
 filter number to :meth:`Group.create_dataset` as the ``compression`` parameter.
 The ``compression_opts`` parameter will then be passed to this filter.
 
+Files using custom filter IDs may require native filter plugins to decode the
+data.  Applications handling untrusted HDF5 files should only enable filter
+plugins from trusted locations.
+
 .. seealso::
 
    `hdf5plugin <https://pypi.org/project/hdf5plugin/>`_
@@ -719,9 +723,9 @@ Reference
        :meth:`Group.create_dataset`. Otherwise, it is ``None``.
 
        For untrusted HDF5 files, inspect this before reading or writing dataset
-       data.  External storage entries can name files outside the HDF5 file, so
-       HDF5 may read from or write to those paths when dataset data is
-       accessed.
+       data and reject unexpected paths.  External storage entries can name
+       files outside the HDF5 file, so HDF5 may read from or write to those
+       paths when dataset data is accessed.
 
     .. attribute:: is_virtual
 

--- a/docs/high/group.rst
+++ b/docs/high/group.rst
@@ -454,13 +454,12 @@ Reference
             it grow as needed. If only a name is given instead of an iterable
             of tuples, it is equivalent to
             ``[(name, 0, h5py.h5f.UNLIMITED)]``.
-            Be careful when opening untrusted files containing external
-            datasets: HDF5 will read from or write to the referenced external
-            file paths when dataset data is accessed.  Applications handling
-            untrusted HDF5 files should inspect ``Dataset.external`` before
-            reading or writing these datasets and reject unexpected absolute
-            paths, parent-directory components, or locations outside an
-            application-controlled directory.
+            When opening untrusted files containing external datasets,
+            inspect ``Dataset.external`` before reading or writing dataset
+            data.  HDF5 will read from or write to the referenced external
+            file paths when dataset data is accessed. Reject unexpected
+            absolute paths, parent-directory components, or locations outside
+            an application-controlled directory.
 
         :keyword allow_unknown_filter: Do not check that the requested filter is
             available for use (T/F). This should only be set if you will

--- a/docs/high/group.rst
+++ b/docs/high/group.rst
@@ -146,6 +146,14 @@ links:
 When the link is accessed, the file "otherfile.hdf5" is opened, and object at
 "/path/to/resource" is returned.
 
+.. warning::
+
+    External links can open files named inside the HDF5 file.  Do not access
+    external links from untrusted files unless your application has first
+    inspected and approved the link target.  A malicious file can use absolute
+    paths or relative paths such as ``..`` to make HDF5 open files outside the
+    directory you expected.
+
 Since the object retrieved is in a different file, its ".file" and ".parent"
 properties will refer to objects in that file, *not* the file in which the
 link resides.
@@ -446,6 +454,13 @@ Reference
             it grow as needed. If only a name is given instead of an iterable
             of tuples, it is equivalent to
             ``[(name, 0, h5py.h5f.UNLIMITED)]``.
+            Be careful when opening untrusted files containing external
+            datasets: HDF5 will read from or write to the referenced external
+            file paths when dataset data is accessed.  Applications handling
+            untrusted HDF5 files should inspect ``Dataset.external`` before
+            reading or writing these datasets and reject unexpected absolute
+            paths, parent-directory components, or locations outside an
+            application-controlled directory.
 
         :keyword allow_unknown_filter: Do not check that the requested filter is
             available for use (T/F). This should only be set if you will
@@ -605,6 +620,9 @@ Link classes
 
     Like :class:`SoftLink`, only they specify a filename in addition to a
     path.  See :ref:`group_extlinks`.
+
+    External links are resolved by HDF5 when they are accessed.  Treat link
+    filenames in untrusted files as untrusted filesystem paths.
 
     :param filename:    Name of the file to which the link points
     :type filename:     String


### PR DESCRIPTION
## Summary

Add security guidance for handling untrusted HDF5 files that contain external dataset storage or external links.

HDF5 resolves these paths when dataset data or external links are accessed. For applications accepting files from other users, this means the file can reference filesystem paths outside the main HDF5 file. The new notes point users toward inspecting `Dataset.external` and approving link/storage targets before reading or writing data from untrusted files.

## Verification

- `git diff --check`
- `python -m py_compile h5py\_hl\group.py h5py\_hl\dataset.py`
- Local benign reproduction with temporary files confirmed external storage reads and writable opens affect the referenced external path, matching the warning text.