### PR TITLE
fix: reject short fileobj reads

### DIFF
--- a/h5py/h5fd.templ.pyx
+++ b/h5py/h5fd.templ.pyx
@@ -156,16 +156,19 @@ cdef haddr_t H5FD_fileobj_get_eof(const H5FD_fileobj_t *f, H5FD_mem_t type) exce
 
 cdef herr_t H5FD_fileobj_read(H5FD_fileobj_t *f, H5FD_mem_t type, hid_t dxpl, haddr_t addr, size_t size, void *buf) except -1 with gil:
     cdef unsigned char[:] mview
+    cdef Py_ssize_t bytes_read
     (<object>f.fileobj).seek(addr)
     if hasattr(<object>f.fileobj, 'readinto'):
         mview = <unsigned char[:size]>(buf)
-        (<object>f.fileobj).readinto(mview)
+        bytes_read = (<object>f.fileobj).readinto(mview)
+        if bytes_read != size:
+            return -1
     else:
         b = (<object>f.fileobj).read(size)
         if <size_t>len(b) == size:
             memcpy(buf, <unsigned char *>b, size)
         else:
-            return 1
+            return -1
     return 0
 
 cdef herr_t H5FD_fileobj_write(H5FD_fileobj_t *f, H5FD_mem_t type, hid_t dxpl, haddr_t addr, size_t size, void *buf) except -1 with gil:

--- a/h5py/tests/test_file2.py
+++ b/h5py/tests/test_file2.py
@@ -223,6 +223,21 @@ class TestFileObj(TestCase):
         f.create_dataset('test', data=list(range(12)))
         self.assertRaises(Exception, list, f['test'])
 
+    def test_short_readinto(self):
+
+        class ShortReadBytesIO(io.BytesIO):
+            def readinto(self, b):
+                if len(b) == 0:
+                    return 0
+                return super().readinto(memoryview(b)[:-1])
+
+        source = io.BytesIO()
+        self.check_write(source)
+        fileobj = ShortReadBytesIO(source.getvalue())
+
+        with self.assertRaises(Exception):
+            h5py.File(fileobj, 'r')
+
     def test_exception_write(self):
 
         class BrokenBytesIO(io.BytesIO):


### PR DESCRIPTION
## Summary

Fixes #2835.

The `fileobj` VFD read callback now treats short reads as failures for both file-like read paths:

- checks the byte count returned by `readinto()` before returning success
- returns `-1` for short `read()` results, matching `herr_t` failure conventions

Previously, `readinto()` results were ignored, so a file-like object that returned fewer bytes than requested could leave part of the destination buffer untouched while the callback still returned success. The fallback `read()` path also returned `1` for a short read, which is non-negative and therefore not a conventional `herr_t` failure.

## Tests

Added `TestFileObj.test_short_readinto`, which builds a valid in-memory HDF5 file and then serves it through a file-like object whose `readinto()` intentionally returns one byte short.

Local checks run:

- `python -m py_compile h5py\tests\test_file2.py`
- `git diff --check`

I could not run the new runtime test locally in this checkout because Cython is not installed here, and this change touches a Cython template that needs the normal h5py extension build.
