### PR TITLE
REL: use a pre-release version number for nightlies

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,7 +60,7 @@ copyright = '2014, Andrew Collette and contributors'
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-release = '3.16.0'
+release = '3.17.0dev0'
 # The short X.Y version.
 version = '.'.join(release.split('.')[:2])
 

--- a/docs/release_guide.rst
+++ b/docs/release_guide.rst
@@ -21,7 +21,7 @@ Steps to make an h5py release:
    - Assemble the release notes in ``docs/whatsnew`` based on the list of merged
      PRs. Commit the changes.
 
-4. Update the version number & commit the changes. The files that need changing
+4. Update the version number to a stable one & commit the changes. The files that need changing
    are:
 
     - ``pyproject.toml``
@@ -44,3 +44,4 @@ Steps to make an h5py release:
    CI job completes.
 9. Close the GitHub milestone for this release and open one for the next
    version.
+10. Change the version number back to a development version (revert step 4. and make a minor bump)

--- a/h5py/version.py
+++ b/h5py/version.py
@@ -28,7 +28,7 @@ class _H5PY_VERSION_CLS(NamedTuple):
     def __str__(self) -> str:
         s = f"{self.major}.{self.minor}.{self.bugfix}"
         if self.pre is not None:
-            s += version_tuple.pre
+            s += self.pre
         if self.post is not None:
             s += f".post{self.post}"
         if version_tuple.dev is not None:

--- a/h5py/version.py
+++ b/h5py/version.py
@@ -10,28 +10,36 @@
 """
     Versioning module for h5py.
 """
-
-from collections import namedtuple
+from typing import Literal, NamedTuple
 from . import h5 as _h5
 import sys
 import numpy
 
 # All should be integers, except pre, as validating versions is more than is
 # needed for our use case
-_H5PY_VERSION_CLS = namedtuple("_H5PY_VERSION_CLS",
-                               "major minor bugfix pre post dev")
+class _H5PY_VERSION_CLS(NamedTuple):
+    major: int
+    minor: int
+    bugfix: int
+    pre: Literal["a", "b", "rc"] | None = None
+    post: int | None = None
+    dev: int | None = None
+
+    def __str__(self) -> str:
+        s = f"{self.major}.{self.minor}.{self.bugfix}"
+        if self.pre is not None:
+            s += version_tuple.pre
+        if self.post is not None:
+            s += f".post{self.post}"
+        if version_tuple.dev is not None:
+            s += f".dev{self.dev}"
+        return s
 
 hdf5_built_version_tuple = _h5.HDF5_VERSION_COMPILED_AGAINST
 
-version_tuple = _H5PY_VERSION_CLS(3, 16, 0, None, None, None)
-
-version = "{0.major:d}.{0.minor:d}.{0.bugfix:d}".format(version_tuple)
-if version_tuple.pre is not None:
-    version += version_tuple.pre
-if version_tuple.post is not None:
-    version += ".post{0.post:d}".format(version_tuple)
-if version_tuple.dev is not None:
-    version += ".dev{0.dev:d}".format(version_tuple)
+# keep in sync with project.version (pyproject.toml)
+version_tuple = _H5PY_VERSION_CLS(major=3, minor=16, bugfix=0, dev=0)
+version = str(version_tuple)
 
 hdf5_version_tuple = _h5.get_libversion()
 hdf5_version = "%d.%d.%d" % hdf5_version_tuple

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ backend-path = ["_custom_build"]
 
 [project]
 name = "h5py"
-version = '3.16.0'
+version = '3.17.0dev0' # keep in sync with h5py.version.version_tuple
 description = "Read and write HDF5 files from Python"
 authors = [
     {name = "Andrew Collette", email = "andrew.collette@gmail.com"},


### PR DESCRIPTION
Gain: allow downstream projects to configure additional registry indexes at the project level (rather than on a per-job basis) while preserving the ability to exclude anaconda.org nightly channels by not accepting pre-releases
Cost: add 2 steps to the release process (is it documented somewhere ? I couldn't find where): dropping and re-adding the `dev0` prefix.

For reference, this would unblock https://github.com/astropy/astropy/pull/19886