### PR TITLE
DEP: drop support for CPython 3.10

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -180,7 +180,7 @@ jobs:
       - uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_BUILD: "cp310-*"
+          CIBW_BUILD: "cp311-*"
           CIBW_BEFORE_BUILD: ${{ matrix.cibw_before_build }}
           CIBW_BUILD_FRONTEND: 'pip; args: --no-build-isolation'
           ONLY_MINDEPS_TESTS: "1"

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@
 HDF5 for Python
 ===============
 `h5py` is a thin, pythonic wrapper around `HDF5 <https://www.hdfgroup.org/solutions/hdf5/>`_,
-which runs on Python 3 (3.10+).
+which runs on Python 3 (3.11+).
 
 Websites
 --------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,16 +8,16 @@ environment:
 
     ### USING HDF5 1.10 ###
 
-    - PYTHON: "C:\\Python310"
-      TOXENV: "py310-test-deps"
+    - PYTHON: "C:\\Python311"
+      TOXENV: "py311-test-deps"
       HDF5_VSVERSION: "14"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
       HDF5_VERSION: "1.10.7"
 
     ### USING HDF5 1.12 ###
 
-    - PYTHON: "C:\\Python310"
-      TOXENV: "py310-test-deps"
+    - PYTHON: "C:\\Python311"
+      TOXENV: "py311-test-deps"
       HDF5_VSVERSION: "14"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
       HDF5_VERSION: "1.12.1"
@@ -31,10 +31,10 @@ environment:
 install:
   # We need wheel installed to build wheels
   - "%PYTHON%\\python.exe -m pip install --upgrade wheel pip setuptools"
-  - "py -3.10 -m pip install --upgrade wheel pip setuptools virtualenv"
-  - "py -3.10 -m pip install requests"
-  - "py -3.10 ci\\get_hdf5_win.py"
-  - "py -3.10 -m pip install tox codecov"
+  - "py -3.11 -m pip install --upgrade wheel pip setuptools virtualenv"
+  - "py -3.11 -m pip install requests"
+  - "py -3.11 ci\\get_hdf5_win.py"
+  - "py -3.11 -m pip install tox codecov"
 
 build: off
 
@@ -43,7 +43,7 @@ test_script:
   # Note that you must use the environment variable %PYTHON% to refer to
   # the interpreter you're using - Appveyor does not do anything special
   # to put the Python evrsion you want to use on PATH.
-  - "py -3.10 -m tox run --discover %PYTHON%\\python.exe"
+  - "py -3.11 -m tox run --discover %PYTHON%\\python.exe"
 
 # This is commented out as there's no easy way to deal with numpy dropping
 # older python versions without a recent pip/setuptools.
@@ -60,4 +60,4 @@ cache:
   - "C:\\hdf5"
 
 on_success:
-  - "py -3.10 ci\\upload_coverage.py"
+  - "py -3.11 ci\\upload_coverage.py"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,12 +20,6 @@ environment:
       TOXENV: "py311-test-deps"
       HDF5_VSVERSION: "14"
       HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
-      HDF5_VERSION: "1.12.1"
-
-    - PYTHON: "C:\\Python311"
-      TOXENV: "py311-test-deps"
-      HDF5_VSVERSION: "14"
-      HDF5_DIR: "C:\\hdf5\\%HDF5_VERSION%\\%HDF5_VSVERSION%"
       HDF5_VERSION: "1.12.2"
 
 install:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -161,26 +161,3 @@ jobs:
       parameters:
         platform: windows
         shell: cmd
-
-- job: 'macOS'
-  pool:
-    vmImage: macOS-latest
-  timeoutInMinutes: 70  # 60 is a little short for macOS sometimes
-  strategy:
-    matrix:
-      # -deps : test with default (latest) versions of dependencies
-      # -mindeps : test with oldest supported version of (python) dependencies
-      # -deps-pre : test pre-release versions of (python) dependencies)
-      py311:
-        python.version: '3.11'
-        python.architecture: 'x64'
-        TOXENV: py311-test-deps
-        H5PY_ENFORCE_COVERAGE: yes
-    maxParallel: 4
-
-  steps:
-    - template: ci/azure-pipelines-steps.yml
-      parameters:
-        platform: macos
-        installer: brew
-        shell: unix

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
   steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '3.10'
+        versionSpec: '3.11'
         architecture: 'x64'
     - script: |
         pip install tox
@@ -34,33 +34,33 @@ jobs:
       # -tables : also check compatibility with pytables
     # HDF5 installed from apt on Ubuntu
     # test when we're not in a unicode locale
-      py310-Clocale:
-        python.version: '3.10'
+      py311-Clocale:
+        python.version: '3.11'
         python.architecture: 'x64'
-        TOXENV: py310-test-deps
+        TOXENV: py311-test-deps
         TOX_TESTENV_PASSENV: LANG LC_ALL
         LANG: C
         LC_ALL: C
         H5PY_ENFORCE_COVERAGE: yes
     # Build HDF5 1.10, 1.12 or 1.14 in the test environment
-      py310-deps-hdf51107:
-        python.version: '3.10'
+      py311-deps-hdf51107:
+        python.version: '3.11'
         python.architecture: 'x64'
-        TOXENV: py310-test-deps
+        TOXENV: py311-test-deps
         HDF5_VERSION: 1.10.7
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         H5PY_ENFORCE_COVERAGE: yes
-      py310-deps-hdf51122:
-        python.version: '3.10'
+      py311-deps-hdf51122:
+        python.version: '3.11'
         python.architecture: 'x64'
-        TOXENV: py310-test-deps
+        TOXENV: py311-test-deps
         HDF5_VERSION: 1.12.2
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         H5PY_ENFORCE_COVERAGE: yes
-      py310-deps-hdf51146:
-        python.version: '3.10'
+      py311-deps-hdf51146:
+        python.version: '3.11'
         python.architecture: 'x64'
-        TOXENV: py310-test-deps
+        TOXENV: py311-test-deps
         HDF5_VERSION: 1.14.6
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         H5PY_ENFORCE_COVERAGE: yes
@@ -79,10 +79,10 @@ jobs:
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         H5PY_ENFORCE_COVERAGE: yes
     # do mpi tests
-      py310-deps-hdf51122-mpi:
-        python.version: '3.10'
+      py311-deps-hdf51122-mpi:
+        python.version: '3.11'
         python.architecture: 'x64'
-        TOXENV: py310-test-mindeps-mpi
+        TOXENV: py311-test-mindeps-mpi
         HDF5_VERSION: 1.12.2
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         HDF5_MPI: ON
@@ -130,27 +130,27 @@ jobs:
     # -deps-pre : test pre-release versions of (python) dependencies)
     #
     # 64 bit - HDF5 1.10
-      py310-hdf5110:
-        python.version: '3.10'
+      py311-hdf5110:
+        python.version: '3.11'
         python.architecture: 'x64'
-        TOXENV: py310-test-deps,py310-test-mindeps,py310-test-deps-pre
+        TOXENV: py311-test-deps,py311-test-mindeps,py311-test-deps-pre
         HDF5_VERSION: 1.10.7
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         H5PY_ENFORCE_COVERAGE: yes
     # 64 bit - HDF5 1.12
     # Fewer combinations here; test_windows_wheels also tests HDF5 1.12
-      py310-hdf5112:
-        python.version: '3.10'
+      py311-hdf5112:
+        python.version: '3.11'
         python.architecture: 'x64'
-        TOXENV: py310-test-deps
+        TOXENV: py311-test-deps
         HDF5_VERSION: 1.12.1
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         H5PY_ENFORCE_COVERAGE: yes
     # 64 bit - HDF5 1.14
-      py310-hdf5114:
-        python.version: '3.10'
+      py311-hdf5114:
+        python.version: '3.11'
         python.architecture: 'x64'
-        TOXENV: py310-test-deps
+        TOXENV: py311-test-deps
         HDF5_VERSION: 1.14.6
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         H5PY_ENFORCE_COVERAGE: yes
@@ -171,10 +171,10 @@ jobs:
       # -deps : test with default (latest) versions of dependencies
       # -mindeps : test with oldest supported version of (python) dependencies
       # -deps-pre : test pre-release versions of (python) dependencies)
-      py310:
-        python.version: '3.10'
+      py311:
+        python.version: '3.11'
         python.architecture: 'x64'
-        TOXENV: py310-test-deps
+        TOXENV: py311-test-deps
         H5PY_ENFORCE_COVERAGE: yes
     maxParallel: 4
 

--- a/ci/get_hdf5_win.py
+++ b/ci/get_hdf5_win.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.11"
 # dependencies = [
 #     "requests>=2.30.0",
 # ]

--- a/news/drop-cp310.rst
+++ b/news/drop-cp310.rst
@@ -1,0 +1,4 @@
+Breaking changes
+----------------
+
+* Support for Python 3.10 was dropped (:pr:`2890`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ classifiers = [
     "Programming Language :: Cython",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -48,7 +47,7 @@ classifiers = [
     "Topic :: Database",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dynamic = ["dependencies"]
 
 [project.readme]
@@ -130,7 +129,6 @@ wheels = [
 
 [tool.cibuildwheel]
 skip = [
-    "cp310-win_arm64", # Skipped due to unavailability of Python binary and NumPy for Win-ARM64
     "*-win32",
 ]
 # See https://github.com/h5py/h5py/issues/2816

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,8 @@ RUN_REQUIRES = [
     # But we don't want to duplicate the information in oldest-supported-numpy
     # here, and if you can build an older NumPy on a newer Python, h5py probably
     # works (assuming you build it from source too).
-    # NumPy 1.21.2 is the first release with any wheels for Python 3.10, our minimum Python.
-    "numpy >=1.21.2",
+    # NumPy 1.23.2 is the first release with any wheels for Python 3.11, our minimum Python.
+    "numpy >=1.23.2",
 ]
 
 if setup_configure.mpi_enabled():

--- a/setup_build.py
+++ b/setup_build.py
@@ -28,12 +28,7 @@ def localpath(*args):
 
 
 if USE_PY_LIMITED_API := (os.getenv('H5PY_LIMITED_API', '0') == '1'):
-    if sys.version_info < (3, 11):
-        msg = (
-            "H5PY_LIMITED_API is set but will be ignored "
-            "because it is only supported for Python 3.11 and newer."
-        )
-    elif sysconfig.get_config_var("Py_GIL_DISABLED"):
+    if sysconfig.get_config_var("Py_GIL_DISABLED"):
         msg = (
             "H5PY_LIMITED_API is set but will be ignored "
             "because it is not supported for free-threaded builds."

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # We want an envlist like
 # envlist = {py36,py37,pypy3}-{test}-{deps,mindeps}-{,mpi}-{,pre},nightly,docs,checkreadme,pre-commit
 # but we want to skip mpi and pre by default, so this envlist is below
-envlist = py{310,311,312,313,313t,314,314t,315,315t,py3}-{test}-{deps,mindeps},nightly,py3{14,15}t-test-concurrency,docs,apidocs,checkreadme,pre-commit
+envlist = py{311,312,313,313t,314,314t,315,315t,py3}-{test}-{deps,mindeps},nightly,py3{14,15}t-test-concurrency,docs,apidocs,checkreadme,pre-commit
 isolated_build = True
 minversion = 4.22.0 # for dependency_groups
 # tox-uv is required for `mindeps` and `pre` factors, however, we allow for it
@@ -57,7 +57,7 @@ pip_pre =
 
 [testenv:nightly]
 pip_pre = True
-basepython = python3.10
+basepython = python3.11
 
 [testenv:docs]
 skip_install=True


### PR DESCRIPTION
Tis the season.
On the surface the gain isn't really apparent but here's what this unblocks:
- `typing` features that could be used in the on-going effort to add stub files
- reduce complexity around abi selection in the build process which is about to go up again when abi3t (PEP 803) becomes usable.
- if we were to drop version-specific wheels in favor of abi3 ones, this removes the one python version for which we cannot make abi3 wheels, thus halving the number of artifacts (excluding sdists)
