### PR TITLE
Fix page_buf_size=0 bug

### DIFF
--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -141,7 +141,7 @@ def make_fapl(
         cache_settings[3] = rdcc_w0
     plist.set_cache(*cache_settings)
 
-    if page_buf_size:
+    if page_buf_size is not None:
         plist.set_page_buffer_size(int(page_buf_size), int(min_meta_keep),
                                    int(min_raw_keep))
 

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -26,7 +26,7 @@ from hashlib import sha256
 import pytest
 
 from .common import ut, TestCase, UNICODE_FILENAMES, closed_tempfile, make_name
-from h5py._hl.files import direct_vfd
+from h5py._hl.files import direct_vfd, make_fapl
 from h5py import File
 import h5py
 import pathlib
@@ -276,6 +276,16 @@ class TestPageBuffering(TestCase):
         with File(fname, mode='r', page_buf_size=pbs-1) as f:
             fapl = f.id.get_access_plist()
             self.assertEqual(fapl.get_page_buffer_size()[0], fsp)
+
+    def test_page_buf_size_zero(self):
+        """An integer page_buf_size=0 is honoured, like the string "0"."""
+        kw = dict(driver=None, min_meta_keep=50, min_raw_keep=20)
+        int_result = make_fapl(page_buf_size=0, **kw).get_page_buffer_size()
+        self.assertEqual(int_result, (0, 50, 20))
+        str_result = make_fapl(page_buf_size="0", **kw).get_page_buffer_size()
+        self.assertEqual(int_result, str_result)
+        none_result = make_fapl(page_buf_size=None, **kw).get_page_buffer_size()
+        self.assertEqual(none_result, (0, 0, 0))
 
 
 class TestModes(TestCase):

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -279,13 +279,21 @@ class TestPageBuffering(TestCase):
 
     def test_page_buf_size_zero(self):
         """An integer page_buf_size=0 is honoured, like the string "0"."""
-        kw = dict(driver=None, min_meta_keep=50, min_raw_keep=20)
-        int_result = make_fapl(page_buf_size=0, **kw).get_page_buffer_size()
-        self.assertEqual(int_result, (0, 50, 20))
-        str_result = make_fapl(page_buf_size="0", **kw).get_page_buffer_size()
-        self.assertEqual(int_result, str_result)
-        none_result = make_fapl(page_buf_size=None, **kw).get_page_buffer_size()
-        self.assertEqual(none_result, (0, 0, 0))
+        for page_buf_size, expected in [
+            (0, (0, 50, 20)),
+            ("0", (0, 50, 20)),
+            (None, (0, 0, 0)),
+        ]:
+            with self.subTest(page_buf_size=page_buf_size):
+                fapl = make_fapl(driver=None, page_buf_size=page_buf_size,
+                                 min_meta_keep=50, min_raw_keep=20)
+                self.assertEqual(fapl.get_page_buffer_size(), expected)
+
+    def test_page_buf_size_empty_string(self):
+        """A nonsensical empty-string page_buf_size raises ValueError."""
+        with self.assertRaises(ValueError):
+            make_fapl(driver=None, page_buf_size="", min_meta_keep=50,
+                      min_raw_keep=20)
 
 
 class TestModes(TestCase):

--- a/news/page-buf-size-zero.rst
+++ b/news/page-buf-size-zero.rst
@@ -1,0 +1,9 @@
+Bug fixes
+---------
+
+* ``File(..., page_buf_size=0)`` now accepts an integer ``0`` and treats it the
+  same as the string ``"0"``. Previously an integer ``0`` was silently ignored
+  (the same as the ``None`` default), which also dropped any ``min_meta_keep``
+  and ``min_raw_keep`` values passed alongside it. As a consequence, a
+  nonsensical empty string ``page_buf_size=""`` now raises ``ValueError``
+  instead of being silently ignored as before.


### PR DESCRIPTION
`File(..., page_buf_size=0)` now accepts an integer `0` whereas previously an integer `0` was silently ignored (the same as the `None` default).

Fixes #2894.