### PR TITLE
MNT: move uv.index settings to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,3 +165,9 @@ H5PY_DIRECT_VFD = "0"
 [tool.uv]
 # never build numpy from source
 no-build-package = ["numpy"]
+index-strategy = "unsafe-best-match"
+
+[[tool.uv.index]]
+name = "sp-nightlies"
+url = "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"
+exclude-newer = false

--- a/tox.ini
+++ b/tox.ini
@@ -48,8 +48,6 @@ allowlist_externals =
     mpirun
 setenv =
     COVERAGE_FILE={toxinidir}/.coverage_dir/coverage-{envname} # needed otherwise coverage cannot find the file when reporting
-    pre: UV_INDEX=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-    pre: UV_INDEX_STRATEGY=unsafe-best-match  # match pip's behavior
 uv_resolution =
     mindeps: lowest-direct
     !mindeps: highest


### PR DESCRIPTION
This makes sp-nightlies permanently configured as an extra index for any uv-based workflow, but artifacts won't be pulled from there unless pre-releases are allowed in resolution.