### PR TITLE
BUG: check realloc() return value in conv_vlen2ndarray

### DIFF
--- a/h5py/_conv.templ.pyx
+++ b/h5py/_conv.templ.pyx
@@ -697,6 +697,7 @@ cdef int conv_vlen2ndarray(void* ipt,
         int flags = NPY_ARRAY_WRITEABLE | NPY_ARRAY_C_CONTIGUOUS | NPY_ARRAY_OWNDATA
         npy_intp dims[1]
         void* data
+        void* new_data
         char[:] buf
         void* back_buf = NULL
         cnp.ndarray ndarray
@@ -710,7 +711,11 @@ cdef int conv_vlen2ndarray(void* ipt,
     dims[0] = size
     itemsize = H5Tget_size(outtype.id)
     if itemsize > H5Tget_size(intype.id):
-        data = realloc(data, itemsize * size)
+        new_data = realloc(data, itemsize * size)
+        if new_data == NULL:
+            efree(data)
+            raise MemoryError("Failed to reallocate vlen conversion buffer")
+        data = new_data
 
     if needs_bkg_buffer(intype.id, outtype.id):
         back_buf = emalloc(H5Tget_size(outtype.id)*size)


### PR DESCRIPTION
## What does this PR do?

Fixes #2896 — `realloc()` return value not checked in `conv_vlen2ndarray`.

## Root cause

In `h5py/_conv.templ.pyx`, when the output itemsize is larger than the input, the buffer is reallocated:

```cython
data = realloc(data, itemsize * size)
```

`realloc()` returns `NULL` on allocation failure. Overwriting `data` with `NULL` causes:

1. **Memory leak** — the original HDF5-allocated buffer at `in_vlen[0].ptr` is lost.
2. **Segfault** — `NULL` is passed to `H5Tconvert()` at the next line.

## Fix

Store the result in a temporary variable, raise `MemoryError` if `NULL`, then update `data`:

```cython
new_data = realloc(data, itemsize * size)
if new_data == NULL:
    efree(data)
    raise MemoryError("Failed to reallocate vlen conversion buffer")
data = new_data
```

This follows the standard safe-realloc pattern required by the C standard (§7.22.3.5).

## Testing

The bug triggers when reading a variable-length dataset whose element type requires upcasting (output `itemsize > input itemsize`) under low-memory conditions.  No existing test covers the OOM path; the fix is a mechanical correction of a well-known C pattern.

---

*Bug found via static FFI boundary analysis of h5py source.*