### PR TITLE
BUG: guard PyBuffer_Release on uninitialized view in write_direct_chunk

### DIFF
--- a/h5py/h5d.templ.pyx
+++ b/h5py/h5d.templ.pyx
@@ -510,6 +510,7 @@ cdef class DatasetID(ObjectID):
         cdef size_t data_size
         cdef int rank
         cdef Py_buffer view
+        cdef bint view_acquired = False
 
         dset_id = self.id
         dxpl_id = pdefault(dxpl)
@@ -523,10 +524,12 @@ cdef class DatasetID(ObjectID):
             offset = <hsize_t*>emalloc(sizeof(hsize_t)*rank)
             convert_tuple(offsets, offset, rank)
             PyObject_GetBuffer(data, &view, PyBUF_ANY_CONTIGUOUS)
+            view_acquired = True
             H5Dwrite_chunk(dset_id, dxpl_id, filter_mask, offset, view.len, view.buf)
         finally:
             efree(offset)
-            PyBuffer_Release(&view)
+            if view_acquired:
+                PyBuffer_Release(&view)
             if space_id:
                 H5Sclose(space_id)
 


### PR DESCRIPTION
## What does this PR do?

Fixes #2898 — `PyBuffer_Release` is called on an uninitialized `Py_buffer` when `PyObject_GetBuffer` fails in `write_direct_chunk`.

## Root cause

```cython
cdef Py_buffer view   # declared on stack, never initialized

try:
    ...
    PyObject_GetBuffer(data, &view, PyBUF_ANY_CONTIGUOUS)  # can raise
    H5Dwrite_chunk(...)
finally:
    efree(offset)
    PyBuffer_Release(&view)   # BUG: called even if GetBuffer raised
```

If `PyObject_GetBuffer` raises (e.g. `data` does not support the buffer protocol), `view` was never populated — its fields contain whatever happened to be on the stack.  `PyBuffer_Release` unconditionally calls `Py_XDECREF(view.obj)`, which dereferences a garbage pointer.  This is undefined behaviour and typically crashes the interpreter.

## Fix

Add a `view_acquired` flag.  `PyBuffer_Release` is only called when `PyObject_GetBuffer` returned successfully, which matches the CPython documentation contract:

> The exporter of the buffer is responsible for deciding whether `bf_releasebuffer` is necessary.  Only call `PyBuffer_Release` if it was successfully acquired via `PyObject_GetBuffer`.

```cython
cdef bint view_acquired = False

try:
    ...
    PyObject_GetBuffer(data, &view, PyBUF_ANY_CONTIGUOUS)
    view_acquired = True
    H5Dwrite_chunk(...)
finally:
    efree(offset)
    if view_acquired:
        PyBuffer_Release(&view)
```

---

*Bug found via static FFI boundary analysis of h5py source.*