### PR TITLE
WHL: enable cp315 nightly builds for Linux

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ test-command = "bash {project}/ci/cibw_test_command.sh {project} {wheel}"
 environment-pass = [
     "GITHUB_ACTIONS",
     "ONLY_MINDEPS_TESTS",
+    "H5PY_LIMITED_API",
 ]
 
 [tool.cibuildwheel.linux.environment]


### PR DESCRIPTION
because I forgot this part in #2874, cp314-abi3 wheels have only shipped for macOS so far
