### PR TITLE
`H5dont_atexit()` Control (for WASM)

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -27,3 +27,24 @@ attributes:
         particular container by specifying ``track_order`` argument to
         :class:`h5py.File`, :meth:`h5py.Group.create_group`,
         :meth:`h5py.Group.create_dataset`.  The default is ``False``.
+
+Environment variables
+---------------------
+
+A few aspects of h5py's runtime behaviour can be controlled with environment
+variables, which are read when :mod:`h5py` is first imported:
+
+    **H5PY_DONT_ATEXIT**
+        If set to ``1``, h5py calls the HDF5 function ``H5dont_atexit()``
+        before any other HDF5 function, so that the HDF5 library does not
+        install its own cleanup routines to run when the process exits.
+        If set to ``0``, HDF5's normal exit cleanup is left enabled.
+
+        If the variable is unset (or empty), HDF5's cleanup is left enabled
+        on all platforms except Emscripten/WebAssembly (e.g. Pyodide), where
+        h5py disables it by default: there, several packages may each bundle
+        their own statically linked copy of HDF5, and running more than one
+        copy's cleanup can crash the interpreter at exit.
+
+Environment variables affecting how h5py is *built* are described in
+:ref:`custom_install`.

--- a/h5py/__init__.py
+++ b/h5py/__init__.py
@@ -30,6 +30,13 @@ except ImportError:
     else:
         raise
 
+# Whether HDF5's atexit cleanup was disabled with H5dont_atexit().  The
+# decision is taken at the top of the _errors module, because importing it
+# (above) already initialises the HDF5 library and H5dont_atexit() must come
+# before that.  See the comments there, the H5PY_DONT_ATEXIT environment
+# variable, and https://github.com/h5py/h5py/issues/2928.
+_hdf5_atexit_disabled = _errors.hdf5_atexit_disabled
+
 from . import version
 
 if version.hdf5_version_tuple != version.hdf5_built_version_tuple:

--- a/h5py/_errors.templ.pxd
+++ b/h5py/_errors.templ.pxd
@@ -411,6 +411,18 @@ cdef extern from "hdf5.h":
     ctypedef herr_t (*H5E_walk_t)(unsigned int n, const H5E_error_t *err_desc, void* client_data)
     herr_t    H5Ewalk(hid_t estack_id, H5E_direction_t direction, H5E_walk_t func, void* client_data)
 
+    # --- Not error-related ---------------------------------------------------
+    # H5dont_atexit() is declared here rather than in api_functions.txt
+    # because the auto-generated wrappers in defs.pyx call
+    # set_default_error_handler() (-> H5Eset_auto) before the real HDF5
+    # function, which would initialise the HDF5 library and turn the
+    # H5dont_atexit() call into a no-op.  It is called at the top of
+    # _errors.pyx: _errors is the first HDF5-linked module h5py imports,
+    # and its own module init is also the first thing to initialise the
+    # HDF5 library (building the error tables expands each H5E_* code to
+    # `H5open(), H5E_..._g` in C).
+    herr_t    H5dont_atexit() nogil
+
 # --- Functions for managing the HDF5 error callback mechanism ---
 
 ctypedef struct err_cookie:

--- a/h5py/_errors.templ.pyx
+++ b/h5py/_errors.templ.pyx
@@ -7,12 +7,38 @@
 # License:  Standard 3-clause BSD; see "license.txt" for full license terms
 #           and contributor agreement.
 
+from cpython cimport PyErr_Occurred, PyErr_SetObject
+import os
+import re
+import sys
+
+# Optionally ask HDF5 not to install its atexit cleanup routines, which
+# H5dont_atexit() only allows before anything initialises the HDF5 library.
+# This module is the first HDF5-linked module h5py imports, and building the
+# error tables below already initialises the library (in C, every H5E_* error
+# code expands to `H5open(), H5E_..._g`), so the call must happen right here,
+# at the top of the module - it cannot wait until h5py/__init__.py.
+#
+# On Emscripten/WebAssembly (e.g. Pyodide), several wheels may each bundle a
+# statically linked copy of HDF5.  Symbol interposition can make every copy's
+# atexit teardown run against the same, already-freed global state, crashing
+# the interpreter at exit, so there we call H5dont_atexit() by default
+# (see https://github.com/h5py/h5py/issues/2928).  Setting H5PY_DONT_ATEXIT=1
+# or =0 forces the behaviour on or off on any platform.
+_dont_atexit_env = os.environ.get('H5PY_DONT_ATEXIT', '')
+if _dont_atexit_env:
+    hdf5_atexit_disabled = _dont_atexit_env != '0'
+else:
+    hdf5_atexit_disabled = sys.platform == 'emscripten'
+if hdf5_atexit_disabled:
+    # A negative return means the call came too late - something else in this
+    # process already initialised (a copy of) HDF5.  That is expected e.g.
+    # under Pyodide when another wheel's interposed HDF5 got there first, so
+    # it is recorded rather than raised as an error.
+    hdf5_atexit_disabled = H5dont_atexit() >= 0
+
 # Python-style minor error classes.  If the minor error code matches an entry
 # in this dict, the generated exception will be used.
-from cpython cimport PyErr_Occurred, PyErr_SetObject
-import re
-
-
 _minor_table = {
     H5E_SEEKERROR:      OSError,    # Seek failed
     H5E_READERROR:      OSError,    # Read failed

--- a/news/dont-atexit.rst
+++ b/news/dont-atexit.rst
@@ -1,0 +1,9 @@
+New features
+------------
+
+* On Emscripten/WebAssembly (e.g. Pyodide), h5py now calls HDF5's
+  ``H5dont_atexit()`` before its first HDF5 call, preventing crashes at
+  interpreter exit when several wheels bundle their own statically linked
+  copies of HDF5.  The new environment variable ``H5PY_DONT_ATEXIT``
+  (``1``/``0``) forces this behaviour on or off on any platform, see
+  :doc:`/config`.


### PR DESCRIPTION
Close #2928: On Emscripten/WebAssembly (e.g. Pyodide), h5py now calls HDF5's ``H5dont_atexit()`` before its first HDF5 call, preventing crashes at interpreter exit when several wheels bundle their own statically linked copies of HDF5.  The new environment variable ``H5PY_DONT_ATEXIT`` (``1``/``0``) forces this behavior on or off on any platform. For all existing platforms besides Emscripten, the existing cleanup is used as the default.


<!--
Thanks for contributing to h5py!

Before opening a pull request, please:

- Run simple static checks with `tox -e pre-commit`
- Run the tests with e.g. `tox -e py312-test-deps`
- If your change is visible to someone using or building h5py, add a release
  note in the news/ folder.

For more information, see the contribution guide:
http://docs.h5py.org/en/stable/contributing.html#how-to-get-your-code-into-h5py

-->
