### PR TITLE
Release the GIL in H5Ocopy()

### DIFF
--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -249,7 +249,7 @@ hdf5:
   herr_t    H5Oget_info_by_idx(hid_t loc_id, char *group_name,  H5_index_t idx_type, H5_iter_order_t order, hsize_t n, H5O_info_t *oinfo, hid_t lapl_id)
 
   herr_t    H5Olink(hid_t obj_id, hid_t new_loc_id, char *new_name, hid_t lcpl_id, hid_t lapl_id)
-  herr_t    H5Ocopy(hid_t src_loc_id, char *src_name, hid_t dst_loc_id,  char *dst_name, hid_t ocpypl_id, hid_t lcpl_id)
+  herr_t    H5Ocopy(hid_t src_loc_id, char *src_name, hid_t dst_loc_id,  char *dst_name, hid_t ocpypl_id, hid_t lcpl_id) nogil
 
   herr_t    H5Oincr_refcount(hid_t object_id)
   herr_t    H5Odecr_refcount(hid_t object_id)


### PR DESCRIPTION
`f.copy()` can copy an arbitrary amount of data, including from one file to another. It would be handy to release the GIL while doing this so other threads can make progress.