### PR TITLE
Let cmake select which Visual Studio version to build with

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -135,11 +135,14 @@ jobs:
           H5PY_LIMITED_API: 1
           CIBW_BUILD: 'cp314-* cp315t-*'
           CIBW_ENABLE: cpython-prerelease
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: ''
           PIP_EXTRA_INDEX_URL: 'https://pypi.anaconda.org/scientific-python-nightly-wheels/simple'
           PIP_PRE: '1'
 
       # Now actually build the wheels
       - uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+        env:
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: ''
 
       - run: python ./ci/bundle_hdf5_whl.py wheelhouse
         if: runner.os == 'Windows'

--- a/ci/cibw_before_all_windows.sh
+++ b/ci/cibw_before_all_windows.sh
@@ -10,10 +10,8 @@ PROJECT_PATH="$1"
 
 if [[ "$ARCH" == "ARM64" ]]; then
     export ZLIB_ROOT="$PROJECT_PATH/zlib-win-arm64"
-    export HDF5_VSVERSION="17-arm64"
 elif [[ "$ARCH" == "AMD64" ]]; then
     export ZLIB_ROOT="$PROJECT_PATH/zlib-win-x64"
-    export HDF5_VSVERSION="17-64"
 else
     echo "Got unexpected arch '$ARCH'"
     exit 1

--- a/ci/get_zlib_windows.sh
+++ b/ci/get_zlib_windows.sh
@@ -16,7 +16,7 @@ if [ ! -d "$ZLIB_DIR" ]; then
   tar -xzf $ZLIB_DIR.tar.gz && rm $ZLIB_DIR.tar.gz
 fi
 
-cmake -S "$ZLIB_DIR" -B build -G "Visual Studio 17 2022" \
+cmake -S "$ZLIB_DIR" -B build \
 -DCMAKE_BUILD_TYPE=Release \
 -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX"
 cmake --build build --config Release --parallel


### PR DESCRIPTION
Fixes #2913 (hopefully)

I'm roughly hoping that specifying the VS version is no longer necessary. I think it used to be necessary to match up the version building extensions with the version used to build Python itself, but we haven't paid much attention to doing so for years, and it seems to still work.