### PR TITLE
Don't set HDF5_VSVERSION in Azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -129,7 +129,6 @@ jobs:
         TOXENV: py310-test-deps,py310-test-mindeps,py310-test-deps-pre
         HDF5_VERSION: 1.10.7
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
-        HDF5_VSVERSION: "17-64"
         H5PY_ENFORCE_COVERAGE: yes
     # 64 bit - HDF5 1.12
     # Fewer combinations here; test_windows_wheels also tests HDF5 1.12
@@ -139,7 +138,6 @@ jobs:
         TOXENV: py310-test-deps
         HDF5_VERSION: 1.12.1
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
-        HDF5_VSVERSION: "17-64"
         H5PY_ENFORCE_COVERAGE: yes
     # 64 bit - HDF5 1.14
       py310-hdf5114:
@@ -148,7 +146,6 @@ jobs:
         TOXENV: py310-test-deps
         HDF5_VERSION: 1.14.6
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
-        HDF5_VSVERSION: "17-64"
         H5PY_ENFORCE_COVERAGE: yes
     maxParallel: 4
 

--- a/ci/azure-pipelines-steps.yml
+++ b/ci/azure-pipelines-steps.yml
@@ -10,7 +10,7 @@ steps:
     # Increment the first number to clear the cache if you change something
     # not captured by the key, e.g. dependencies.
     ${{ if eq(parameters.platform, 'windows') }}:
-      key: 0 | HDF5 | "$(Agent.OS)" | "$(Agent.OSArchitecture)" | "$(HDF5_VERSION)" | "$(HDF5_VSVERSION)" | "$(HDF5_MPI)" | ci/get_hdf5_win.py
+      key: 0 | HDF5 | "$(Agent.OS)" | "$(Agent.OSArchitecture)" | "$(HDF5_VERSION)" | "$(HDF5_MPI)" | ci/get_hdf5_win.py
     ${{ if ne(parameters.platform, 'windows') }}:
       key: 0 | HDF5 | "$(Agent.OS)" | "$(Agent.OSArchitecture)" | "$(HDF5_VERSION)" | "$(HDF5_MPI)" | ci/get_hdf5_if_needed.sh
     path: $(HDF5_CACHE_DIR)


### PR DESCRIPTION
Follow up to #2932, to see if we can skip setting this on Azure as well.

I've left the setting on Appveyor in place for now, because I think it's how we tell it to do a 32-bit build (we've kept Appveyor specifically for testing 32-bit builds).