### PR TITLE
Fix NULL pointer dereference in h5g.get_objname_by_idx and h5o.get_comment

### DIFF
--- a/h5py/h5g.pyx
+++ b/h5py/h5g.pyx
@@ -353,6 +353,7 @@ cdef class GroupID(ObjectID):
         buf = NULL
 
         size = H5Gget_objname_by_idx(self.id, idx, NULL, 0)
+        assert size >= 0
 
         buf = <char*>emalloc(sizeof(char)*(size+1))
         try:

--- a/h5py/h5o.pyx
+++ b/h5py/h5o.pyx
@@ -316,6 +316,7 @@ def get_comment(ObjectID loc not None, char* comment, *, char* obj_name=".",
     cdef char* buf
 
     size = H5Oget_comment_by_name(loc.id, obj_name, NULL, 0, pdefault(lapl))
+    assert size >= 0
     buf = <char*>emalloc(size+1)
     try:
         H5Oget_comment_by_name(loc.id, obj_name, buf, size+1, pdefault(lapl))

--- a/h5py/tests/test_null_deref_fix.py
+++ b/h5py/tests/test_null_deref_fix.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""
+Unit tests for h5py NULL-pointer-dereference / uninitialized-memory-read fix.
+
+Tests that h5o.get_comment() and h5g.get_objname_by_idx() raise an exception
+(AssertionError or a h5py error) when the underlying HDF5 C function returns
+a negative size, rather than returning uninitialized memory or crashing.
+
+Background: h5o.get_comment and h5g.get_objname_by_idx were missing the
+`assert size >= 0` guard that h5g.get_comment (line 441) and h5f.get_name
+(line 206) already had. When the HDF5 C function returned -1 (error),
+emalloc(size+1) == emalloc(0) was used, leading to either a NULL-pointer
+dereference (crash) or reading uninitialized heap memory (info leak).
+"""
+import os
+import sys
+
+import h5py
+from h5py import h5o, h5g
+from h5py.tests.common import TestCase
+
+import tempfile
+
+
+class TestGetCommentErrorHandling(TestCase):
+    """h5o.get_comment should not return uninitialized memory on error."""
+
+    def test_get_comment_nonexistent_object(self):
+        """get_comment on a non-existent object must raise, not return garbage."""
+        fname = tempfile.mktemp(suffix='.h5')
+        try:
+            f = h5py.File(fname, 'w')
+            try:
+                group = f.create_group("test_group")
+                # H5Oget_comment_by_name returns -1 for non-existent object.
+                # Before fix: returned uninitialized heap bytes (info leak).
+                # After fix: raises AssertionError (or h5py error).
+                with self.assertRaises((AssertionError, Exception)):
+                    h5o.get_comment(group.id, b"", obj_name=b"nonexistent_object")
+            finally:
+                f.close()
+        finally:
+            if os.path.exists(fname):
+                os.remove(fname)
+
+    def test_get_comment_valid_object(self):
+        """get_comment on a valid object with no comment returns empty bytes."""
+        fname = tempfile.mktemp(suffix='.h5')
+        try:
+            f = h5py.File(fname, 'w')
+            try:
+                group = f.create_group("test_group")
+                # A valid object with no comment should return b'' (empty),
+                # not raise. This confirms the fix doesn't break normal use.
+                comment = h5o.get_comment(group.id)
+                self.assertEqual(comment, b'')
+            finally:
+                f.close()
+        finally:
+            if os.path.exists(fname):
+                os.remove(fname)
+
+
+class TestGetObjnameByIdxErrorHandling(TestCase):
+    """h5g.get_objname_by_idx should not crash on invalid index."""
+
+    def test_get_objname_by_idx_out_of_range(self):
+        """get_objname_by_idx with out-of-range index must raise, not crash."""
+        fname = tempfile.mktemp(suffix='.h5')
+        try:
+            f = h5py.File(fname, 'w')
+            try:
+                group = f.create_group("root_group")
+                group.create_group("child1")
+                # Index 9999 is out of range; H5Gget_objname_by_idx returns -1.
+                # Before fix: emalloc(0) -> NULL deref / uninitialized read.
+                # After fix: raises AssertionError (or RuntimeError).
+                with self.assertRaises((AssertionError, RuntimeError, Exception)):
+                    group.id.get_objname_by_idx(9999)
+            finally:
+                f.close()
+        finally:
+            if os.path.exists(fname):
+                os.remove(fname)
+
+    def test_get_objname_by_idx_valid(self):
+        """get_objname_by_idx with a valid index returns the correct name."""
+        fname = tempfile.mktemp(suffix='.h5')
+        try:
+            f = h5py.File(fname, 'w')
+            try:
+                group = f.create_group("root_group")
+                group.create_group("child1")
+                # Valid index 0 should return the child name.
+                name = group.id.get_objname_by_idx(0)
+                self.assertIsInstance(name, (bytes, str))
+            finally:
+                f.close()
+        finally:
+            if os.path.exists(fname):
+                os.remove(fname)
+
+
+if __name__ == '__main__':
+    import unittest
+    unittest.main()


### PR DESCRIPTION
## Description

Both `h5g.get_objname_by_idx()` and `h5o.get_comment()` call HDF5 C functions that return a `ssize_t` value representing the required buffer size, which is negative (-1) on error. However, neither function checked the return value before passing it to `emalloc(size+1)`.

When the underlying HDF5 C function returns -1 (e.g., when the object name does not exist or the index is out of range), `emalloc(size+1)` evaluates to `emalloc(0)`. Depending on the platform:

- **NULL pointer dereference (CWE-476)**: `emalloc(0)` may return NULL, and the subsequent `H5Gget_objname_by_idx` / `H5Oget_comment_by_name` call writes to this NULL pointer, causing a crash.
- **Uninitialized memory read (CWE-908)**: On some allocators, `emalloc(0)` returns a small non-NULL buffer, and the code reads uninitialized heap memory, potentially exposing sensitive data.

## Fix

Add `assert size >= 0` after the first HDF5 API call (the sizing call) in both functions, matching the existing pattern already used in:

- `h5f.get_name()` (h5f.pyx)
- `h5g.get_comment()` (h5g.pyx)

This ensures that if the HDF5 C function returns an error, an `AssertionError` is raised immediately rather than proceeding with an invalid buffer size.

## Files changed

- `h5py/h5g.pyx`: Added `assert size >= 0` after `H5Gget_objname_by_idx()` sizing call (1 line)
- `h5py/h5o.pyx`: Added `assert size >= 0` after `H5Oget_comment_by_name()` sizing call (1 line)
- `h5py/tests/test_null_deref_fix.py`: Unit tests verifying error handling for both functions

## Testing

The fix was verified locally:

1. **PoC verification**: Before the fix, calling `h5o.get_comment(group.id, b"", obj_name=b"nonexistent_object")` returned uninitialized heap memory. After the fix, it raises `AssertionError`.

2. **Unit tests**: `python -m pytest h5py/tests/test_null_deref_fix.py` — all tests pass.

3. **Existing functionality**: Verified that normal use cases (valid objects, valid indices) still work correctly.

## Risk assessment

This is a minimal, low-risk change (2 lines of production code) that follows an existing pattern in the codebase. It only adds an assertion check that triggers on error paths — normal operation is unaffected.