### PR TITLE
DEP: upgrade cibuilwheel to 4.1.1

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -122,7 +122,7 @@ jobs:
 
       # For nightlies, also build a future-compatible abi3 wheel
       # this comes first to avoid inter-job pollution which then fails abi3audit
-      - uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+      - uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c # v4.1.1
         if: github.event_name == 'schedule' ||
             (
               (
@@ -140,7 +140,7 @@ jobs:
           PIP_PRE: '1'
 
       # Now actually build the wheels
-      - uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+      - uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c # v4.1.1
         env:
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: ''
 
@@ -178,7 +178,7 @@ jobs:
       - run: bash ./ci/triage_build.sh "${{ matrix.arch }}" "${{ github.event.pull_request.head.sha || github.sha }}"
 
       # Now actually build the wheels
-      - uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+      - uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c # v4.1.1
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: "cp310-*"


### PR DESCRIPTION
This should fix recent failures with Python 3.15, where I think the root problem is simply some ABI incompatibility between beta 2 (which we're currently on) and beta 4 (which latest numpy nightlies were built against)