### PR TITLE
MNT: disable pre-commit.ci autofixes to PRs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,4 @@ repos:
 
 ci:
     autoupdate_schedule: monthly
+    autofix_prs: false


### PR DESCRIPTION
While genuine, this PR is mostly a pretext to exercise cp315 wheels and check the stability of the build process.