### PR TITLE
ENH allow require_group to set track_order

### DIFF
--- a/docs/high/group.rst
+++ b/docs/high/group.rst
@@ -378,11 +378,15 @@ Reference
         :return:        The new :class:`Group` object.
 
 
-    .. method:: require_group(name)
+    .. method:: require_group(name, track_order=None)
 
         Open a group in the file, creating it if it doesn't exist.
         TypeError is raised if a conflicting object already exists.
         Parameters as in :meth:`Group.create_group`.
+
+        :param track_order: Track dataset/group/attribute creation order under
+                        this group if ``True``. If ``None``, use
+                        ``h5.get_config().track_order``.
 
 
     .. method:: create_dataset(name, shape=None, dtype=None, data=None, **kwds)

--- a/h5py/_hl/group.py
+++ b/h5py/_hl/group.py
@@ -387,7 +387,7 @@ class Group(HLObject, MutableMappingHDF5):
 
         return self.create_dataset(name, **kwupdate)
 
-    def require_group(self, name):
+    def require_group(self, name, track_order=None):
         # TODO: support kwargs like require_dataset
         """Return a group, creating it if it doesn't exist.
 
@@ -396,7 +396,7 @@ class Group(HLObject, MutableMappingHDF5):
         """
         with phil:
             if name not in self:
-                return self.create_group(name)
+                return self.create_group(name, track_order=track_order)
             grp = self[name]
             if not isinstance(grp, Group):
                 raise TypeError("Incompatible object (%s) already exists" % grp.__class__.__name__)

--- a/h5py/tests/test_group.py
+++ b/h5py/tests/test_group.py
@@ -175,6 +175,14 @@ class TestRequire(BaseGroup):
         self.assertIsInstance(grp, Group)
         self.assertEqual(grp.name, '/' + name)
 
+    def test_create_track_order(self):
+        """ Track creation order when creating a group through require_group. """
+        name = make_name()
+        grp = self.f.require_group(name, track_order=True)
+        grp.create_group("b")
+        grp.create_group("a")
+        self.assertEqual(list(grp), ["b", "a"])
+
     def test_require_exception(self):
         """ Opening conflicting object results in TypeError """
         name = make_name()


### PR DESCRIPTION
Addresses h5py/h5py#2802.

Add the missing `track_order` argument to `Group.require_group`, pass it through when creating a new group, and document the behavior. A regression test verifies that creation order is preserved.