### PR TITLE
examples/swmr_inotify_example.py: asyncore module is deprecated and removed in

### DIFF
--- a/examples/swmr_inotify_example.py
+++ b/examples/swmr_inotify_example.py
@@ -17,7 +17,7 @@
     concurrently writing data to the file, the writer must have have switched
     the file into SWMR mode before this script can open the file.
 """
-import asyncore
+import asyncio
 import pyinotify
 import sys
 import h5py


### PR DESCRIPTION
This PR fixes the documentation issue reported in #2292: corrects `import asyncore` to `import asyncio` in `examples/swmr_inotify_example.py`.

Fixes #2292