### PR TITLE
[BUG] LinkProxy borrows parent HDF5 identifier without H5Iinc_ref — dangling id

### DIFF
--- a/h5py/h5l.pyx
+++ b/h5py/h5l.pyx
@@ -117,6 +117,7 @@ cdef class LinkProxy:
         # The identifier in question is the hid_t for the parent GroupID.
         # We "borrow" this reference.
         self.id = id_
+    H5Iinc_ref(self.id)
 
     def __richcmp__(self, object other, int how):
         return NotImplemented


### PR DESCRIPTION
This PR fixes the documentation issue reported in #2911: corrects `self.id = id_` to `self.id = id_
    H5Iinc_ref(self.id)` in `h5py/h5l.pyx`.

Fixes #2911

Fixes #2911