### PR TITLE
WHL: stop building and shipping win32 wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,7 @@ wheels = [
 [tool.cibuildwheel]
 skip = [
     "cp310-win_arm64", # Skipped due to unavailability of Python binary and NumPy for Win-ARM64
+    "*-win32",
 ]
 
 build-verbosity = 1


### PR DESCRIPTION
Following this arch being dropped by numpy.
Builds are currently failing so I'm hoping this could get us back to a stable state.