### PR TITLE
Bundle HDF5 2.2.0 in wheels

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,6 +71,13 @@ jobs:
         HDF5_VERSION: 2.0.0
         HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
         H5PY_ENFORCE_COVERAGE: yes
+      py314-deps-hdf5-2_2:
+        python.version: '3.14'
+        python.architecture: 'x64'
+        TOXENV: py314-test-deps
+        HDF5_VERSION: 2.2.0
+        HDF5_DIR: $(HDF5_CACHE_DIR)/$(HDF5_VERSION)
+        H5PY_ENFORCE_COVERAGE: yes
     # do mpi tests
       py310-deps-hdf51122-mpi:
         python.version: '3.10'

--- a/ci/cibw_before_all_macos.sh
+++ b/ci/cibw_before_all_macos.sh
@@ -8,7 +8,7 @@ if [[ "$1" == "" ]] ; then
 fi
 PROJECT_PATH="$1"
 ARCH=$(uname -m)
-export HDF5_VERSION="2.0.0"
+export HDF5_VERSION="2.2.0"
 export HDF5_DIR="$PROJECT_PATH/cache/hdf5/$HDF5_VERSION-$ARCH"
 source $PROJECT_PATH/ci/get_hdf5_if_needed.sh
 

--- a/ci/cibw_before_all_windows.sh
+++ b/ci/cibw_before_all_windows.sh
@@ -27,7 +27,7 @@ export LINK="/LIBPATH:$ZLIB_ROOT/lib"
 export PATH="$PATH:$EXTRA_PATH"
 
 # HDF5
-export HDF5_VERSION="2.0.0"
+export HDF5_VERSION="2.2.0"
 export HDF5_DIR="$PROJECT_PATH/cache/hdf5/$HDF5_VERSION"
 
 pip install requests

--- a/ci/get_hdf5_if_needed.sh
+++ b/ci/get_hdf5_if_needed.sh
@@ -34,7 +34,9 @@ else
         echo "building HDF5"
 
         IFS='.-' read MAJOR_V MINOR_V REL_V PATCH_V <<< "$HDF5_VERSION"
-        # the assets in GitHub (currently) have two naming conventions
+        # the assets in GitHub (currently) have three naming conventions;
+        # releases after 2.1.0 are tagged with the plain version only
+        ASSET_FMT3="${HDF5_VERSION}"
         if [[ -n "${PATCH_V}" ]]; then
             ASSET_FMT1="hdf5-${MAJOR_V}_${MINOR_V}_${REL_V}-${PATCH_V}"
             ASSET_FMT2="hdf5_${MAJOR_V}.${MINOR_V}.${REL_V}.${PATCH_V}"
@@ -79,7 +81,7 @@ else
 
         pushd /tmp
         url_base="https://github.com/HDFGroup/hdf5/archive/refs/tags/"
-        curl -fsSL -o "hdf5-$HDF5_VERSION.tar.gz" "${url_base}${ASSET_FMT1}.tar.gz" || curl -fsSL -o "hdf5-$HDF5_VERSION.tar.gz" "${url_base}${ASSET_FMT2}.tar.gz"
+        curl -fsSL -o "hdf5-$HDF5_VERSION.tar.gz" "${url_base}${ASSET_FMT3}.tar.gz" || curl -fsSL -o "hdf5-$HDF5_VERSION.tar.gz" "${url_base}${ASSET_FMT1}.tar.gz" || curl -fsSL -o "hdf5-$HDF5_VERSION.tar.gz" "${url_base}${ASSET_FMT2}.tar.gz"
 
         mkdir -p hdf5-$HDF5_VERSION && tar -xzvf hdf5-$HDF5_VERSION.tar.gz --strip-components=1 -C hdf5-$HDF5_VERSION
 

--- a/ci/get_hdf5_if_needed.sh
+++ b/ci/get_hdf5_if_needed.sh
@@ -81,7 +81,23 @@ else
 
         pushd /tmp
         url_base="https://github.com/HDFGroup/hdf5/archive/refs/tags/"
-        curl -fsSL -o "hdf5-$HDF5_VERSION.tar.gz" "${url_base}${ASSET_FMT3}.tar.gz" || curl -fsSL -o "hdf5-$HDF5_VERSION.tar.gz" "${url_base}${ASSET_FMT1}.tar.gz" || curl -fsSL -o "hdf5-$HDF5_VERSION.tar.gz" "${url_base}${ASSET_FMT2}.tar.gz"
+        urls=(
+            "${url_base}${ASSET_FMT3}.tar.gz"
+            "${url_base}${ASSET_FMT1}.tar.gz"
+            "${url_base}${ASSET_FMT2}.tar.gz"
+        )
+        set +e
+        for url in "${urls[@]}"; do
+            echo "downloading from $url"
+            curl --location "$url" --output "hdf5-$HDF5_VERSION.tar.gz" --fail --silent --show-error
+            if [[ "$?" == 0 ]]; then
+                echo "download succeeded"
+                break
+            else
+                echo "download failed"
+            fi
+        done
+        set -e
 
         mkdir -p hdf5-$HDF5_VERSION && tar -xzvf hdf5-$HDF5_VERSION.tar.gz --strip-components=1 -C hdf5-$HDF5_VERSION
 

--- a/ci/get_hdf5_win.py
+++ b/ci/get_hdf5_win.py
@@ -74,10 +74,13 @@ VSVERSION_TO_GENERATOR = {
 
 
 def download_hdf5(version, outfile):
-    zip_fmt1 = "hdf5-" + version.replace(".", "_") + ".zip"
-    zip_fmt2 = "hdf5_" + version.replace("-", ".") + ".zip"
+    # releases after 2.1.0 are tagged with the plain version only
+    zip_fmt1 = version + ".zip"
+    zip_fmt2 = "hdf5-" + version.replace(".", "_") + ".zip"
+    zip_fmt3 = "hdf5_" + version.replace("-", ".") + ".zip"
     files = [HDF5_URL.format(zip_file=zip_fmt1),
              HDF5_URL.format(zip_file=zip_fmt2),
+             HDF5_URL.format(zip_file=zip_fmt3),
              ]
 
     for file in files:

--- a/ci/get_zlib_windows.sh
+++ b/ci/get_zlib_windows.sh
@@ -12,11 +12,25 @@ ZLIB_VERSION="1.3.2"
 ZLIB_DIR="zlib-$ZLIB_VERSION"
 
 if [ ! -d "$ZLIB_DIR" ]; then
-  # zlib.net intermittently answers HTTP 200 with an error page, which curl -f
-  # cannot detect (it broke this job twice), so fetch from the zlib GitHub
-  # release mirror first and verify the archive, falling back to zlib.net.
-  curl -fsSLO --retry 5 https://github.com/madler/zlib/releases/download/v$ZLIB_VERSION/$ZLIB_DIR.tar.gz && gzip -t $ZLIB_DIR.tar.gz 2>/dev/null \
-      || curl -fsSLO --retry 5 https://zlib.net/fossils/$ZLIB_DIR.tar.gz
+  # zlib.net intermittently answers HTTP 200 with an error page, which
+  # --fail cannot detect (it broke this job twice), so try the zlib GitHub
+  # release mirror first and verify each download before accepting it.
+  urls=(
+      "https://github.com/madler/zlib/releases/download/v$ZLIB_VERSION/$ZLIB_DIR.tar.gz"
+      "https://zlib.net/fossils/$ZLIB_DIR.tar.gz"
+  )
+  set +e
+  for url in "${urls[@]}"; do
+      echo "downloading from $url"
+      curl --location "$url" --output "$ZLIB_DIR.tar.gz" --fail --silent --show-error --retry 5
+      if [[ "$?" == 0 ]] && gzip -t "$ZLIB_DIR.tar.gz" 2>/dev/null; then
+          echo "download succeeded"
+          break
+      else
+          echo "download failed"
+      fi
+  done
+  set -e
   gzip -t $ZLIB_DIR.tar.gz
   tar -xzf $ZLIB_DIR.tar.gz && rm $ZLIB_DIR.tar.gz
 fi

--- a/ci/get_zlib_windows.sh
+++ b/ci/get_zlib_windows.sh
@@ -12,10 +12,12 @@ ZLIB_VERSION="1.3.2"
 ZLIB_DIR="zlib-$ZLIB_VERSION"
 
 if [ ! -d "$ZLIB_DIR" ]; then
-  # Without -f, an HTTP error page from zlib.net gets saved as the tarball;
-  # fall back to the zlib GitHub release mirror if zlib.net is unavailable.
-  curl -fsSLO --retry 5 https://zlib.net/fossils/$ZLIB_DIR.tar.gz \
-      || curl -fsSLO --retry 5 https://github.com/madler/zlib/releases/download/v$ZLIB_VERSION/$ZLIB_DIR.tar.gz
+  # zlib.net intermittently answers HTTP 200 with an error page, which curl -f
+  # cannot detect (it broke this job twice), so fetch from the zlib GitHub
+  # release mirror first and verify the archive, falling back to zlib.net.
+  curl -fsSLO --retry 5 https://github.com/madler/zlib/releases/download/v$ZLIB_VERSION/$ZLIB_DIR.tar.gz && gzip -t $ZLIB_DIR.tar.gz 2>/dev/null \
+      || curl -fsSLO --retry 5 https://zlib.net/fossils/$ZLIB_DIR.tar.gz
+  gzip -t $ZLIB_DIR.tar.gz
   tar -xzf $ZLIB_DIR.tar.gz && rm $ZLIB_DIR.tar.gz
 fi
 

--- a/ci/get_zlib_windows.sh
+++ b/ci/get_zlib_windows.sh
@@ -12,7 +12,10 @@ ZLIB_VERSION="1.3.2"
 ZLIB_DIR="zlib-$ZLIB_VERSION"
 
 if [ ! -d "$ZLIB_DIR" ]; then
-  curl -sLO https://zlib.net/fossils/$ZLIB_DIR.tar.gz
+  # Without -f, an HTTP error page from zlib.net gets saved as the tarball;
+  # fall back to the zlib GitHub release mirror if zlib.net is unavailable.
+  curl -fsSLO --retry 5 https://zlib.net/fossils/$ZLIB_DIR.tar.gz \
+      || curl -fsSLO --retry 5 https://github.com/madler/zlib/releases/download/v$ZLIB_VERSION/$ZLIB_DIR.tar.gz
   tar -xzf $ZLIB_DIR.tar.gz && rm $ZLIB_DIR.tar.gz
 fi
 

--- a/news/bundle-hdf5-2.2.0.rst
+++ b/news/bundle-hdf5-2.2.0.rst
@@ -1,0 +1,10 @@
+Building h5py
+-------------
+
+* The pre-built wheels now bundle HDF5 2.2.0, previously 2.0.0 (:pr:`2947`).
+  This picks up the fixes for several CVEs affecting 2.0.0 — CVE-2025-44904,
+  CVE-2025-2308, CVE-2025-2309, CVE-2026-26197 and CVE-2026-26199 (fixed
+  upstream in HDF5 2.1.0), and CVE-2026-17572, CVE-2026-17573, CVE-2026-17574
+  and CVE-2025-9274 (fixed in HDF5 2.2.0) — and relaxes a chunk validation
+  check that made 2.0.0 reject spec-conforming files written by some
+  third-party libraries (:issue:`2930`).


### PR DESCRIPTION
The current wheels bundle HDF5 2.0.0, which is affected by a number of published CVEs that were fixed upstream in HDF5 2.1.0 and 2.2.0 (there are no 2.0.x patch releases, so bumping is the only way to pick up the fixes). This PR moves the bundled HDF5 for the Mac and Windows wheels to 2.2.0 (released 2026-07-29).

## CVEs present in HDF5 2.0.0

Fixed in 2.1.0:

* **CVE-2025-44904** — heap buffer overflow in `H5VM_memcpyvv` via an unvalidated stored chunk size, reachable by opening a crafted file (NVD rates this 8.8 HIGH)
* **CVE-2025-2308** — heap overflow in the scale-offset filter decompression (`H5Z__scaleoffset_decompress_one_byte`)
* **CVE-2025-2309** — heap overflow in type conversion (`H5T__bit_copy`)
* **CVE-2026-26197** ([GHSA-gh44-7wpq-622f](https://github.com/HDFGroup/hdf5/security/advisories/GHSA-gh44-7wpq-622f)) — out-of-bounds read decoding a malformed array datatype; the advisory explicitly lists 2.0.0 as the affected version
* **CVE-2026-26199** ([GHSA-5c6x-jmgf-f5vc](https://github.com/HDFGroup/hdf5/security/advisories/GHSA-5c6x-jmgf-f5vc)) — buffer underflow in `H5Iget_name`/`H5G_get_name` when called with size 0

Fixed in 2.2.0:

* **CVE-2026-17572** — heap buffer overflow deserializing a crafted SOHM list index (HDF Group CNA lists all versions <= 2.1.1 as affected)
* **CVE-2026-17573** — double free in the chunk-copy code via a crafted chunk-index size field
* **CVE-2026-17574** — NULL pointer dereference decoding an invalid variable-length datatype
* **CVE-2025-9274** — NULL callback dereference via `H5Aiterate2` (root cause fixed in the library in 2.2.0; not reachable through h5py itself, which always passes a real callback)

The HDF Group's own CVE tracking is at [HDFGroup/cve_hdf5](https://github.com/HDFGroup/cve_hdf5).

## Changes

* `HDF5_VERSION` 2.0.0 → 2.2.0 in `ci/cibw_before_all_macos.sh` and `ci/cibw_before_all_windows.sh`
* HDF5 releases after 2.1.0 are tagged with the plain version only (e.g. `2.2.0` — the `hdf5-2_2_0`/`hdf5_2.2.0` conventions stopped after 2.1.0), so `get_hdf5_if_needed.sh` and `get_hdf5_win.py` now try the plain tag first and fall back to the older conventions
* Added an HDF5 2.2.0 entry to the Azure test matrix, mirroring the 2.0.0 entry added in #2750

Linux wheels take their HDF5 from the `h5py/hdf5-manylinux` images; companion PR: h5py/hdf5-manylinux#33

## Testing

Built HDF5 2.2.0 locally on macOS arm64 with the same CMake invocation `get_hdf5_if_needed.sh` uses, built h5py against it (Python 3.14), and ran the full test suite:

```
874 passed, 28 skipped, 15 warnings, 3 subtests passed in 17.14s
```

All skips are environment-specific (MPI, ros3, szip, the Linux-only DIRECT driver, complex256 on arm64, and one test marked "Requires HDF5 <= 1.14.3").

