### PR TITLE
Add ROS3 block caching feature

### DIFF
--- a/docs/high/file.rst
+++ b/docs/high/file.rst
@@ -136,6 +136,49 @@ of supported drivers and their options:
         The argument values must be ``bytes`` objects. Arguments aws_region,
         secret_id, and secret_key are required to activate AWS authentication.
 
+        Starting with HDF5 2.2, the driver no longer sends a separate request to
+        the object store for every read. It instead fetches the file in
+        fixed-size blocks and keeps recently used blocks in memory, so that any
+        read landing in a block which has already been fetched is served without
+        going back to the network. This usually makes the biggest difference for
+        files that were not written with cloud access in mind, where the
+        metadata a reader needs is spread across many small regions of the file.
+        The three keywords below tune that behaviour, and unlike the
+        credential keywords above they take plain integers and a boolean rather
+        than ``bytes``. Each of them requires HDF5 2.2.0 or later, and passing
+        any of them to an older library raises a ``ValueError``.
+
+        block_size:
+          Size, in bytes, of the block the driver requests from a file in a
+          single read. The default is 16 MiB. Larger blocks mean fewer requests,
+          but they can also transfer a good deal more data than actually
+          required. Setting it to ``0`` disables block caching altogether and
+          returns the driver to the behaviour it had before HDF5 2.2, where
+          every read becomes its own request.
+
+        block_cache_size:
+          Total size, in bytes, that the cached blocks are allowed to occupy.
+          The default is 128 MiB. Since the cache only ever holds whole blocks,
+          it makes sense to choose a multiple of ``block_size``. For a
+          value smaller than ``block_size``, HDF5 quietly reduces ``block_size``
+          to match so that at least one block still fits. As with
+          ``block_size``, setting this to ``0`` disables block caching.
+
+        lock_superblock:
+          Whether the block holding the file's superblock should be pinned in
+          the cache and never evicted to make room for other blocks. The default
+          is ``True``, because that metadata is usually worth keeping around for
+          as long as the file is open. Note that the driver assumes the first
+          block it caches contains the superblock, so a file with a
+          user block as large as, or larger than, ``block_size`` will not get the
+          superblock pinned unless ``block_size`` is increased accordingly.
+
+        .. note::
+          The driver only caches blocks for files that do not use paged file
+          space allocation (cloud optimized). If a file was created with ``fs_strategy="page"``,
+          the library's own page buffer handles this instead, and the three
+          keywords above have no effect. See ``page_buf_size``.
+
         .. note::
           Pre-built h5py packages on PyPI do not include ros3 driver support. If
           you need this driver, you could use packages from conda-forge or

--- a/h5py/_hl/files.py
+++ b/h5py/_hl/files.py
@@ -167,11 +167,25 @@ def make_fapl(
     else:
         if driver == 'ros3':
             token = kwds.pop('session_token', None)
+            block_size = kwds.pop('block_size', None)
+            block_cache_size = kwds.pop('block_cache_size', None)
+            lock_superblock = kwds.pop('lock_superblock', None)
             set_fapl(plist, **kwds)
             if token:
                 if hdf5_version < (1, 14, 2):
                     raise ValueError('HDF5 >= 1.14.2 required for AWS session token')
                 plist.set_fapl_ros3_token(token)
+            block_config = {}
+            if block_size is not None:
+                block_config['block_size'] = int(block_size)
+            if block_cache_size is not None:
+                block_config['block_cache_size'] = int(block_cache_size)
+            if lock_superblock is not None:
+                block_config['lock_superblock'] = bool(lock_superblock)
+            if block_config:
+                if hdf5_version < (2, 2, 0):
+                    raise ValueError('HDF5 >= 2.2.0 required to configure the ROS3 block cache')
+                plist.set_fapl_ros3_block_caching(**block_config)
         else:
             set_fapl(plist, **kwds)
 

--- a/h5py/api_functions.txt
+++ b/h5py/api_functions.txt
@@ -306,6 +306,8 @@ hdf5:
   ROS3 herr_t    H5Pset_fapl_ros3(hid_t fapl_id, H5FD_ros3_fapl_t *fa)
   ROS3 1.14.2 herr_t H5Pget_fapl_ros3_token(hid_t fapl_id, size_t size, char *token)
   ROS3 1.14.2 herr_t H5Pset_fapl_ros3_token(hid_t fapl_id, const char *token)
+  ROS3 2.2.0 herr_t H5Pget_fapl_ros3_block_caching(hid_t fapl_id, size_t *block_size, size_t *block_cache_size, hbool_t *lock_superblock)
+  ROS3 2.2.0 herr_t H5Pset_fapl_ros3_block_caching(hid_t fapl_id, size_t block_size, size_t block_cache_size, hbool_t lock_superblock)
   DIRECT_VFD herr_t H5Pget_fapl_direct(hid_t fapl_id, size_t *boundary, size_t *block_size, size_t *cbuf_size);
   DIRECT_VFD herr_t H5Pset_fapl_direct(hid_t fapl_id, size_t alignment, size_t block_size, size_t cbuf_size);
   herr_t    H5Pset_fapl_log(hid_t fapl_id, char *logfile, unsigned int flags, size_t buf_size)

--- a/h5py/api_types_hdf5.templ.pxd
+++ b/h5py/api_types_hdf5.templ.pxd
@@ -363,6 +363,10 @@ cdef extern from "hdf5.h":
   ### {{if HDF5_VERSION >= (1, 14, 2)}}
   size_t H5FD_ROS3_MAX_SECRET_TOK_LEN
   ### {{endif}}
+  ### {{if HDF5_VERSION >= (2, 2, 0)}}
+  size_t HDF5_ROS3_VFD_DEFAULT_BLOCK_SIZE
+  size_t HDF5_ROS3_VFD_DEFAULT_BLOCK_CACHE_SIZE
+  ### {{endif}}
 # === H5G - Groups API ========================================================
 
   ctypedef enum H5G_link_t:

--- a/h5py/h5p.templ.pyx
+++ b/h5py/h5p.templ.pyx
@@ -25,13 +25,19 @@ from .h5t cimport TypeID, py_create
 from .h5s cimport SpaceID
 from .h5ac cimport CacheConfig
 
-# Python level imports
-from ._objects import phil, with_phil
-
 ### {{if MPI}}
 from mpi4py.libmpi cimport (
     MPI_Comm, MPI_Info, MPI_Comm_dup, MPI_Info_dup,
     MPI_Comm_free, MPI_Info_free)
+### {{endif}}
+
+# Python level imports
+from collections import namedtuple
+from ._objects import phil, with_phil
+
+### {{if ROS3 and HDF5_VERSION >= (2, 2, 0)}}
+Ros3_BlockConfig = namedtuple(
+    'Ros3_BlockConfig', ['block_size', 'block_cache_size', 'lock_superblock'])
 ### {{endif}}
 
 # Initialization
@@ -1139,6 +1145,59 @@ cdef class PropFAID(PropInstanceID):
         Set session token in the file access property list.
         """
         H5Pset_fapl_ros3_token(self.id, token)
+    ### {{endif}}
+
+    ### {{if HDF5_VERSION >= (2, 2, 0)}}
+    @with_phil
+    def set_fapl_ros3_block_caching(
+        self,
+        size_t block_size=HDF5_ROS3_VFD_DEFAULT_BLOCK_SIZE,
+        size_t block_cache_size=HDF5_ROS3_VFD_DEFAULT_BLOCK_CACHE_SIZE,
+        bint lock_superblock=True
+    ):
+        """(UINT block_size, UINT block_cache_size, BOOL lock_superblock=True)
+
+        Set ROS3 block access and caching parameters. Block reading and caching
+        helps improve performance of typical (non-cloud optimized) files. This
+        method sets all three parameters at once, so the unspecified ones are
+        reset to their defaults and not preserved at the previous value.
+
+        ``block_size`` is the size, in bytes, of S3 request for one block from
+        the file. The default is ``HDF5_ROS3_VFD_DEFAULT_BLOCK_SIZE``.
+
+        ``block_cache_size`` is the total size, in bytes, of the block cache.
+        The default is ``HDF5_ROS3_VFD_DEFAULT_BLOCK_CACHE_SIZE``.
+
+        Setting either size to 0 disables the cache (the legacy, inefficient,
+        one-request-per-read behaviour).
+
+        ``lock_superblock`` instructs whether or not to protect the block with
+        the file's superblock from eviction from the cache. The default value is
+        ``True``.
+
+        Available since HDF5 2.2.0.
+        """
+        H5Pset_fapl_ros3_block_caching(
+            self.id, block_size, block_cache_size, <hbool_t>lock_superblock)
+
+
+    @with_phil
+    def get_fapl_ros3_block_caching(self):
+        """ () => NAMEDTUPLE Ros3_BlockConfig('block_size', 'block_cache_size',
+        'lock_superblock')
+
+        Get ROS3 block caching configuration: block request size, block cache
+        size, and superblock cache lock flag.
+
+        Available since HDF5 2.2.0.
+        """
+        cdef size_t block_size
+        cdef size_t block_cache_size
+        cdef hbool_t lock_superblock
+
+        H5Pget_fapl_ros3_block_caching(
+            self.id, &block_size, &block_cache_size, &lock_superblock)
+        return Ros3_BlockConfig(block_size, block_cache_size, <bint>lock_superblock)
     ### {{endif}}
     ### {{endif}}
 

--- a/h5py/tests/test_ros3.py
+++ b/h5py/tests/test_ros3.py
@@ -12,6 +12,7 @@
 """
 
 import h5py
+from h5py import h5p
 from h5py._hl.files import make_fapl
 import pytest
 
@@ -21,6 +22,27 @@ pytestmark = [
         not h5py.h5.get_config().ros3,
         reason="ros3 driver not available")
 ]
+
+MiB = 1024 * 1024
+
+# ROS3 I/O block caching defaults documented in HDF5's H5FDros3.h. HDF5 applies
+# these to every parameter not given to H5Pset_fapl_ros3_block_caching(), so
+# they are also what h5py's own defaults must resolve to.
+DEFAULT_BLOCK_SIZE = 16 * MiB
+DEFAULT_BLOCK_CACHE_SIZE = 128 * MiB
+
+block_caching = pytest.mark.skipif(
+    h5py.version.hdf5_version_tuple < (2, 2, 0),
+    reason='ROS3 block caching requires HDF5 >= 2.2.0')
+
+
+def ros3_fapl(**kwds):
+    """A ros3 file access property list with only ``kwds`` customized"""
+    return make_fapl('ros3', libver=None, rdcc_nslots=None, rdcc_nbytes=None,
+                     rdcc_w0=None, locking=None, page_buf_size=None,
+                     min_meta_keep=None, min_raw_keep=None,
+                     alignment_threshold=1, alignment_interval=1,
+                     meta_block_size=None, **kwds)
 
 
 @pytest.mark.network
@@ -81,8 +103,180 @@ def test_ros3_s3_fails(exc, match_exc):
 def test_ros3_temp_token():
     """Set and get S3 access token"""
     token = b'#0123FakeToken4567/8/9'
-    fapl = make_fapl('ros3', libver=None, rdcc_nslots=None, rdcc_nbytes=None,
-                     rdcc_w0=None, locking=None, page_buf_size=None, min_meta_keep=None,
-                     min_raw_keep=None, alignment_threshold=1, alignment_interval=1,
-                     meta_block_size=None, session_token=token)
-    assert token, fapl.get_fapl_ros3_token()
+    fapl = ros3_fapl(session_token=token)
+    assert fapl.get_fapl_ros3_token() == token
+
+
+@block_caching
+@pytest.mark.parametrize(
+    "block_size,block_cache_size,lock_superblock",
+    [
+        (1 * MiB, 8 * MiB, True),
+        (4 * MiB, 4 * MiB, False),
+        (2 * MiB, 40 * MiB, False),
+    ]
+)
+def test_ros3_block_caching_roundtrip(block_size, block_cache_size,
+                                      lock_superblock):
+    """Set and get all ROS3 block caching parameters"""
+    fapl = ros3_fapl()
+    fapl.set_fapl_ros3_block_caching(block_size, block_cache_size,
+                                     lock_superblock)
+    assert fapl.get_fapl_ros3_block_caching() == (block_size, block_cache_size,
+                                                  lock_superblock)
+
+
+@block_caching
+def test_ros3_block_caching_hdf5_defaults():
+    """Unspecified block caching parameters fall back to the HDF5 defaults"""
+    fapl = ros3_fapl()
+    fapl.set_fapl_ros3_block_caching()
+    config = fapl.get_fapl_ros3_block_caching()
+
+    assert config.block_size == DEFAULT_BLOCK_SIZE
+    assert config.block_cache_size == DEFAULT_BLOCK_CACHE_SIZE
+    assert config.lock_superblock is True
+
+
+@block_caching
+@pytest.mark.parametrize(
+    "kwds,expected",
+    [
+        ({'block_size': 1 * MiB},
+         (1 * MiB, DEFAULT_BLOCK_CACHE_SIZE, True)),
+        ({'block_cache_size': 40 * MiB},
+         (DEFAULT_BLOCK_SIZE, 40 * MiB, True)),
+        ({'lock_superblock': False},
+         (DEFAULT_BLOCK_SIZE, DEFAULT_BLOCK_CACHE_SIZE, False)),
+    ]
+)
+def test_ros3_block_caching_partial(kwds, expected):
+    """Setting one block caching parameter defaults the other two"""
+    fapl = ros3_fapl()
+    fapl.set_fapl_ros3_block_caching(**kwds)
+    assert fapl.get_fapl_ros3_block_caching() == expected
+
+
+@block_caching
+@pytest.mark.parametrize(
+    "kwds,expected",
+    [
+        ({"block_size": 1 * MiB}, (1 * MiB, DEFAULT_BLOCK_CACHE_SIZE, True)),
+        ({"block_cache_size": 40 * MiB}, (DEFAULT_BLOCK_SIZE, 40 * MiB, True)),
+        (
+            {"lock_superblock": False},
+            (DEFAULT_BLOCK_SIZE, DEFAULT_BLOCK_CACHE_SIZE, False),
+        ),
+        (
+            {
+                "block_size": 2 * MiB,
+                "block_cache_size": 32 * MiB,
+                "lock_superblock": False,
+            },
+            (2 * MiB, 32 * MiB, False),
+        ),
+    ],
+)
+def test_ros3_block_caching_file_keywords(kwds, expected):
+    """h5py.File() block caching keywords reach the ros3 driver"""
+    assert ros3_fapl(**kwds).get_fapl_ros3_block_caching() == expected
+
+
+@block_caching
+def test_ros3_block_caching_untouched_by_default():
+    """Block caching stays enabled when no keyword asks for anything"""
+    config = ros3_fapl().get_fapl_ros3_block_caching()
+
+    assert config.block_size > 0
+    assert config.block_cache_size > 0
+    assert config.lock_superblock is True
+
+
+@block_caching
+@pytest.mark.parametrize(
+    "kwds,expected",
+    [
+        ({'block_size': 0}, (0, DEFAULT_BLOCK_CACHE_SIZE, True)),
+        ({'block_cache_size': 0}, (DEFAULT_BLOCK_SIZE, 0, True)),
+    ]
+)
+def test_ros3_block_caching_disabled(kwds, expected):
+    """A zero block or cache size disables ROS3 block caching"""
+    assert ros3_fapl(**kwds).get_fapl_ros3_block_caching() == expected
+
+
+@block_caching
+def test_ros3_block_size_clamped():
+    """HDF5 clamps the block size down to the block cache size"""
+    fapl = ros3_fapl(block_size=8 * MiB, block_cache_size=4 * MiB)
+    assert fapl.get_fapl_ros3_block_caching() == (4 * MiB, 4 * MiB, True)
+
+
+@block_caching
+def test_ros3_block_caching_needs_ros3_driver():
+    """Block caching is rejected on a property list without the ros3 driver"""
+    fapl = h5p.create(h5p.FILE_ACCESS)
+    fapl.set_fapl_sec2()
+
+    with pytest.raises(ValueError, match='driver is not set'):
+        fapl.set_fapl_ros3_block_caching(1 * MiB)
+
+    with pytest.raises(ValueError, match='driver is not set'):
+        fapl.get_fapl_ros3_block_caching()
+
+
+@pytest.mark.skipif(h5py.version.hdf5_version_tuple >= (2, 2, 0),
+                    reason='Requires HDF5 < 2.2.0')
+@pytest.mark.parametrize(
+    "kwds",
+    [
+        {'block_size': 1 * MiB},
+        {'block_cache_size': 40 * MiB},
+        {'lock_superblock': False},
+    ]
+)
+def test_ros3_block_caching_unsupported(kwds):
+    """Block caching keywords are refused when HDF5 is too old"""
+    with pytest.raises(ValueError, match='HDF5 >= 2.2.0 required'):
+        ros3_fapl(**kwds)
+
+
+@pytest.mark.parametrize("driver", [None, 'sec2'])
+def test_ros3_block_caching_wrong_driver(driver):
+    """Block caching keywords are not silently swallowed by other drivers"""
+    with pytest.raises(TypeError, match='block_size'):
+        make_fapl(driver, libver=None, rdcc_nslots=None, rdcc_nbytes=None,
+                  rdcc_w0=None, locking=None, page_buf_size=None,
+                  min_meta_keep=None, min_raw_keep=None,
+                  alignment_threshold=1, alignment_interval=1,
+                  meta_block_size=None, block_size=1 * MiB)
+
+
+@block_caching
+@pytest.mark.network
+@pytest.mark.parametrize(
+    "kwds",
+    [
+        pytest.param({}, id="hdf5-defaults"),
+        # A block cache holding only two 4 KiB blocks forces the driver to
+        # evict and re-fetch while reading this file.
+        pytest.param({"block_size": 4096, "block_cache_size": 8192}, id="tiny-cache"),
+        pytest.param(
+            {"block_size": 4096, "block_cache_size": 8192, "lock_superblock": False},
+            id="tiny-cache-unlocked",
+        ),
+        pytest.param({"block_size": 0}, id="disabled"),
+    ],
+)
+def test_ros3_block_caching_read(kwds):
+    """Reading a file is unaffected by its block caching configuration"""
+    url = 'https://dandiarchive.s3.amazonaws.com/ros3test.hdf5'
+
+    with h5py.File(url, 'r', aws_region=b'us-east-2', **kwds) as f:
+        assert list(f.keys()) == ['mydataset', 'subgroup', 'subgroup2']
+
+        dset = f['mydataset']
+        assert dset.shape == (100,)
+        assert dset.dtype == 'int32'
+        assert dset.attrs['temperature'] == 99.5
+        assert (dset[...] == 0).all()

--- a/news/ros3-block-caching.rst
+++ b/news/ros3-block-caching.rst
@@ -1,0 +1,20 @@
+New features
+------------
+
+* The Read-Only S3 ('ros3') driver can now be told how to read and cache blocks
+  of a file, using three new :class:`h5py.File` keywords: ``block_size``,
+  ``block_cache_size`` and ``lock_superblock``. Instead of sending a separate
+  request to the object store for every read, the driver fetches the file in
+  fixed-size blocks and holds recently used blocks in memory, so that reads
+  landing in a block that has already been fetched are served without going back
+  to the network. This tends to help most with files that were not written with
+  cloud access in mind, where the metadata a reader needs is scattered across
+  many small regions of the file. This feature requires HDF5 2.2.0 or later, and
+  using it with an older library raises a ``ValueError``. By default the driver
+  reads in blocks of 16 MiB and lets the cache grow to 128 MiB.
+
+Exposing HDF5 functions
+-----------------------
+
+* ``H5Pget_fapl_ros3_block_caching`` & ``H5Pset_fapl_ros3_block_caching`` (where
+  HDF5 is built with read-only S3 support, and is version 2.2.0 or later).


### PR DESCRIPTION
ROS3 driver can now have improved performance with typical, non-cloud optimized, HDF5 files in S3.

Available since HDF5 2.2.0.