### PR TITLE
Fix writing a single vlen field of a compound dataset

### DIFF
--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -1010,8 +1010,16 @@ class Dataset(HLObject):
 
             val = numpy.asarray(val, dtype=dtype.base, order='C')
             if cast_compound:
-                val = val.view(numpy.dtype([(names[0], dtype)]))
-                val = val.reshape(val.shape[:len(val.shape) - len(dtype.shape)])
+                cast_dtype = numpy.dtype([(names[0], dtype)])
+                cast_shape = val.shape[:len(val.shape) - len(dtype.shape)]
+                if dtype.base.kind == 'O':
+                    # Vlen data is held in object arrays, which numpy refuses to
+                    # reinterpret as another dtype, so copy it into place instead.
+                    tmp = numpy.empty(cast_shape, dtype=cast_dtype)
+                    tmp[names[0]] = val
+                    val = tmp
+                else:
+                    val = val.view(cast_dtype).reshape(cast_shape)
         elif (self.dtype.kind == 'S'
               and (h5t.check_string_dtype(self.dtype).encoding == 'utf-8')
               and (find_item_type(val) is str)

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1572,6 +1572,32 @@ class TestCompound(BaseDataset):
         self.assertTrue(np.all(outdata == testdata))
         self.assertEqual(outdata.dtype, testdata.dtype)
 
+    def test_assign_vlen_field(self):
+        """ A single vlen field can be written on its own (issue 1857)"""
+        dt = np.dtype([('a_float', np.float64),
+                       ('a_string', h5py.string_dtype(encoding='utf-8')),
+                       ('a_seq', h5py.vlen_dtype(np.int32))])
+
+        ds = self.f.create_dataset(make_name(), (3,), dtype=dt)
+        ds['a_float'] = [1.0, 2.0, 3.0]
+        ds['a_string'] = ['one', 'two', 'three']
+        ds['a_seq'] = np.array([np.arange(n, dtype=np.int32) for n in (1, 2, 3)],
+                               dtype=object)
+
+        outdata = ds[...]
+        self.assertArrayEqual(outdata['a_float'], np.array([1.0, 2.0, 3.0]))
+        self.assertArrayEqual(outdata['a_string'],
+                              np.array([b'one', b'two', b'three'], dtype=object))
+        for got, expected in zip(outdata['a_seq'], (1, 2, 3)):
+            self.assertArrayEqual(got, np.arange(expected, dtype=np.int32))
+
+        # A scalar is broadcast over the field, leaving other fields alone
+        ds['a_string'] = 'same'
+        outdata = ds[...]
+        self.assertArrayEqual(outdata['a_string'],
+                              np.array([b'same'] * 3, dtype=object))
+        self.assertArrayEqual(outdata['a_float'], np.array([1.0, 2.0, 3.0]))
+
     def test_fields(self):
         dt = np.dtype([
             ('x', np.float64),

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -1576,13 +1576,17 @@ class TestCompound(BaseDataset):
         """ A single vlen field can be written on its own (issue 1857)"""
         dt = np.dtype([('a_float', np.float64),
                        ('a_string', h5py.string_dtype(encoding='utf-8')),
-                       ('a_seq', h5py.vlen_dtype(np.int32))])
+                       ('a_seq', h5py.vlen_dtype(np.int32)),
+                       # dtype.base drops the (2,), so an array valued field
+                       # goes down the same path as a plain vlen one
+                       ('a_pair', h5py.string_dtype(encoding='utf-8'), (2,))])
 
         ds = self.f.create_dataset(make_name(), (3,), dtype=dt)
         ds['a_float'] = [1.0, 2.0, 3.0]
         ds['a_string'] = ['one', 'two', 'three']
         ds['a_seq'] = np.array([np.arange(n, dtype=np.int32) for n in (1, 2, 3)],
                                dtype=object)
+        ds['a_pair'] = [['a', 'bb'], ['ccc', 'dddd'], ['e', 'ff']]
 
         outdata = ds[...]
         self.assertArrayEqual(outdata['a_float'], np.array([1.0, 2.0, 3.0]))
@@ -1590,6 +1594,9 @@ class TestCompound(BaseDataset):
                               np.array([b'one', b'two', b'three'], dtype=object))
         for got, expected in zip(outdata['a_seq'], (1, 2, 3)):
             self.assertArrayEqual(got, np.arange(expected, dtype=np.int32))
+        self.assertArrayEqual(outdata['a_pair'],
+                              np.array([[b'a', b'bb'], [b'ccc', b'dddd'],
+                                        [b'e', b'ff']], dtype=object))
 
         # A scalar is broadcast over the field, leaving other fields alone
         ds['a_string'] = 'same'

--- a/news/compound-vlen-field-write.rst
+++ b/news/compound-vlen-field-write.rst
@@ -1,0 +1,8 @@
+Bug fixes
+---------
+
+* Writing a single variable length field of a compound dataset, e.g.
+  ``ds['a_string'] = 'some text'``, no longer raises ``TypeError: Cannot change
+  data-type for array of references``. Variable length data is stored in object
+  arrays, which NumPy will not reinterpret as a compound dtype, so the value is
+  now copied into a one field array instead of being viewed as one.


### PR DESCRIPTION
Fixes #1857.

## The bug

Assigning to a single variable-length-string field of a compound dataset raises `TypeError`:

```python
dt = np.dtype([('num', '<u8'), ('a_string', h5py.string_dtype())])
ds = f.create_dataset('x', (3,), dtype=dt)
ds['a_string'] = 'test string'
```

```
TypeError: Cannot change data-type for array of references.
```

Numeric fields work; vlen fields do not. (The NumPy message has changed wording since the issue was
filed — it used to say "object array" — but it is the same failure.)

## Cause

`Dataset.__setitem__` builds a one-field structured array by reinterpreting the value with
`ndarray.view()`:

```python
val = val.view(numpy.dtype([(names[0], dtype)]))
```

NumPy refuses `.view()` on object-dtype arrays, and object dtype is exactly how h5py represents vlen
data. Fixed-width and numeric fields take the same path successfully because `.view()` is legal for
them.

## The fix

When the target field's dtype is object (`dtype.base.kind == 'O'`), allocate the one-field array and
copy the value in instead of reinterpreting it. Every other dtype keeps the existing zero-copy
`view()` path, so there is no behaviour or performance change for numeric or fixed-length string
fields.

## Verification

Built from source against HDF5 1.14.6 (Python 3.13, NumPy 2.5.1, Cython 3.2.9).

Fail-before (fix reverted, new test present):

```
>           raise TypeError("Cannot change data-type for array of references.")
E           TypeError: Cannot change data-type for array of references.
FAILED h5py/tests/test_dataset.py::TestCompound::test_assign_vlen_field
====================== 1 failed, 240 deselected in 0.58s =======================
```

Pass-after:

```
h5py/tests/test_dataset.py::TestCompound::test_assign_vlen_field PASSED  [100%]
====================== 1 passed, 240 deselected in 0.17s =======================
```

Suites: `test_dataset.py` 240 passed / 1 skipped. Full `h5py/tests` 849 passed / 54 skipped in 10.4s.
No pre-existing failures.

I also checked by hand that numeric scalar and array field assignment, numeric subarray fields
(`('a', 'f4', (3,))`), fixed-length `S5` fields, and object-reference fields all round-trip
identically before and after.

## Notes

- The `kind == 'O'` guard is deliberately narrow. The copy path also works for numeric fields, so an
  unconditional copy would pass the suite too — but `view()` is zero-copy, and keeping the branch
  narrow limits the change to the broken case. Happy to simplify it if you'd prefer.
- The two `reshape` calls were collapsed into one shared local so the branches stay symmetric. That
  is the only incidental change and it is behaviour-preserving.
- Thanks to @takluyver, whose workaround on the issue pointed at where this goes wrong.
