### PR TITLE
Don't warn about ABI-compatible HDF5 versions from 2.0 onwards

### DIFF
--- a/h5py/__init__.py
+++ b/h5py/__init__.py
@@ -32,7 +32,9 @@ except ImportError:
 
 from . import version
 
-if version.hdf5_version_tuple != version.hdf5_built_version_tuple:
+if not version._hdf5_abi_compatible(
+    version.hdf5_built_version_tuple, version.hdf5_version_tuple
+):
     _warn(("h5py is running against HDF5 {0} when it was built against {1}, "
            "this may cause problems").format(
             '{0}.{1}.{2}'.format(*version.hdf5_version_tuple),

--- a/h5py/tests/test_version.py
+++ b/h5py/tests/test_version.py
@@ -1,0 +1,47 @@
+# This file is part of h5py, a Python interface to the HDF5 library.
+#
+# http://www.h5py.org
+#
+# Copyright 2008-2013 Andrew Collette and contributors
+#
+# License:  Standard 3-clause BSD; see "license.txt" for full license terms
+#           and contributor agreement.
+
+"""
+    Tests for the versioning helpers in h5py.version
+"""
+
+import pytest
+
+from h5py.version import _hdf5_abi_compatible
+
+
+@pytest.mark.parametrize('built, running', [
+    # Identical versions are always fine
+    ((1, 14, 6), (1, 14, 6)),
+    ((2, 0, 0), (2, 0, 0)),
+    # HDF5 promises ABI compatibility with later releases of the same major
+    # version from 2.0 onwards
+    ((2, 0, 0), (2, 0, 1)),
+    ((2, 1, 0), (2, 2, 0)),
+    ((2, 0, 0), (2, 11, 3)),
+])
+def test_abi_compatible(built, running):
+    assert _hdf5_abi_compatible(built, running)
+
+
+@pytest.mark.parametrize('built, running', [
+    # Older libraries may lack symbols h5py was built against
+    ((2, 2, 0), (2, 1, 0)),
+    ((2, 0, 1), (2, 0, 0)),
+    # Nothing is promised across a major version
+    ((2, 0, 0), (3, 0, 0)),
+    ((2, 0, 0), (1, 14, 6)),
+    ((1, 14, 6), (2, 0, 0)),
+    # 1.x predates the ABI compatibility promise
+    ((1, 14, 3), (1, 14, 6)),
+    ((1, 14, 6), (1, 14, 3)),
+    ((1, 12, 3), (1, 14, 3)),
+])
+def test_abi_incompatible(built, running):
+    assert not _hdf5_abi_compatible(built, running)

--- a/h5py/version.py
+++ b/h5py/version.py
@@ -44,6 +44,31 @@ version = str(version_tuple)
 hdf5_version_tuple = _h5.get_libversion()
 hdf5_version = "%d.%d.%d" % hdf5_version_tuple
 
+
+def _hdf5_abi_compatible(built_version, running_version):
+    """Can h5py built against ``built_version`` safely use ``running_version``?
+
+    From 2.0.0 onwards HDF5 guarantees ABI backwards compatibility within a
+    major version: an application linked against X.Y.Z runs without
+    recompilation against any later X.A.B.  See
+    https://github.com/HDFGroup/hdf5/wiki/HDF5-Version-Numbers-and-Branch-Strategy
+
+    HDF5 1.x predates that promise -- its minor number played the role the
+    major number plays now, and the ABI was known to change even between
+    maintenance releases (e.g. H5Oget_info* in 1.10.4) -- so there we only
+    accept an exact match, as h5py always has.
+    """
+    if running_version == built_version:
+        return True
+
+    if built_version[0] < 2:
+        return False
+
+    # The majors must match, and an older library of the same major version may
+    # be missing symbols and features h5py was built against, so only accept
+    # newer ones.
+    return (running_version[0] == built_version[0]) and (running_version > built_version)
+
 api_version_tuple = (1,8)
 api_version = "%d.%d" % api_version_tuple
 

--- a/news/hdf5-2-abi-version-warning.rst
+++ b/news/hdf5-2-abi-version-warning.rst
@@ -1,0 +1,10 @@
+Bug fixes
+---------
+
+* Importing h5py no longer warns that "h5py is running against HDF5 X when it
+  was built against Y" when the two versions are ABI compatible (:pr:`2955`).
+  From 2.0.0 onwards HDF5 guarantees that an application linked against X.Y.Z
+  runs unmodified against any later X.A.B, so a build against e.g. HDF5 2.1.0
+  running on 2.2.0 is now accepted silently. Downgrades, changes of major
+  version, and any mismatch in the 1.x series (which predates that guarantee)
+  still warn as before.


### PR DESCRIPTION
this warning is not necessary anymore for HDF5-2 since HDF5 2 guarantees


> An application dynamically linked against version X.Y.Z of the shared library
> MUST run without recompilation against any later version X.A.B where A >= Y.

— [HDF5 Version Numbers and Branch Strategy Minor Version](https://github.com/HDFGroup/hdf5/wiki/HDF5-Version-Numbers-and-Branch-Strategy#-minor-version)


<details><summary>claude</summary>
> [!WARNING]
> **AI disclosure:** this branch was drafted by Claude Code (Claude Opus) at my
> direction, including the code, tests, news entry and this description. I have
> reviewed it, and I'm opening it as a draft so it gets a careful human read
> before anyone spends review time on it. Happy to rewrite any part of it by
> hand if you'd prefer.

### The problem

Importing h5py warns whenever the runtime HDF5 version differs *at all* from the
one it was built against:

```
.../site-packages/h5py/__init__.py:36: UserWarning: h5py is running against
HDF5 2.2.0 when it was built against 2.1.0, this may cause problems
```

That check predates HDF5 2.0. From 2.0.0 onwards the HDF Group guarantees ABI
backwards compatibility within a major version:

> An application dynamically linked against version X.Y.Z of the shared library
> MUST run without recompilation against any later version X.A.B where A >= Y.

— [HDF5 Version Numbers and Branch Strategy](https://github.com/HDFGroup/hdf5/wiki/HDF5-Version-Numbers-and-Branch-Strategy)

So a build against HDF5 2.1.0 running on 2.2.0 is fine by construction, and the
warning is just noise for anyone whose HDF5 is updated independently of h5py —
conda-forge, distro packages, or any environment that resolves a newer 2.x at
install time. Every user hitting it is being told to worry about something the
library explicitly promises is safe.

### The change

Add `version._hdf5_abi_compatible()` and only warn when the versions genuinely
may be incompatible:

* the major versions differ, or
* the running library is older than the one built against — it may be missing
  symbols and features h5py was built against, or
* the versions are 1.x and not identical.

| built against | running | before | after |
| --- | --- | --- | --- |
| 2.1.0 | 2.2.0 | warns | silent |
| 2.0.0 | 2.0.1 | warns | silent |
| 2.2.0 | 2.1.0 | warns | warns |
| 2.0.0 | 3.0.0 | warns | warns |
| 1.14.3 | 1.14.6 | warns | warns |

**1.x behaviour is deliberately unchanged.** 1.x predates the guarantee — its
minor number played the role the major number plays now, and the ABI was known
to change even between maintenance releases (`H5Oget_info*` in 1.10.4, discussed
in [this forum thread](https://forum.hdfgroup.org/t/c-c-abi-stability-and-binary-compatibility-between-patch-versions/5312)).
Relaxing 1.14.x patch mismatches too would silence the long tail of reports like
#2263, but that seemed like a separate judgement call, so I left it out. Say the
word if you'd like it in scope.

### Notes for reviewers

* `_hdf5_abi_compatible` is private on purpose — it's not intended as API, just
  as something testable without an import-time side effect.
* Tests are pure-logic parametrized cases in `h5py/tests/test_version.py`; they
  don't need a particular HDF5 to be installed.
* I could not run `tox -e pre-commit` locally (hook environment failed to
  build), so I checked trailing whitespace and end-of-file newlines by hand. The
  full test suite has not been run locally either — I'm relying on CI for that,
  which is another reason this is a draft.

</details>