### PR TITLE
Fix file images with libver on older HDF5

### DIFF
--- a/h5py/h5f.templ.pyx
+++ b/h5py/h5f.templ.pyx
@@ -15,6 +15,8 @@
 from cpython.buffer cimport PyObject_CheckBuffer, \
                             PyObject_GetBuffer, PyBuffer_Release, \
                             PyBUF_SIMPLE
+from libc.stdint cimport uint8_t, uint32_t
+from libc.string cimport memcmp
 from ._objects cimport pdefault
 from .h5p cimport propwrap, PropFAID, PropFCID
 from .h5i cimport wrap_identifier
@@ -28,6 +30,126 @@ from . import _objects, h5o
 from ._objects import phil, with_phil
 
 from cpython.bytes cimport PyBytes_FromStringAndSize, PyBytes_AsString
+
+
+### {{if HDF5_VERSION < (2, 0, 0)}}
+cdef inline uint32_t _lookup3_rot(uint32_t value, unsigned int shift) noexcept nogil:
+    return (value << shift) ^ (value >> (32 - shift))
+
+
+cdef uint32_t _lookup3_checksum(
+    const uint8_t *data, size_t length, uint32_t initval
+) noexcept nogil:
+    """Bob Jenkins' lookup3 checksum, as used for HDF5 metadata."""
+    cdef uint32_t a = <uint32_t>0xdeadbeef + <uint32_t>length + initval
+    cdef uint32_t b = a
+    cdef uint32_t c = a
+
+    while length > 12:
+        a += data[0]
+        a += (<uint32_t>data[1]) << 8
+        a += (<uint32_t>data[2]) << 16
+        a += (<uint32_t>data[3]) << 24
+        b += data[4]
+        b += (<uint32_t>data[5]) << 8
+        b += (<uint32_t>data[6]) << 16
+        b += (<uint32_t>data[7]) << 24
+        c += data[8]
+        c += (<uint32_t>data[9]) << 8
+        c += (<uint32_t>data[10]) << 16
+        c += (<uint32_t>data[11]) << 24
+
+        a -= c
+        a ^= _lookup3_rot(c, 4)
+        c += b
+        b -= a
+        b ^= _lookup3_rot(a, 6)
+        a += c
+        c -= b
+        c ^= _lookup3_rot(b, 8)
+        b += a
+        a -= c
+        a ^= _lookup3_rot(c, 16)
+        c += b
+        b -= a
+        b ^= _lookup3_rot(a, 19)
+        a += c
+        c -= b
+        c ^= _lookup3_rot(b, 4)
+        b += a
+
+        length -= 12
+        data += 12
+
+    if length == 0:
+        return c
+
+    if length >= 12:
+        c += (<uint32_t>data[11]) << 24
+    if length >= 11:
+        c += (<uint32_t>data[10]) << 16
+    if length >= 10:
+        c += (<uint32_t>data[9]) << 8
+    if length >= 9:
+        c += data[8]
+    if length >= 8:
+        b += (<uint32_t>data[7]) << 24
+    if length >= 7:
+        b += (<uint32_t>data[6]) << 16
+    if length >= 6:
+        b += (<uint32_t>data[5]) << 8
+    if length >= 5:
+        b += data[4]
+    if length >= 4:
+        a += (<uint32_t>data[3]) << 24
+    if length >= 3:
+        a += (<uint32_t>data[2]) << 16
+    if length >= 2:
+        a += (<uint32_t>data[1]) << 8
+    if length >= 1:
+        a += data[0]
+
+    c ^= b
+    c -= _lookup3_rot(b, 14)
+    a ^= c
+    a -= _lookup3_rot(c, 11)
+    b ^= a
+    b -= _lookup3_rot(a, 25)
+    c ^= b
+    c -= _lookup3_rot(b, 16)
+    a ^= c
+    a -= _lookup3_rot(c, 4)
+    b ^= a
+    b -= _lookup3_rot(a, 14)
+    c ^= b
+    c -= _lookup3_rot(b, 24)
+
+    return c
+
+
+cdef void _repair_file_image_checksum(char *image, ssize_t size) noexcept nogil:
+    """Repair the superblock checksum omitted by HDF5 before version 2.0."""
+    cdef uint8_t superblock_version
+    cdef size_t checksum_offset
+    cdef uint32_t checksum
+
+    if size < 16 or memcmp(image, "\x89HDF\r\n\x1a\n", 8) != 0:
+        return
+
+    superblock_version = <uint8_t>image[8]
+    if superblock_version < 2 or superblock_version > 3:
+        return
+
+    checksum_offset = 12 + (4 * <uint8_t>image[9])
+    if checksum_offset + 4 > <size_t>size:
+        return
+
+    checksum = _lookup3_checksum(<const uint8_t *>image, checksum_offset, 0)
+    image[checksum_offset] = <char>(checksum & 0xff)
+    image[checksum_offset + 1] = <char>((checksum >> 8) & 0xff)
+    image[checksum_offset + 2] = <char>((checksum >> 16) & 0xff)
+    image[checksum_offset + 3] = <char>((checksum >> 24) & 0xff)
+### {{endif}}
 
 # Initialization
 
@@ -451,11 +573,21 @@ cdef class FileID(GroupID):
         """
 
         cdef ssize_t size
+        cdef char *image_buf
 
         size = H5Fget_file_image(self.id, NULL, 0)
         image = PyBytes_FromStringAndSize(NULL, size)
+        image_buf = PyBytes_AsString(image)
 
-        H5Fget_file_image(self.id, PyBytes_AsString(image), size)
+        H5Fget_file_image(self.id, image_buf, size)
+
+        # HDF5 < 2.0 clears the file-open status flags in the returned image
+        # without updating the superblock checksum. This makes images using
+        # superblock v2 or v3 impossible to reopen. HDF5 2.0 fixed this in
+        # HDFGroup/hdf5#5489; mirror that repair for older supported versions.
+        ### {{if HDF5_VERSION < (2, 0, 0)}}
+        _repair_file_image_checksum(image_buf, size)
+        ### {{endif}}
 
         return image
 

--- a/h5py/tests/test_file_image.py
+++ b/h5py/tests/test_file_image.py
@@ -52,3 +52,17 @@ def test_in_memory():
     # Reuse image now that previous files are closed
     with h5py.File.in_memory(img) as f3:
         np.testing.assert_array_equal(f3['a'][:], arr)
+
+
+def test_in_memory_libver():
+    arr = np.arange(10)
+    with h5py.File.in_memory(libver='v108') as f1:
+        f1['a'] = arr
+        f1.flush()
+        img = f1.id.get_file_image()
+
+        with h5py.File.in_memory(img, libver='v108') as f2:
+            np.testing.assert_array_equal(f2['a'][:], arr)
+
+    with h5py.File.in_memory(img, libver='v108') as f3:
+        np.testing.assert_array_equal(f3['a'][:], arr)

--- a/news/in-memory-libver.rst
+++ b/news/in-memory-libver.rst
@@ -1,0 +1,5 @@
+Bug fixes
+---------
+
+* Fix file images from ``File.in_memory(libver=...)`` being impossible to
+  reopen when h5py is built against HDF5 versions before 2.0.


### PR DESCRIPTION
## Summary

- repair the version 2/3 superblock checksum in file images returned by HDF5 versions before 2.0
- compile the compatibility path out for HDF5 2.0 and later
- add a regression covering reopening a `File.in_memory(libver="v108")` image before and after closing the original file

Before HDF5 2.0, `H5Fget_file_image()` clears the file-open status flags without updating the affected superblock checksum. HDFGroup/hdf5#5489 fixed that upstream; this PR mirrors the repair for older supported HDF5 versions.

Closes #2558.

## Validation

- HDF5 1.14.6: focused file-image tests passed (4); full suite passed (847 passed, 56 skipped, 3 subtests passed); a clean wheel install reopened all six available libver bounds
- HDF5 2.0.0: clean wheel install and focused file-image tests passed (4)
- `pre-commit run --all-files` and `git diff --check` passed
- follow-up `4d268f01`: rebuilt against HDF5 1.14.6 and reran the focused file-image tests (4 passed)

## AI assistance

OpenAI Codex was used to investigate the issue, implement and test the change, and draft this pull request. The checksum implementation was checked against the cited HDF5 1.14.6 source, and the base failure and repaired behavior were reproduced locally.