### PR TITLE
Avoid stale caches for growing virtual datasets

### DIFF
--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -549,9 +549,9 @@ class Dataset(HLObject):
         with phil:
             shape = self.id.shape
 
-        # If the file is read-only, cache the shape to speed-up future uses.
-        # This cache is invalidated by .refresh() when using SWMR.
-        if self._readonly:
+        # Cache the shape for read-only, non-VDS datasets. This cache is
+        # invalidated by .refresh() when using SWMR.
+        if self._should_cache_props:
             self._cache_props['shape'] = shape
         return shape
 
@@ -572,11 +572,16 @@ class Dataset(HLObject):
         else:
             size = product(self.shape)
 
-        # If the file is read-only, cache the size to speed-up future uses.
-        # This cache is invalidated by .refresh() when using SWMR.
-        if self._readonly:
+        # Cache the size for read-only, non-VDS datasets. This cache is
+        # invalidated by .refresh() when using SWMR.
+        if self._should_cache_props:
             self._cache_props['size'] = size
         return size
+
+    @property
+    def _should_cache_props(self):
+        """Whether dataspace-derived properties can be cached safely."""
+        return self._readonly and (not vds_support or not self.is_virtual)
 
     @property
     def nbytes(self):
@@ -594,9 +599,9 @@ class Dataset(HLObject):
 
         slr = _selector.Selector(self.id.get_space())
 
-        # If the file is read-only, cache the reader to speed up future uses.
-        # This cache is invalidated by .refresh() when using SWMR.
-        if self._readonly:
+        # Cache the selector for read-only, non-VDS datasets. This cache is
+        # invalidated by .refresh() when using SWMR.
+        if self._should_cache_props:
             self._cache_props['_selector'] = slr
         return slr
 
@@ -608,9 +613,9 @@ class Dataset(HLObject):
 
         rdr = _selector.Reader(self.id)
 
-        # If the file is read-only, cache the reader to speed up future uses.
-        # This cache is invalidated by .refresh() when using SWMR.
-        if self._readonly:
+        # Cache the reader for read-only, non-VDS datasets. This cache is
+        # invalidated by .refresh() when using SWMR.
+        if self._should_cache_props:
             self._cache_props['_fast_reader'] = rdr
         return rdr
 

--- a/h5py/tests/test_vds/test_highlevel_vds.py
+++ b/h5py/tests/test_vds/test_highlevel_vds.py
@@ -463,6 +463,7 @@ class VDSUnlimitedTestCase(ut.TestCase):
             source_dset[10:, 1] = np.zeros((10,), dtype=int)
             np.testing.assert_array_equal(comp3, virtual_dset)
 
+    @pytest.mark.thread_unsafe(reason="Grows a shared VDS source file")
     def test_readonly_vds_tracks_source_growth(self):
         vds_path = osp.join(self.tmpdir, make_name("resize_vds{}.h5"))
         layout = h5.VirtualLayout((10, 1), int, maxshape=(None, 1))

--- a/h5py/tests/test_vds/test_highlevel_vds.py
+++ b/h5py/tests/test_vds/test_highlevel_vds.py
@@ -463,6 +463,36 @@ class VDSUnlimitedTestCase(ut.TestCase):
             source_dset[10:, 1] = np.zeros((10,), dtype=int)
             np.testing.assert_array_equal(comp3, virtual_dset)
 
+    def test_readonly_vds_tracks_source_growth(self):
+        vds_path = osp.join(self.tmpdir, make_name("resize_vds{}.h5"))
+        layout = h5.VirtualLayout((10, 1), int, maxshape=(None, 1))
+        layout_source = h5.VirtualSource(
+            self.path, "source", shape=(10, 2), maxshape=(None, 2)
+        )
+        layout[:h5.UNLIMITED, 0] = layout_source[:h5.UNLIMITED, 1]
+
+        with h5.File(vds_path, "w") as f:
+            f.create_virtual_dataset("virtual", layout)
+
+        with h5.File(self.path, "a") as f, h5.File(vds_path, "r") as fv:
+            source_dset = f["source"]
+            virtual_dset = fv["virtual"]
+            np.testing.assert_array_equal(
+                virtual_dset[:], np.arange(1, 20, 2).reshape(10, 1)
+            )
+            assert virtual_dset.shape == (10, 1)
+            assert virtual_dset.size == 10
+
+            source_dset.resize(20, axis=0)
+            source_dset[10:, 1] = np.arange(10) + 100
+            f.flush()
+
+            assert virtual_dset.shape == (20, 1)
+            assert virtual_dset.size == 20
+            np.testing.assert_array_equal(
+                virtual_dset[10:, 0], np.arange(10) + 100
+            )
+
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
 

--- a/news/vds-shape-cache.rst
+++ b/news/vds-shape-cache.rst
@@ -1,0 +1,5 @@
+Bug fixes
+---------
+
+* Avoid stale shapes and reads when an unlimited virtual dataset in a
+  read-only file grows as its source dataset grows.


### PR DESCRIPTION
Closes #1693.

## Summary

- Do not cache dataspace-derived shape, size, selector, or fast-reader objects
  for virtual datasets opened from read-only files.
- Preserve the existing cache optimization for ordinary read-only datasets.
- Add a regression test which reads an unlimited VDS, grows its source dataset,
  and observes the new shape and data without calling `refresh()`.

## Root cause

The file containing a virtual dataset can be read-only while the source dataset
continues to grow. h5py cached the VDS shape and reader because the VDS file was
read-only, so both metadata and later reads could remain limited to the old
extent. The new cache eligibility check excludes virtual datasets, whose extent
can change through their sources.

## Validation

- `pytest h5py/tests/test_vds/test_highlevel_vds.py -q`: 13 passed.
- Clean CPython 3.13 wheel built against HDF5 1.14.6: full suite 847 passed,
  56 skipped, 3 subtests passed.
- Clean CPython 3.13 wheel built from a fresh sdist against HDF5 2.0.0: full
  suite 874 passed, 29 skipped, 3 subtests passed.
- Independent installed-wheel workflow on both HDF5 versions: the read-only VDS
  grew from `(10, 1)` to `(20, 1)` and exposed the new values without a refresh.
- Ordinary read-only datasets still populated the shape, size, and fast-reader
  caches.
- `pytest-run-parallel --parallel-threads 4`: the unmarked file-mutating test
  reproduced a shared-file race; with the repository's `thread_unsafe` marker
  it ran serially and passed.
- `pre-commit run --all-files`: passed.

An initial HDF5 2.0.0 clean-wheel full-suite run omitted the repository's
declared `pytest-mpi` and `pytest-cov` dependencies and failed only on missing
plugin/fixture setup. The same unchanged wheel passed the full suite after those
declared test dependencies and the repository pytest configuration were loaded.

Not run locally: Linux, macOS, MPI-enabled builds, free-threaded Python, and the
complete upstream HDF5/Python matrix. Those remain for project CI.

## AI assistance

AI tools were used in preparing this contribution. This disclosure and the follow-up reply were prepared with OpenAI Codex; the original model/version has not been verified.
