### PR TITLE
WHL: upgrade abi3 nightlies to cp315

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -132,11 +132,8 @@ jobs:
             )
         env:
           H5PY_LIMITED_API: 1
-          CIBW_BUILD: 'cp314-* cp315t-*'
-          CIBW_ENABLE: cpython-prerelease
+          CIBW_BUILD: 'cp315-*'
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: ''
-          PIP_EXTRA_INDEX_URL: 'https://pypi.anaconda.org/scientific-python-nightly-wheels/simple'
-          PIP_PRE: '1'
 
       # Now actually build the wheels
       - uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,13 @@ delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel} \
 H5PY_ROS3 = "0"
 H5PY_DIRECT_VFD = "0"
 
+[[tool.cibuildwheel.overrides]]
+# do not audit cp315 wheels for abi3 violations yet
+# because abi3audit isn't caught up with cp315-abi3 (at the time of writing)
+# https://github.com/cython/cython/issues/7955
+select = "cp315-*"
+audit-command = ""
+
 [tool.uv]
 # never build numpy from source
 no-build-package = ["numpy"]


### PR DESCRIPTION
Now possible with #2958 + numpy 2.5.2 which has cp315* wheels