### PR TITLE
Fix memory leak reading vlen string fill values

### DIFF
--- a/h5py/h5p.templ.pyx
+++ b/h5py/h5p.templ.pyx
@@ -532,7 +532,9 @@ cdef class PropDCID(PropOCID):
         rank, only the first element will contain the value.
         """
         from .h5t import check_string_dtype
+        from .h5s import create as create_space, SCALAR
         cdef TypeID tid
+        cdef SpaceID sid
         cdef char * c_ptr = NULL
 
         check_numpy_write(value, -1)
@@ -542,7 +544,7 @@ cdef class PropDCID(PropOCID):
         string_info = check_string_dtype(value.dtype)
         if string_info is not None and string_info.length is None:
             tid = py_create(value.dtype, logical=1)
-            ret = H5Pget_fill_value(self.id, tid.id, &c_ptr)
+            H5Pget_fill_value(self.id, tid.id, &c_ptr)
             if c_ptr == NULL:
                 # If the pointer is NULL (either the value did not get changed,
                 # or maybe the 0 length string, it's unclear currently), if
@@ -551,8 +553,16 @@ cdef class PropDCID(PropOCID):
                 # shouldn't segfault.
                 value[0] = b""
                 return
-            fill_value = c_ptr
-            value[0] = fill_value
+            try:
+                # Copies the C string into a Python bytes object
+                fill_value = c_ptr
+                value[0] = fill_value
+            finally:
+                # HDF5 allocated the string when converting the fill value to
+                # the requested type, and handed us ownership of it.  Without
+                # this the buffer is leaked on every call.
+                sid = create_space(SCALAR)
+                H5Dvlen_reclaim(tid.id, sid.id, H5P_DEFAULT, &c_ptr)
             return
 
         tid = py_create(value.dtype)

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -629,6 +629,37 @@ def test_get_unset_fill_value(dt, expected, writable_file):
     assert dset.fillvalue == expected
 
 
+@pytest.mark.skipif(sys.platform == 'win32', reason="resource is POSIX-only")
+def test_vlen_fillvalue_not_leaked(writable_file):
+    """ Reading a vlen string fillvalue must not leak the buffer HDF5 hands us
+    """
+    import resource
+
+    # ru_maxrss is in bytes on macOS, kilobytes elsewhere
+    scale = 1 if sys.platform == 'darwin' else 1024
+
+    def maxrss():
+        return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * scale
+
+    fill_value = b'x' * 65536
+    dset = writable_file.create_dataset(
+        make_name(), (4,), dtype=h5py.string_dtype(), fillvalue=fill_value)
+
+    # Warm up, so the high-water mark reflects a settled allocator
+    for _ in range(100):
+        assert dset.fillvalue == fill_value
+
+    n = 4000
+    before = maxrss()
+    for _ in range(n):
+        dset.fillvalue
+    growth = maxrss() - before
+
+    # Leaking grows the high-water mark by n * len(fill_value) (256 MiB here).
+    # The margin is deliberately wide; this only has to catch the leak.
+    assert growth < n * len(fill_value) // 8
+
+
 class TestCreateNamedType(BaseDataset):
 
     """

--- a/news/vlen-fillvalue-leak.rst
+++ b/news/vlen-fillvalue-leak.rst
@@ -1,0 +1,6 @@
+Bug fixes
+---------
+
+* Fixed a memory leak when reading the fill value of a dataset with a
+  variable-length string datatype. Each access to :attr:`Dataset.fillvalue`
+  leaked the string buffer allocated by HDF5.


### PR DESCRIPTION
`H5Pget_fill_value()` converts the stored fill value into the type the caller
asks for. When that type is a variable-length string, the conversion allocates
the string and hands ownership to the caller. `PropDCID.get_fill_value()`
copied the bytes into Python but never released the buffer, so every read of
`Dataset.fillvalue` leaked it, and since it is an uncached property, this compounds
with each access:

```python
import h5py
import resource

with h5py.File('t.h5', 'w') as f:
    d = f.create_dataset('s', (4,), dtype=h5py.string_dtype(),
                         fillvalue=b'x' * 4096)
    for _ in range(50_000):
        d.fillvalue
    # ru_maxrss is bytes on macOS, kilobytes on Linux
    print(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
```

Peak RSS growth over 50,000 reads (macOS/arm64, HDF5 2.2.0):

| fill value | before | after |
| --- | --- | --- |
| `f8` scalar (control) | 0.0 MB | 0.0 MB |
| vlen string, 64 B | 4.1 MB | 0.0 MB |
| vlen string, 4 KiB | 231.3 MB | 0.0 MB |

Growth tracks the payload size, and the fixed-size control is flat.

## Fix

Reclaim the buffer with `H5Dvlen_reclaim()` after copying the value out. The
copy is wrapped in `try`/`finally` so a failure while building the Python bytes
object cannot lose the buffer.

I used `H5Dvlen_reclaim()` rather than `H5Treclaim()` because it is the one
h5py already wraps and what `_proxy.pyx` uses throughout. Happy to add an
`H5Treclaim()` binding instead if that is preferred.

The undefined-fill path returns early on a `NULL` pointer and is unaffected,
there is nothing to reclaim there.

## Tests

Added `test_vlen_fillvalue_not_leaked` in `h5py/tests/test_dataset.py`. I
confirmed it fails without the fix and passes with it:

| build | RSS growth, 4000 reads of a 64 KiB fill | result |
| --- | --- | --- |
| unpatched | 327 MB | fail (threshold 32 MB) |
| patched | 0 MB | pass |

This is the only memory test in the suite and an
RSS-based test may not be something desirable in CI. It skips on Windows (no
`resource`), normalizes the macOS/Linux `ru_maxrss` unit difference, and leaves
a 10x margin against the threshold. I am willing to reduce it to just a correctness-only test.