### PR TITLE
Support fill values for array fixed-length datatypes

### DIFF
--- a/docs/high/dataset.rst
+++ b/docs/high/dataset.rst
@@ -712,6 +712,15 @@ Reference
         type-appropriate default value.  Can't be changed after the dataset is
         created.
 
+        For a dataset with an array datatype, such as ``('f4', (3,))``, this is
+        an array of the base type.  The base type may be anything of a fixed
+        size, including a compound type. Array datatypes built on
+        variable-length strings, variable-length sequences or references do not
+        support fill values yet.
+
+        .. versionchanged:: 3.17
+           Array fixed-size datatypes are supported.
+
     .. attribute:: external
 
        If this dataset is stored in one or more external files, this is a list

--- a/docs/high/group.rst
+++ b/docs/high/group.rst
@@ -420,7 +420,9 @@ Reference
         :keyword fletcher32: Enable Fletcher32 checksum (T/**F**).  See :ref:`dataset_fletcher32`.
 
         :keyword fillvalue: This value will be used when reading
-                            uninitialized parts of the dataset.
+                            uninitialized parts of the dataset.  For an array
+                            datatype it is broadcast to the shape of one
+                            element, so both a scalar and a sequence work.
 
         :keyword fill_time: Control when to write the fill value. One of the
             following choices: `alloc`, write fill value before writing

--- a/h5py/_hl/dataset.py
+++ b/h5py/_hl/dataset.py
@@ -139,9 +139,23 @@ def make_new_dset(parent, shape=None, dtype=None, data=None, name=None,
             # to not trigger unwanted encoding
             dtype = h5t.string_dtype(string_info.encoding)
             fillvalue = numpy.array(fillvalue, dtype=dtype)
+            dcpl.set_fill_value(fillvalue)
+        elif dtype.subdtype is not None:
+            # NumPy collapses an array dtype into the array's own shape, so it
+            # can never appear as ndarray.dtype.  The H5T_ARRAY type therefore
+            # has to be handed to HDF5 explicitly.
+            if dtype.hasobject:
+                raise NotImplementedError(
+                    "Fill values are not supported for array datatypes with "
+                    "variable-length or reference components"
+                )
+            # 0-d array of an array dtype is exactly one element of it
+            fill_buf = numpy.zeros((), dtype=dtype)
+            fill_buf[...] = fillvalue
+            dcpl.set_fill_value(fill_buf, tid)
         else:
             fillvalue = numpy.array(fillvalue)
-        dcpl.set_fill_value(fillvalue)
+            dcpl.set_fill_value(fillvalue)
 
     if track_times is None:
         # In case someone explicitly passes None for the default
@@ -716,8 +730,15 @@ class Dataset(HLObject):
     @with_phil
     def fillvalue(self):
         """Fill value for this dataset (0 by default)"""
-        arr = numpy.zeros((1,), dtype=self.dtype)
-        self._dcpl.get_fill_value(arr)
+        dt = self.dtype
+        arr = numpy.zeros((1,), dtype=dt)
+        if dt.subdtype is not None and not dt.hasobject:
+            # NumPy cannot hand back an array dtype on an array, so the
+            # H5T_ARRAY type has to be passed explicitly.  numpy.zeros sized
+            # the buffer to one element of it already.
+            self._dcpl.get_fill_value(arr, h5t.py_create(dt, logical=1))
+        else:
+            self._dcpl.get_fill_value(arr)
         return arr[0]
 
     @cached_property

--- a/h5py/_hl/vds.py
+++ b/h5py/_hl/vds.py
@@ -230,21 +230,29 @@ class VirtualLayout:
         """ Return a new low-level dataset identifier for a virtual dataset """
         dcpl = self._get_dcpl(parent.file.filename)
 
-        if fillvalue is not None:
-            dcpl.set_fill_value(np.array([fillvalue]))
-
-        maxshape = self.maxshape
-        if maxshape is not None:
-            maxshape = tuple(m if m is not None else h5s.UNLIMITED for m in maxshape)
-
-        virt_dspace = h5s.create_simple(self.shape, maxshape)
-
         if isinstance(self.dtype, Datatype):
             # Named types are used as-is
             tid = self.dtype.id
         else:
             dtype = np.dtype(self.dtype)
             tid = h5t.py_create(dtype, logical=1)
+
+        if fillvalue is not None:
+            dt = tid.dtype
+            if dt.subdtype is not None and not dt.hasobject:
+                # Array dtypes cannot go through ndarray.dtype; pass the
+                # H5T_ARRAY type explicitly
+                fill_buf = np.zeros((), dtype=dt)
+                fill_buf[...] = fillvalue
+                dcpl.set_fill_value(fill_buf, tid)
+            else:
+                dcpl.set_fill_value(np.array([fillvalue]))
+
+        maxshape = self.maxshape
+        if maxshape is not None:
+            maxshape = tuple(m if m is not None else h5s.UNLIMITED for m in maxshape)
+
+        virt_dspace = h5s.create_simple(self.shape, maxshape)
 
         return h5d.create(parent.id, name=name, tid=tid, space=virt_dspace,
                           dcpl=dcpl)

--- a/h5py/h5p.templ.pyx
+++ b/h5py/h5p.templ.pyx
@@ -415,6 +415,28 @@ cdef class PropFCID(PropOCID):
         H5Pget_file_space_page_size(self.id, &fsp_size)
         return fsp_size
 
+cdef int _check_fill_buffer(ndarray value, TypeID mtype) except -1:
+    # H5Pset_fill_value/H5Pget_fill_value read and write exactly
+    # H5Tget_size(mtype) bytes at the start of the buffer, with no size
+    # checking of their own.  check_numpy_read/check_numpy_write only validate
+    # contiguity and writability, so the size has to be checked here.
+    cdef size_t size = mtype.get_size()
+
+    # An object array holds PyObject* where HDF5 expects the variable-length
+    # or reference data itself.  Those are the same width, so the size check
+    # below cannot catch it.
+    if value.dtype.hasobject:
+        raise NotImplementedError(
+            "Fill values for datatypes with variable-length or reference "
+            "components are not supported")
+
+    if <size_t>value.nbytes < size:
+        raise ValueError(
+            "Fill value buffer is %d bytes; datatype needs %d"
+            % (value.nbytes, size))
+    return 0
+
+
 # Dataset creation
 cdef class PropDCID(PropOCID):
 
@@ -493,18 +515,28 @@ cdef class PropDCID(PropOCID):
 
 
     @with_phil
-    def set_fill_value(self, ndarray value not None):
-        """(NDARRAY value)
+    def set_fill_value(self, ndarray value not None, TypeID mtype=None):
+        """(NDARRAY value, TypeID mtype=None)
 
         Set the dataset fill value.  The object provided should be an
         0-dimensional NumPy array; otherwise, the value will be read from
         the first element.
+
+        mtype is the HDF5 datatype describing the buffer.  Pass it for
+        datatypes NumPy cannot express on an array itself, such as H5T_ARRAY;
+        by default the type is inferred from value.dtype.  Datatypes with
+        variable-length components are not supported this way.
         """
         from .h5t import check_string_dtype
         cdef TypeID tid
         cdef char * c_ptr
 
         check_numpy_read(value, -1)
+
+        if mtype is not None:
+            _check_fill_buffer(value, mtype)
+            H5Pset_fill_value(self.id, mtype.id, value.data)
+            return
 
         # check for strings
         # create correct typeID and pointer to c_str
@@ -524,12 +556,17 @@ cdef class PropDCID(PropOCID):
 
 
     @with_phil
-    def get_fill_value(self, ndarray value not None):
-        """(NDARRAY value)
+    def get_fill_value(self, ndarray value not None, TypeID mtype=None):
+        """(NDARRAY value, TypeID mtype=None)
 
         Read the dataset fill value into a NumPy array.  It will be
         converted to match the array dtype.  If the array has nonzero
         rank, only the first element will contain the value.
+
+        mtype is the HDF5 datatype describing the buffer.  Pass it for
+        datatypes NumPy cannot express on an array itself, such as H5T_ARRAY;
+        by default the type is inferred from value.dtype.  Datatypes with
+        variable-length components are not supported this way.
         """
         from .h5t import check_string_dtype
         from .h5s import create as create_space, SCALAR
@@ -538,6 +575,11 @@ cdef class PropDCID(PropOCID):
         cdef char * c_ptr = NULL
 
         check_numpy_write(value, -1)
+
+        if mtype is not None:
+            _check_fill_buffer(value, mtype)
+            H5Pget_fill_value(self.id, mtype.id, value.data)
+            return
 
         # check for vlen strings
         # create correct typeID and convert from c_str pointer to string

--- a/h5py/h5p.templ.pyx
+++ b/h5py/h5p.templ.pyx
@@ -532,7 +532,9 @@ cdef class PropDCID(PropOCID):
         rank, only the first element will contain the value.
         """
         from .h5t import check_string_dtype
+        from .h5s import create as create_space, SCALAR
         cdef TypeID tid
+        cdef SpaceID sid
         cdef char * c_ptr = NULL
 
         check_numpy_write(value, -1)
@@ -542,7 +544,7 @@ cdef class PropDCID(PropOCID):
         string_info = check_string_dtype(value.dtype)
         if string_info is not None and string_info.length is None:
             tid = py_create(value.dtype, logical=1)
-            ret = H5Pget_fill_value(self.id, tid.id, &c_ptr)
+            H5Pget_fill_value(self.id, tid.id, &c_ptr)
             if c_ptr == NULL:
                 # If the pointer is NULL (either the value did not get changed,
                 # or maybe the 0 length string, it's unclear currently), if
@@ -551,8 +553,16 @@ cdef class PropDCID(PropOCID):
                 # shouldn't segfault.
                 value[0] = b""
                 return
-            fill_value = c_ptr
-            value[0] = fill_value
+            try:
+                # Copies the C string into a Python bytes object
+                fill_value = c_ptr
+                value[0] = fill_value
+            finally:
+                # HDF5 allocated the string when converting the fill value to
+                # the requested type, and handed us ownership of it.  Without
+                # this the buffer is leaked on every call.
+                sid = create_space(SCALAR)
+                H5Dvlen_reclaim(tid.id, sid.id, H5P_DEFAULT, &c_ptr)
             return
 
         tid = py_create(value.dtype)

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -660,6 +660,154 @@ def test_vlen_fillvalue_not_leaked(writable_file):
     assert growth < n * len(fill_value) // 8
 
 
+ARRAY_DTYPE_FILLVALUES = [
+    (np.dtype(('f4', (3,))), [1.5, 2.5, 3.5]),
+    (np.dtype(('f4', (3,))), 7),                       # broadcast a scalar
+    (np.dtype(('i2', (2, 2))), [[1, 2], [3, 4]]),
+    (np.dtype(('>f8', (2,))), [1.25, -2.5]),           # non-native byte order
+    (np.dtype(('i4', (4,))), np.array([9, 8, 7, 6])),
+    (np.dtype(('S5', (3,))), [b'aa', b'bb', b'cc']),   # fixed-length strings
+    (np.dtype(('S4', (3,))), b'pad'),                  # broadcast one string
+    (np.dtype(('c8', (2,))), [1 + 2j, 3 - 4j]),        # stored as compound
+    (np.dtype(('?', (3,))), [True, False, True]),      # HDF5 enum
+    (np.dtype(([('a', 'i4'), ('b', 'f8')], (2,))),     # compound base
+     [(1, 2.0), (3, 4.0)]),
+]
+
+
+@pytest.mark.parametrize('dt,fillvalue', ARRAY_DTYPE_FILLVALUES)
+def test_array_dtype_fillvalue(dt, fillvalue, writable_file):
+    """ Datasets with an array datatype accept and report a fill value """
+    expected = np.zeros((), dtype=dt)
+    expected[...] = fillvalue
+
+    dset = writable_file.create_dataset(make_name(), (2,), dtype=dt,
+                                        fillvalue=fillvalue)
+
+    assert dset.fillvalue.dtype == dt.base
+    np.testing.assert_array_equal(dset.fillvalue, expected)
+    # unwritten elements come back as the fill value
+    np.testing.assert_array_equal(dset[0], expected)
+    np.testing.assert_array_equal(dset[1], expected)
+
+
+@pytest.mark.parametrize('dt,fillvalue', ARRAY_DTYPE_FILLVALUES)
+def test_array_dtype_fillvalue_reopen(dt, fillvalue, tmp_path):
+    """ An array datatype fill value survives a round trip through a file """
+    expected = np.zeros((), dtype=dt)
+    expected[...] = fillvalue
+
+    path = tmp_path / 'array_fillvalue.h5'
+    with File(path, 'w') as f:
+        f.create_dataset('x', (2,), dtype=dt, fillvalue=fillvalue)
+
+    with File(path, 'r') as f:
+        np.testing.assert_array_equal(f['x'].fillvalue, expected)
+        np.testing.assert_array_equal(f['x'][1], expected)
+
+
+def test_array_dtype_fillvalue_defined(writable_file):
+    """ An array datatype fill value is recorded as user-defined """
+    dt = np.dtype(('f4', (3,)))
+    dset = writable_file.create_dataset(make_name(), (2,), dtype=dt,
+                                        fillvalue=[1, 2, 3])
+    assert dset._dcpl.fill_value_defined() == h5py.h5d.FILL_VALUE_USER_DEFINED
+
+
+def test_array_dtype_unset_fillvalue(writable_file):
+    """ An array datatype without a fill value reports zeros """
+    dt = np.dtype(('f4', (3,)))
+    dset = writable_file.create_dataset(make_name(), (2,), dtype=dt)
+    np.testing.assert_array_equal(dset.fillvalue, np.zeros(3, dtype='f4'))
+
+
+@pytest.mark.skipif(h5py.version.hdf5_version_tuple < (2, 0, 0),
+                    reason="Requires HDF5 >= 2.0")
+@pytest.mark.skipif(not h5py.get_config().has_native_complex,
+                    reason="Native HDF5 complex number datatypes not available")
+def test_array_dtype_native_complex_fillvalue(tmp_path):
+    """ An array of native H5T_COMPLEX accepts a fill value
+
+    py_create() maps a NumPy complex dtype to an HDF5 compound, so the native
+    complex type has to be built explicitly and passed as the dtype. The
+    buffer is still filled from the NumPy dtype, which is where passing the
+    dataset's own type rather than re-deriving one from the dtype matters.
+    """
+    fillvalue = [1 + 2j, 3 - 4j]
+    expected = np.array(fillvalue, dtype='c8')
+    path = tmp_path / 'native_complex.h5'
+
+    with File(path, 'w') as f:
+        tid = h5t.array_create(h5t.NATIVE_FLOAT_COMPLEX, (2,))
+        dset = f.create_dataset('x', (2,), dtype=tid, fillvalue=fillvalue)
+
+        assert dset.id.get_type().get_super().get_class() == h5t.COMPLEX
+        np.testing.assert_array_equal(dset.fillvalue, expected)
+        np.testing.assert_array_equal(dset[1], expected)
+
+    with File(path, 'r') as f:
+        dset = f['x']
+        assert dset.id.get_type().get_super().get_class() == h5t.COMPLEX
+        np.testing.assert_array_equal(dset.fillvalue, expected)
+        np.testing.assert_array_equal(dset[1], expected)
+
+
+def test_array_dtype_fixed_utf8_fillvalue(writable_file):
+    """ An array of fixed-length UTF-8 strings keeps its character set """
+    dt = np.dtype((h5py.string_dtype(encoding='utf-8', length=6), (2,)))
+    fillvalue = ['b\u00e1r'.encode('utf-8'), b'ok']
+
+    dset = writable_file.create_dataset(make_name(), (2,), dtype=dt,
+                                        fillvalue=fillvalue)
+
+    assert dset.id.get_type().get_super().get_cset() == h5t.CSET_UTF8
+    np.testing.assert_array_equal(dset.fillvalue,
+                                  np.array(fillvalue, dtype='S6'))
+    np.testing.assert_array_equal(dset[1], dset.fillvalue)
+
+
+@pytest.mark.parametrize('base', [
+    h5py.string_dtype(),                # variable-length string
+    h5py.vlen_dtype(np.int32),          # variable-length sequence
+    h5py.ref_dtype,                     # object reference
+    h5py.regionref_dtype,               # region reference
+])
+def test_array_dtype_object_fillvalue_rejected(base, writable_file):
+    """ Array datatypes needing a deep copy reject a fill value for now
+
+    These are exactly the dtypes NumPy represents with object elements.
+    """
+    dt = np.dtype((base, (2,)))
+    with pytest.raises(NotImplementedError, match='variable-length or ref'):
+        writable_file.create_dataset(make_name(), (2,), dtype=dt,
+                                     fillvalue=[None, None])
+
+
+@pytest.mark.parametrize('method', ['set_fill_value', 'get_fill_value'])
+def test_fill_value_object_buffer_rejected(method):
+    """ An object array must not be paired with an explicit datatype
+
+    Its elements are PyObject pointers, not the variable-length data HDF5
+    expects, and the two are the same width so the size check cannot catch it.
+    """
+    dcpl = h5py.h5p.create(h5py.h5p.DATASET_CREATE)
+    tid = h5t.py_create(np.dtype((h5py.string_dtype(), (2,))), logical=1)
+    buf = np.zeros((2,), dtype=object)
+    assert buf.nbytes == tid.get_size()   # the size check would let this pass
+
+    with pytest.raises(NotImplementedError, match='variable-length or ref'):
+        getattr(dcpl, method)(buf, tid)
+
+
+@pytest.mark.parametrize('method', ['set_fill_value', 'get_fill_value'])
+def test_fill_value_buffer_too_small(method):
+    """ An explicit type must not be able to overrun the supplied buffer """
+    dcpl = h5py.h5p.create(h5py.h5p.DATASET_CREATE)
+    tid = h5t.py_create(np.dtype(('f4', (3,))), logical=1)
+    with pytest.raises(ValueError, match='too small|needs'):
+        getattr(dcpl, method)(np.zeros(1, dtype='f4'), tid)
+
+
 class TestCreateNamedType(BaseDataset):
 
     """

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -629,6 +629,37 @@ def test_get_unset_fill_value(dt, expected, writable_file):
     assert dset.fillvalue == expected
 
 
+@pytest.mark.skipif(sys.platform == 'win32', reason="resource is POSIX-only")
+def test_vlen_fillvalue_not_leaked(writable_file):
+    """ Reading a vlen string fillvalue must not leak the buffer HDF5 hands us
+    """
+    import resource
+
+    # ru_maxrss is in bytes on macOS, kilobytes elsewhere
+    scale = 1 if sys.platform == 'darwin' else 1024
+
+    def maxrss():
+        return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * scale
+
+    fill_value = b'x' * 65536
+    dset = writable_file.create_dataset(
+        make_name(), (4,), dtype=h5py.string_dtype(), fillvalue=fill_value)
+
+    # Warm up, so the high-water mark reflects a settled allocator
+    for _ in range(100):
+        assert dset.fillvalue == fill_value
+
+    n = 4000
+    before = maxrss()
+    for _ in range(n):
+        dset.fillvalue
+    growth = maxrss() - before
+
+    # Leaking grows the high-water mark by n * len(fill_value) (256 MiB here).
+    # The margin is deliberately wide; this only has to catch the leak.
+    assert growth < n * len(fill_value) // 8
+
+
 class TestCreateNamedType(BaseDataset):
 
     """

--- a/h5py/tests/test_vds/test_highlevel_vds.py
+++ b/h5py/tests/test_vds/test_highlevel_vds.py
@@ -478,5 +478,27 @@ def test_no_mappings(writable_file):
     np.testing.assert_array_equal(dset[()], np.zeros((10, 20), np.int32))
 
 
+@pytest.mark.skipif(not vds_support, reason='VDS requires HDF5 >= 1.9.233')
+def test_array_dtype_fillvalue(tmp_path):
+    """ A virtual dataset with an array datatype accepts a fill value """
+    dt = np.dtype(('f4', (3,)))
+    src_path = tmp_path / 'src.h5'
+    with h5.File(src_path, 'w') as f:
+        f.create_dataset('x', (2,), dtype=dt)[...] = [[1, 2, 3], [4, 5, 6]]
+
+    layout = h5.VirtualLayout(shape=(4,), dtype=dt)
+    layout[0:2] = h5.VirtualSource(src_path, 'x', shape=(2,), dtype=dt)
+
+    vds_path = tmp_path / 'vds.h5'
+    with h5.File(vds_path, 'w') as f:
+        f.create_virtual_dataset('v', layout, fillvalue=[-1, -2, -3])
+
+    with h5.File(vds_path, 'r') as f:
+        dset = f['v']
+        assert_array_equal(dset.fillvalue, [-1, -2, -3])
+        assert_array_equal(dset[0], [1, 2, 3])
+        assert_array_equal(dset[3], [-1, -2, -3])
+
+
 if __name__ == "__main__":
     ut.main()

--- a/news/array-dtype-fillvalue.rst
+++ b/news/array-dtype-fillvalue.rst
@@ -1,0 +1,15 @@
+New features
+------------
+
+* Datasets with an array datatype (``H5T_ARRAY``), such as ``('f4', (3,))``,
+  now support fill values. The value is broadcast to the shape of one element,
+  so both ``fillvalue=7`` and ``fillvalue=[1, 2, 3]`` work, and
+  :attr:`Dataset.fillvalue` reads such fill values back. The base type may be
+  anything of a fixed size, including a compound type; array datatypes built on
+  variable-length strings, variable-length sequences or references are not
+  supported yet.
+
+* :meth:`h5py.h5p.PropDCID.set_fill_value` and
+  :meth:`h5py.h5p.PropDCID.get_fill_value` take an optional ``mtype`` argument
+  giving the HDF5 datatype of the buffer, for datatypes NumPy cannot put on an
+  array itself. Both now check that the buffer is large enough for the datatype.

--- a/news/vlen-fillvalue-leak.rst
+++ b/news/vlen-fillvalue-leak.rst
@@ -1,0 +1,6 @@
+Bug fixes
+---------
+
+* Fixed a memory leak when reading the fill value of a dataset with a
+  variable-length string datatype. Each access to :attr:`Dataset.fillvalue`
+  leaked the string buffer allocated by HDF5.


### PR DESCRIPTION
Note that this branch is stacked on PR #2960.

Datasets with an array fixed-size datatype (`H5T_ARRAY`) now accept a fill value:

```python
dt = np.dtype(('f4', (3,)))
d = f.create_dataset('x', (2,), dtype=dt, fillvalue=[1.5, 2.5, 3.5])
d.fillvalue        # array([1.5, 2.5, 3.5], dtype=float32)
d[1]               # array([1.5, 2.5, 3.5], dtype=float32)
```

The value is broadcast to the shape of one element, so `fillvalue=7` becomes
`[7., 7., 7.]`. For an array datatype `Dataset.fillvalue` returns an array of
the base type. Before this, any fill value failed at dataset creation:

```
ValueError: Unable to synchronously create dataset
  (no appropriate function for conversion path)
```

and reading an array datatype fill value from a file raised
`RuntimeError: Can't get fill value`, which this also fixes.

`PropDCID.set_fill_value()` inferred the HDF5 datatype from `value.dtype`.
NumPy collapses an array dtype into the array's own shape, so `ndarray.dtype`
can never itself be an array dtype: for `('f4', (3,))`, `np.array([1, 2, 3])`
has dtype `f4` and shape `(3,)`. HDF5 was therefore asked to convert `f4` to
`3 x f4`, and there is no such conversion path. The array type was unreachable
through the signature, whatever the caller passed.

Now `PropDCID.set_fill_value()` and `.get_fill_value()` take an optional `mtype`
giving the HDF5 datatype of the buffer for datatypes NumPy cannot express on an
array itself. Omitting it keeps the current inference, so the change is backward
compatible.

The high-level callers pass it when the dtype has a `subdtype`:
`make_new_dset()`, the `Dataset.fillvalue` property, and
`VirtualLayout.make_dataset()` for virtual datasets. The buffer is
`numpy.zeros((), dtype=dtype)`, which is exactly one element of the array
datatype, filled by broadcast assignment and no manual allocation involved.

Supported are any array datatypes with a fixed-size base type, for example:
multidimensional bases (`('i2', (2, 2))`), non-native byte order (`('>f8',
(2,))`), or fixed-length ASCII or UTF-8 strings.

Array datatypes whose base has variable-length components raise
`NotImplementedError` for now. Reading `.fillvalue` on such a dataset is left
unchanged.

### Buffer safety

`H5Pset_fill_value()`/`H5Pget_fill_value()` read and write exactly
`H5Tget_size(mtype)` bytes at the buffer with no checking of their own, and
`check_numpy_read()`/`check_numpy_write()` only validate contiguity and
writability. Since `mtype` is public API, the new `_check_fill_buffer()` rejects two
things before HDF5 is called:

* a buffer smaller than the datatype, which would otherwise overrun the heap;
* an object array, whose elements are `PyObject*` rather than the
  variable-length data HDF5 expects.

The second cannot be folded into the first: those are the same width, so an
object array paired with an array-of-vlen type passes the size check exactly.
There's also a new test for this.

### Tests

Twenty-three new tests. The main ones are parametrized across seven dtype/fill-value
combinations and run twice, once in-memory after creation and once after a
round trip through a closed file.