### PR TITLE
Enable Windows ARM64 builds on CI

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -70,9 +70,8 @@ jobs:
             arch: aarch64
           - os: windows-latest
             arch: AMD64
-          # See https://github.com/h5py/h5py/issues/2816
-          #- os: windows-11-arm
-          #  arch: ARM64
+          - os: windows-11-arm
+            arch: ARM64
           - os: macos-14
             arch: arm64
           - os: macos-15-intel

--- a/.github/zizmor.yaml
+++ b/.github/zizmor.yaml
@@ -2,5 +2,5 @@ rules:
   cache-poisoning:
     ignore:
       # actions/cache is already disabled for releases
-      - build_wheels.yml:92
-      - build_wheels.yml:110
+      - build_wheels.yml:91
+      - build_wheels.yml:109

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,16 @@ skip = [
     "cp310-win_arm64", # Skipped due to unavailability of Python binary and NumPy for Win-ARM64
     "*-win32",
 ]
+# See https://github.com/h5py/h5py/issues/2816
+test-skip = [
+    # Skipped due to UV package picks x86_64 Python Interpreter
+    # See https://github.com/astral-sh/uv/issues/12906
+    # Skip the test suite for Python builds that are not preinstalled on the Win-ARM64 runner.
+    "cp311-win_arm64",
+    "cp315-win_arm64",
+    "cp314t-win_arm64",
+    "cp315t-win_arm64",
+]
 
 build-verbosity = 1
 build-frontend = { name = "pip", args = ["--only-binary", "numpy"] }


### PR DESCRIPTION
PR Description:

* As discussed in [[h5py#2816](https://github.com/h5py/h5py/issues/2816#issuecomment-5311606178)](https://github.com/h5py/h5py/issues/2816#issuecomment-5311606178), Windows ARM64 CI builds currently fail while running the test suite.
* This is caused by the UV Python manager selecting an x86_64 Python interpreter instead of the ARM64 interpreter configured by cibuildwheel (CIBW).
* The CI passes for Python versions that are preinstalled on the Windows ARM64 runner. Therefore, this PR skips the test suite for Python versions that are not preinstalled on the runner.
* Several downstream projects that depend on h5py for Windows ARM64 are currently blocked by this issue. This PR addresses the problem and helps unblock Windows ARM64 support for these projects.

cc: @neutrinoceros & @khmyznikov