### PR TITLE
Fix crash reading variable-length region reference data

### DIFF
--- a/h5py/_conv.templ.pyx
+++ b/h5py/_conv.templ.pyx
@@ -18,7 +18,7 @@ from .h5 import get_config
 from .h5r cimport Reference, RegionReference, hobj_ref_t, hdset_reg_ref_t
 from .h5t cimport H5PY_OBJ, typewrap, py_create, TypeID, H5PY_PYTHON_OPAQUE_TAG
 from libc.stdlib cimport realloc
-from libc.string cimport strcmp
+from libc.string cimport strcmp, memset
 from .utils cimport emalloc, efree
 from ._proxy cimport needs_bkg_buffer
 cfg = get_config()
@@ -718,7 +718,11 @@ cdef int conv_vlen2ndarray(void* ipt,
         data = new_data
 
     if needs_bkg_buffer(intype.id, outtype.id):
+        # The background buffer holds the existing destination value, which a
+        # converter may release -- conv_regref2pyref decrefs it.  It has to be
+        # zeroed rather than left holding whatever was on the heap.
         back_buf = emalloc(H5Tget_size(outtype.id)*size)
+        memset(back_buf, 0, H5Tget_size(outtype.id)*size)
 
     try:
         H5Tconvert(intype.id, outtype.id, size, data, back_buf, H5P_DEFAULT)
@@ -869,7 +873,9 @@ cdef int conv_ndarray2vlen(void* ipt,
         PyBuffer_Release(&view)
 
         if needs_bkg_buffer(intype.id, outtype.id):
+            # Zeroed for the same reason as in conv_vlen2ndarray above
             back_buf = emalloc(H5Tget_size(outtype.id)*len)
+            memset(back_buf, 0, H5Tget_size(outtype.id)*len)
 
         H5Tconvert(intype.id, outtype.id, len, data, back_buf, H5P_DEFAULT)
 

--- a/h5py/tests/test_dataset.py
+++ b/h5py/tests/test_dataset.py
@@ -2363,3 +2363,28 @@ def test_store_regionrefs(writable_file):
     refs_ds = writable_file.create_dataset(make_name("refs"), shape=(1,), dtype=h5py.ref_dtype)
     with pytest.raises(TypeError, match="convert"):
         refs_ds[0] = ds1.regionref[:6]
+
+
+@pytest.mark.parametrize('ref_dtype,make_ref', [
+    (h5py.ref_dtype, lambda ds: ds.ref),
+    (h5py.regionref_dtype, lambda ds: ds.regionref[:6]),
+], ids=['object', 'region'])
+def test_store_vlen_refs(ref_dtype, make_ref, writable_file):
+    """ A variable-length sequence of references round-trips
+
+    Converting region references needs a background buffer, and that buffer
+    used to be allocated without being zeroed.  Reading one back released
+    whatever pointer happened to be in it, which segfaulted on every platform
+    whose allocator does not hand back zeroed memory.
+    """
+    ds1 = writable_file.create_dataset(make_name("foo"), data=np.arange(12))
+    ref = make_ref(ds1)
+
+    vlen_ds = writable_file.create_dataset(make_name("vlen_refs"), (2,),
+                                           dtype=h5py.vlen_dtype(ref_dtype))
+    vlen_ds[0] = np.array([ref, ref], dtype=object)
+
+    stored = vlen_ds[0]
+    assert len(stored) == 2
+    for r in stored:
+        assert writable_file[r] == ds1

--- a/news/vlen-regionref-segfault.rst
+++ b/news/vlen-regionref-segfault.rst
@@ -1,0 +1,8 @@
+Bug fixes
+---------
+
+* Fixed a crash when reading a dataset whose datatype is a variable-length
+  sequence of region references. The background buffer used while converting
+  the references was allocated without being zeroed, and the converter
+  released whatever pointer it found there. This affected every platform whose
+  allocator does not hand back zeroed memory.


### PR DESCRIPTION
Reading a dataset whose datatype is a variable-length sequence of region references segfaults:

```python
dt = h5py.vlen_dtype(h5py.regionref_dtype)
d = f.create_dataset('x', (2,), dtype=dt)
d[0] = np.array([ref, ref], dtype=object)   # write: fine
d[0]                                        # read: SIGSEGV
```

This bug was revealed by failing CI workflows in my other PR #2964.

| platform | |
| --- | --- |
| Linux x86_64 | segfaults |
| Linux aarch64 | segfaults |
| Windows AMD64 / ARM64 | segfaults |
| macOS | passes |

`conv_vlen2ndarray` allocates the background buffer for the element conversion with `emalloc` and never initializes it. `conv_regref2pyref` treats that buffer as holding the existing destination value and releases it:

```cython
bkg_obj0 = bkg_obj[0]
...
Py_XDECREF(bkg_obj0)
```

so it decrefs whatever pointer happened to be on the heap. The gdb backtrace lands in `_Py_DECREF` with a garbage `op`, three frames below `conv_vlen2ndarray`.

Object references never hit this because they register with `H5T_BKG_NO` and never read the buffer, while region references register `H5T_BKG_YES`. That asymmetry is exactly why `vlen_dtype(ref_dtype)` is fine and `vlen_dtype(regionref_dtype)` is not. MacOS escapes because its allocator hands back zeroed pages.

### Fix

Zero the buffer after allocating it, in both `conv_vlen2ndarray` and `conv_ndarray2vlen`.

The second function is not causing any crash but it is the same unzeroed allocation, and garbage there would reach unwritten compound fields. Fixing one and not the other seemed worse than fixing both.