### PR TITLE
Close leaked compound type handle in make_reduced_type

### DIFF
--- a/h5py/_proxy.templ.pyx
+++ b/h5py/_proxy.templ.pyx
@@ -275,18 +275,25 @@ cdef hid_t make_reduced_type(hid_t mtype, hid_t dstype):
 
     # Second pass: pick out the matching fields and pack them in the new type
     temptype = H5I_UNINIT
-    for idx in range(H5Tget_nmembers(dstype)):
-        member_name = H5Tget_member_name(dstype, idx)
-        try:
-            if member_name not in mtype_fields:
-                continue
-            temptype = H5Tget_member_type(dstype, idx)
-            H5Tinsert(newtype, member_name, offset, temptype)
-            offset += H5Tget_size(temptype)
+    try:
+        for idx in range(H5Tget_nmembers(dstype)):
+            member_name = H5Tget_member_name(dstype, idx)
+            try:
+                if member_name not in mtype_fields:
+                    continue
+                temptype = H5Tget_member_type(dstype, idx)
+                H5Tinsert(newtype, member_name, offset, temptype)
+                offset += H5Tget_size(temptype)
+                H5Tclose(temptype)
+                temptype = H5I_UNINIT
+            finally:
+                H5free_memory(member_name)
+                member_name = NULL
+    except:
+        if temptype > 0:
             H5Tclose(temptype)
-        finally:
-            H5free_memory(member_name)
-            member_name = NULL
+        H5Tclose(newtype)
+        raise
 
     return newtype
 

--- a/news/fix-make_reduced_type-handle-leak.rst
+++ b/news/fix-make_reduced_type-handle-leak.rst
@@ -1,0 +1,7 @@
+Bug fixes
+---------
+
+* Fixed an HDF5 type identifier leak in ``make_reduced_type`` (used when
+  reading compound datasets with a ``fields`` selection): if inserting a
+  member into the reduced compound type failed partway through, the newly
+  created type was never closed.


### PR DESCRIPTION
`make_reduced_type` in `h5py/_proxy.templ.pyx` builds a compound type by creating `newtype` with `H5Tcreate` and then inserting matching members into it one by one. If `H5Tinsert` raises partway through (a duplicate member name, an invalid size, anything the C layer rejects), the exception propagates straight out of the function and `newtype` is never closed. Every failure of this kind leaks an HDF5 type identifier, and HDF5's identifier table isn't unbounded, so repeated failures can eventually break other, unrelated type operations in the same process.

This wraps the insertion loop so both the freshly created type and whichever member type was open at the moment of failure get closed before the exception is re-raised, matching the finally block already used a few lines above for `read_dataset`'s own cleanup.

Tested with:

- `pytest h5py/tests/test_dataset.py -k "compound or field"` (13 passed)
- the full `test_dataset.py`, `test_slicing.py`, and `test_dtype.py` suites (299 passed, 7 skipped, none newly failing)

I didn't add a dedicated failure-triggering test. Reaching the failing branch here needs an on-disk compound type with a duplicate or otherwise invalid member, and HDF5's own `H5Tinsert` already refuses to create such a type through the normal API, which is presumably why this went unnoticed. Happy to add one if there's a preferred way to fabricate that condition.

Added a news entry under `news/` per the contributing guide.
