### PR TITLE
Test File context-manager cleanup on exceptions

### DIFF
--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -693,6 +693,16 @@ class TestContextManager(TestCase):
             self.assertTrue(fid)
         self.assertTrue(not fid)
 
+    def test_context_manager_closes_on_exception(self):
+        """File objects close when an exception is raised in a with block."""
+        exception = RuntimeError("test exception")
+
+        with pytest.raises(RuntimeError, match="test exception"):
+            with File(self.mktemp(), 'w') as fid:
+                raise exception
+
+        self.assertFalse(fid.id.valid)
+
 
 @ut.skipIf(not UNICODE_FILENAMES, "Filesystem unicode support required")
 class TestUnicode(TestCase):


### PR DESCRIPTION
## Summary
- add regression coverage for exceptional exits from an `h5py.File` context manager
- verify the raised exception propagates and the file is closed afterward

## Testing
- `/tmp/h5py-test-env/bin/python -m pytest h5py/tests/test_file.py::TestContextManager::test_context_manager_closes_on_exception`
- `VIRTUAL_ENV=/tmp/h5py-test-env /tmp/h5py-test-env/bin/pre-commit run --files h5py/tests/test_file.py`

<!-- repo-agent-case:7baa3107-297c-4c0a-9b29-086a50096d2c -->